### PR TITLE
Allow getGems to work with GemsAdded event

### DIFF
--- a/lib/getGems.js
+++ b/lib/getGems.js
@@ -1,17 +1,27 @@
 const {findEvents} = require("./findEvents.js");
 
-async function getMintEventGems(_receipt, _catalyst, _catalystRegistry) {
+async function getGems(_receipt, _catalyst, _catalystRegistry) {
   const catalystAppliedEvent = await findEvents(_catalystRegistry, "CatalystApplied", _receipt.blockHash);
+  const gemsAddedEvent = await findEvents(_catalystRegistry, "GemsAdded", _receipt.blockHash);
   const catalystId = catalystAppliedEvent[0].args[1];
-  const gems = catalystAppliedEvent[0].args[3].length;
+  const appliedGems = catalystAppliedEvent[0].args[3].length;
+
+  let totalGems;
+  if (gemsAddedEvent.length === 0) {
+    totalGems = appliedGems;
+  } else {
+    const addedGems = gemsAddedEvent[0].args[3].length;
+    totalGems = appliedGems + addedGems;
+  }
+
   const mintData = await _catalyst.getMintData(catalystId);
   const maxGemsConfigured = mintData[0];
   return {
-    gems,
+    totalGems,
     maxGemsConfigured,
   };
 }
 
 module.exports = {
-  getMintEventGems,
+  getGems,
 };

--- a/test/catalyst/testCatalystMinter.js
+++ b/test/catalyst/testCatalystMinter.js
@@ -1,10 +1,11 @@
 const {assert, expect} = require("local-chai");
 const {setupCatalystUsers} = require("./fixtures");
+const {getGems} = require("../../lib/getGems.js");
+const {findEvents} = require("../../lib/findEvents.js");
 const {
   expectRevert,
   emptyBytes,
   waitFor,
-  findEvents,
   checERC20Balances,
   checERC1155Balances,
   toWei,

--- a/test/node_modules/local-utils.js
+++ b/test/node_modules/local-utils.js
@@ -47,12 +47,6 @@ function recurseTests(test) {
   }
 }
 
-async function findEvents(contract, event, blockHash) {
-  const filter = contract.filters[event]();
-  const events = await contract.queryFilter(filter, blockHash)
-  return events;
-}
-
 async function checERC1155Balances(account, balances, func) {
   const intialBalances = [];
   for(const name of Object.keys(balances)) {
@@ -97,7 +91,6 @@ module.exports = {
   expectRevert,
   waitFor: (p) => p.then((tx) => tx.wait()),
   recurseTests,
-  findEvents,
   checERC20Balances,
   checERC1155Balances,
   mine: () => ethers.provider.send("evm_mine", []),


### PR DESCRIPTION
I'm not sure about making `getGems` more general-purpose. For example, it could maybe accept an array of receipts and aggregates all the gems added to an asset over multiple TXs. 
For now, using `getGems` once for each TX of interest works without over-complicating things, but I'm open to suggestions.

Also some minor tweaks & cleanup.