### PR TITLE
Adding tests for gem events

### DIFF
--- a/test/catalyst/fixtures.js
+++ b/test/catalyst/fixtures.js
@@ -1,4 +1,5 @@
-const {toWei, findEvents, waitFor} = require("local-utils");
+const {toWei, waitFor} = require("local-utils");
+const {findEvents} = require("../../lib/findEvents.js");
 const {ethers, deployments, getNamedAccounts} = require("@nomiclabs/buidler");
 const {BigNumber} = require("@ethersproject/bignumber");
 

--- a/test/catalyst/testCatalystMinter.js
+++ b/test/catalyst/testCatalystMinter.js
@@ -322,7 +322,9 @@ describe("Catalyst:Minting", function () {
     assert.equal(rarity, 0); // rarity is no more in use
   });
 
-  it("creator mint Epic Asset And new onwer add gems", async function () {
+  it("extracted asset share same gems", async function () {});
+
+  it("creator mint Epic Asset And new owner add gems", async function () {
     const {creator, user, asset, catalystRegistry} = await setupCatalystUsers();
     const originalGemIds = [PowerGem, SpeedGem];
     const quantity = 30;
@@ -343,6 +345,12 @@ describe("Catalyst:Minting", function () {
     expect(catalystData[1]).to.equal(EpicCatalyst);
 
     const gemsAddedEvent = (await findEvents(catalystRegistry, "GemsAdded", receipt.blockHash))[0];
+
+    const mintedGems = catalystAppliedEvent.args.gemIds.length;
+    const addedGems = gemsAddedEvent.args.gemIds.length;
+    const totalGems = mintedGems + addedGems;
+
+    expect(totalGems).to.equal(3);
     expect(gemsAddedEvent.args.gemIds[0]).to.equal(newGemIds[0]);
     expect(gemsAddedEvent.args.assetId).to.equal(tokenId);
     expect(gemsAddedEvent.args.startIndex).to.equal(2);

--- a/test/catalyst/testCatalystMinter.js
+++ b/test/catalyst/testCatalystMinter.js
@@ -51,7 +51,7 @@ describe("Catalyst:Minting", function () {
         emptyBytes
       )
     );
-    const {totalGems, maxGemsConfigured} = await getMintEventGems(receipt, catalyst, catalystRegistry);
+    const {totalGems, maxGemsConfigured} = await getGems(receipt, catalyst, catalystRegistry);
     assert.isAtMost(totalGems, maxGemsConfigured, "more gems than allowed!");
   });
 
@@ -128,7 +128,7 @@ describe("Catalyst:Minting", function () {
     const catalystData = await catalystRegistry.getCatalyst(tokenId);
     expect(catalystData[0]).to.equal(true);
     expect(catalystData[1]).to.equal(EpicCatalyst);
-    const {totalGems, maxGemsConfigured} = await getMintEventGems(receipt, catalyst, catalystRegistry);
+    const {totalGems, maxGemsConfigured} = await getGems(receipt, catalyst, catalystRegistry);
 
     const balance = await asset["balanceOf(address,uint256)"](creator.address, tokenId);
     const rarity = await asset.rarity(tokenId);
@@ -159,7 +159,7 @@ describe("Catalyst:Minting", function () {
     expect(catalystData[0]).to.equal(true);
     expect(catalystData[1]).to.equal(LegendaryCatalyst);
 
-    const {totalGems, maxGemsConfigured} = await getMintEventGems(receipt, catalyst, catalystRegistry);
+    const {totalGems, maxGemsConfigured} = await getGems(receipt, catalyst, catalystRegistry);
     const balance = await asset["balanceOf(address,uint256)"](creator.address, tokenId);
     const rarity = await asset.rarity(tokenId);
     await mine(); // future block need to be mined to get the value
@@ -181,7 +181,7 @@ describe("Catalyst:Minting", function () {
       quantity,
     });
     const receipt = await waitFor(creator.Asset.extractERC721(originalTokenId, creator.address));
-    const {totalGems, maxGemsConfigured} = await getMintEventGems(mintReceipt, catalyst, catalystRegistry);
+    const {totalGems, maxGemsConfigured} = await getGems(mintReceipt, catalyst, catalystRegistry);
     const transferEvents = await findEvents(asset, "Transfer", receipt.blockHash);
     const tokenId = transferEvents[0].args[2];
 
@@ -214,12 +214,12 @@ describe("Catalyst:Minting", function () {
       catalyst: LegendaryCatalyst,
       gemIds,
     });
-    const {totalGems: originalTotalGems, maxGemsConfigured: originalMaxGems} = await getMintEventGems(
+    const {totalGems: originalTotalGems, maxGemsConfigured: originalMaxGems} = await getGems(
       mintReceipt,
       catalyst,
       catalystRegistry
     );
-    const {totalGems: newTotalGems, maxGemsConfigured: newMaxGems} = await getMintEventGems(
+    const {totalGems: newTotalGems, maxGemsConfigured: newMaxGems} = await getGems(
       postExtractionReceipt,
       catalyst,
       catalystRegistry

--- a/test/catalyst/testCatalystMinter.js
+++ b/test/catalyst/testCatalystMinter.js
@@ -270,6 +270,16 @@ describe("Catalyst:Minting", function () {
       gemIds,
     });
 
+    const {totalGems: newTotalGems, maxGemsConfigured: newMaxGems} = await getGems(
+      postExtractionReceipt,
+      catalyst,
+      catalystRegistry
+    );
+
+    expect(newTotalGems).to.equal(2);
+    expect(newMaxGems).to.equal(2);
+    assert.isAtMost(newTotalGems, newMaxGems);
+
     const catalystData = await catalystRegistry.getCatalyst(tokenId);
     expect(catalystData[0]).to.equal(true);
     expect(catalystData[1]).to.equal(RareCatalyst);

--- a/test/catalyst/testCatalystMinter.js
+++ b/test/catalyst/testCatalystMinter.js
@@ -322,8 +322,6 @@ describe("Catalyst:Minting", function () {
     assert.equal(rarity, 0); // rarity is no more in use
   });
 
-  it("extracted asset share same gems", async function () {});
-
   it("creator mint Epic Asset And new owner add gems", async function () {
     const {creator, user, asset, catalystRegistry} = await setupCatalystUsers();
     const originalGemIds = [PowerGem, SpeedGem];


### PR DESCRIPTION
Adding tests to ensure the total number of gems is not more than the configured maximum amount.

I split out some of this pr into #19 to simplify review , so after that's merged I'll rebase this one and re-push it. So it's just the changes in `testCatalystMinter.js` which are unique to this pr.

depends on #19 