### PR TITLE
Moving getMintEventGems to lib

### DIFF
--- a/lib/gems.js
+++ b/lib/gems.js
@@ -1,0 +1,13 @@
+async function getMintEventGems(_receipt, _catalyst, _catalystRegistry) {
+  const catalystAppliedEvent = await findEvents(_catalystRegistry, "CatalystApplied", _receipt.blockHash);
+  const catalystId = catalystAppliedEvent[0].args[1];
+  const gems = catalystAppliedEvent[0].args[3].length;
+  const mintData = await _catalyst.getMintData(catalystId);
+  const maxGemsConfigured = mintData[0];
+  return {
+    gems,
+    maxGemsConfigured,
+  };
+}
+
+module.exports = getMintEventGems;


### PR DESCRIPTION
Moving the helper function I wrote to retrieve both the actual and max configured gems based on a receipt from a mint tx.
A further improvement could be to make this more general, getting the gems from upgrades as well as the original minting.