### PR TITLE
update for audit

### DIFF
--- a/src/BaseWithStorage/ERC20Group.sol
+++ b/src/BaseWithStorage/ERC20Group.sol
@@ -10,6 +10,7 @@ import "../contracts_common/src/Libraries/BytesUtil.sol";
 import "../contracts_common/src/BaseWithStorage/SuperOperators.sol";
 import "../contracts_common/src/BaseWithStorage/MetaTransactionReceiver.sol";
 
+
 contract ERC20Group is SuperOperators, MetaTransactionReceiver {
     /// @notice emitted when a new Token is added to the group.
     /// @param subToken the token added, its id will be its index in the array.
@@ -47,7 +48,7 @@ contract ERC20Group is SuperOperators, MetaTransactionReceiver {
         uint256 id,
         uint256 amount
     ) external {
-        require(_minters[msg.sender], "NOT_AUTHORIZED_ADMIN");
+        require(_minters[msg.sender], "NOT_AUTHORIZED_MINTER");
         (uint256 bin, uint256 index) = id.getTokenBinIndex();
         _packedTokenBalance[to][bin] = _packedTokenBalance[to][bin].updateTokenBalance(index, amount, ObjectLib32.Operations.ADD);
         _packedSupplies[bin] = _packedSupplies[bin].updateTokenBalance(index, amount, ObjectLib32.Operations.ADD);
@@ -73,12 +74,12 @@ contract ERC20Group is SuperOperators, MetaTransactionReceiver {
         uint256[] memory ids,
         uint256[] memory amounts
     ) internal {
-        uint256 lastBin = 2**256 - 1;
+        uint256 lastBin = ~uint256(0);
         uint256 bal = 0;
         uint256 supply = 0;
         for (uint256 i = 0; i < ids.length; i++) {
             (uint256 bin, uint256 index) = ids[i].getTokenBinIndex();
-            if (lastBin == 2**256 - 1) {
+            if (lastBin == ~uint256(0)) {
                 lastBin = bin;
                 bal = _packedTokenBalance[to][bin].updateTokenBalance(index, amounts[i], ObjectLib32.Operations.ADD);
                 supply = _packedSupplies[bin].updateTokenBalance(index, amounts[i], ObjectLib32.Operations.ADD);
@@ -95,7 +96,7 @@ contract ERC20Group is SuperOperators, MetaTransactionReceiver {
             }
             _erc20s[ids[i]].emitTransferEvent(address(0), to, amounts[i]);
         }
-        if (lastBin != 2**256 - 1) {
+        if (lastBin != ~uint256(0)) {
             _packedTokenBalance[to][lastBin] = bal;
             _packedSupplies[lastBin] = supply;
         }
@@ -290,11 +291,11 @@ contract ERC20Group is SuperOperators, MetaTransactionReceiver {
     ) internal {
         uint256 balFrom = 0;
         uint256 supply = 0;
-        uint256 lastBin = 2**256 - 1;
+        uint256 lastBin = ~uint256(0);
         for (uint256 i = 0; i < ids.length; i++) {
-            if (amounts[i] > 0) {
+            if (amounts[i] != 0) {
                 (uint256 bin, uint256 index) = ids[i].getTokenBinIndex();
-                if (lastBin == 2**256 - 1) {
+                if (lastBin == ~uint256(0)) {
                     lastBin = bin;
                     balFrom = _packedTokenBalance[from][bin].updateTokenBalance(index, amounts[i], ObjectLib32.Operations.SUB);
                     supply = _packedSupplies[bin].updateTokenBalance(index, amounts[i], ObjectLib32.Operations.SUB);
@@ -313,7 +314,7 @@ contract ERC20Group is SuperOperators, MetaTransactionReceiver {
             }
             _erc20s[ids[i]].emitTransferEvent(from, address(0), amounts[i]);
         }
-        if (lastBin != 2**256 - 1) {
+        if (lastBin != ~uint256(0)) {
             _packedTokenBalance[from][lastBin] = balFrom;
             _packedSupplies[lastBin] = supply;
         }
@@ -361,10 +362,10 @@ contract ERC20Group is SuperOperators, MetaTransactionReceiver {
     using SafeMath for uint256;
 
     // ////////////////// DATA ///////////////////////////////
-    mapping(uint256 => uint256) private _packedSupplies;
-    mapping(address => mapping(uint256 => uint256)) private _packedTokenBalance;
-    mapping(address => mapping(address => bool)) _operatorsForAll;
-    ERC20SubToken[] _erc20s;
+    mapping(uint256 => uint256) internal _packedSupplies;
+    mapping(address => mapping(uint256 => uint256)) internal _packedTokenBalance;
+    mapping(address => mapping(address => bool)) internal _operatorsForAll;
+    ERC20SubToken[] internal _erc20s;
     mapping(address => bool) internal _minters;
 
     // ////////////// CONSTRUCTOR ////////////////////////////

--- a/src/BaseWithStorage/ERC20SubToken.sol
+++ b/src/BaseWithStorage/ERC20SubToken.sol
@@ -1,6 +1,6 @@
 pragma solidity 0.6.5;
 
-import "../contracts_common/src/Libraries/SafeMath.sol";
+import "../contracts_common/src/Libraries/SafeMathWithRequire.sol";
 import "../contracts_common/src/BaseWithStorage/SuperOperators.sol";
 import "../contracts_common/src/BaseWithStorage/MetaTransactionReceiver.sol";
 
@@ -62,7 +62,7 @@ contract ERC20SubToken {
     ) external returns (bool success) {
         if (msg.sender != from && !_group.isAuthorizedToTransfer(from, msg.sender)) {
             uint256 allowance = _mAllowed[from][msg.sender];
-            if (allowance != (2**256) - 1) {
+            if (allowance != ~uint256(0)) {
                 // save gas when allowance is maximal by not reducing it (see https://github.com/ethereum/EIPs/issues/717)
                 require(allowance >= amount, "NOT_AUTHOIZED_ALLOWANCE");
                 _mAllowed[from][msg.sender] = allowance.sub(amount);
@@ -127,7 +127,7 @@ contract ERC20SubToken {
     }
 
     // ///////////////////// UTILITIES ///////////////////////
-    using SafeMath for uint256;
+    using SafeMathWithRequire for uint256;
 
     // //////////////////// CONSTRUCTOR /////////////////////
     constructor(
@@ -138,10 +138,10 @@ contract ERC20SubToken {
     ) public {
         _group = group;
         _index = index;
-        require(bytes(tokenName).length > 0, "INVALID_NAME_REQUIRED");
+        require(bytes(tokenName).length != 0, "INVALID_NAME_REQUIRED");
         require(bytes(tokenName).length <= 32, "INVALID_NAME_TOO_LONG");
         _name = _firstBytes32(bytes(tokenName));
-        require(bytes(tokenSymbol).length > 0, "INVALID_SYMBOL_REQUIRED");
+        require(bytes(tokenSymbol).length != 0, "INVALID_SYMBOL_REQUIRED");
         require(bytes(tokenSymbol).length <= 32, "INVALID_SYMBOL_TOO_LONG");
         _symbol = _firstBytes32(bytes(tokenSymbol));
     }

--- a/src/BaseWithStorage/wip/ERC1155BaseToken.sol
+++ b/src/BaseWithStorage/wip/ERC1155BaseToken.sol
@@ -127,11 +127,11 @@ contract ERC1155BaseToken is MetaTransactionReceiver, SuperOperators, ERC1155 {
 
         uint256 balFrom;
 
-        uint256 lastBin = 2**256 - 1;
+        uint256 lastBin = ~uint256(0);
         for (uint256 i = 0; i < ids.length; i++) {
             if (amounts[i] > 0) {
                 (uint256 bin, uint256 index) = ids[i].getTokenBinIndex();
-                if (lastBin == 2**256 - 1) {
+                if (lastBin == ~uint256(0)) {
                     lastBin = bin;
                     balFrom = ObjectLib32.updateTokenBalance(_packedTokenBalance[from][bin], index, amounts[i], ObjectLib32.Operations.SUB);
                 } else {
@@ -145,7 +145,7 @@ contract ERC1155BaseToken is MetaTransactionReceiver, SuperOperators, ERC1155 {
                 }
             }
         }
-        if (lastBin != 2**256 - 1) {
+        if (lastBin != ~uint256(0)) {
             _packedTokenBalance[from][lastBin] = balFrom;
         }
         emit TransferBatch(metaTx ? from : msg.sender, from, address(0), ids, amounts);
@@ -206,11 +206,11 @@ contract ERC1155BaseToken is MetaTransactionReceiver, SuperOperators, ERC1155 {
         uint256 balFrom;
         uint256 balTo;
 
-        uint256 lastBin = 2**256 - 1;
+        uint256 lastBin = ~uint256(0);
         for (uint256 i = 0; i < numItems; i++) {
             if (values[i] > 0) {
                 (bin, index) = ids[i].getTokenBinIndex();
-                if (lastBin == 2**256 - 1) {
+                if (lastBin == ~uint256(0)) {
                     lastBin = bin;
                     balFrom = ObjectLib32.updateTokenBalance(_packedTokenBalance[from][bin], index, values[i], ObjectLib32.Operations.SUB);
                     balTo = ObjectLib32.updateTokenBalance(_packedTokenBalance[to][bin], index, values[i], ObjectLib32.Operations.ADD);
@@ -228,7 +228,7 @@ contract ERC1155BaseToken is MetaTransactionReceiver, SuperOperators, ERC1155 {
                 }
             }
         }
-        if (lastBin != 2**256 - 1) {
+        if (lastBin != ~uint256(0)) {
             _packedTokenBalance[from][lastBin] = balFrom;
             _packedTokenBalance[to][lastBin] = balTo;
         }

--- a/src/BaseWithStorage/wip/ERC20BaseToken.sol
+++ b/src/BaseWithStorage/wip/ERC20BaseToken.sol
@@ -87,7 +87,7 @@ contract ERC20BaseToken is SuperOperators, ERC20, ERC20Extended {
     ) external override returns (bool success) {
         if (msg.sender != from && !_superOperators[msg.sender]) {
             uint256 currentAllowance = _allowances[from][msg.sender];
-            if (currentAllowance != (2**256) - 1) {
+            if (currentAllowance != ~uint256(0)) {
                 // save gas when allowance is maximal by not reducing it (see https://github.com/ethereum/EIPs/issues/717)
                 require(currentAllowance >= amount, "NOT_AUTHOIZED_ALLOWANCE");
                 _allowances[from][msg.sender] = currentAllowance - amount;
@@ -109,7 +109,7 @@ contract ERC20BaseToken is SuperOperators, ERC20, ERC20Extended {
     function burnFor(address from, uint256 amount) external override {
         if (msg.sender != from && !_superOperators[msg.sender]) {
             uint256 currentAllowance = _allowances[from][msg.sender];
-            if (currentAllowance != (2**256) - 1) {
+            if (currentAllowance != ~uint256(0)) {
                 require(currentAllowance >= amount, "NOT_AUTHOIZED_ALLOWANCE");
                 _allowances[from][msg.sender] = currentAllowance - amount;
             }
@@ -203,7 +203,7 @@ contract ERC20BaseToken is SuperOperators, ERC20, ERC20Extended {
         if (msg.sender != from && !_superOperators[msg.sender]) {
             uint256 currentAllowance = _allowances[from][msg.sender];
             require(currentAllowance >= amount, "Not enough funds allowed");
-            if (currentAllowance != (2**256) - 1) {
+            if (currentAllowance != ~uint256(0)) {
                 // save gas when allowance is maximal by not reducing it (see https://github.com/ethereum/EIPs/issues/717)
                 _allowances[from][msg.sender] = currentAllowance - amount;
             }

--- a/src/BaseWithStorage/wip/MintableERC1155Token.sol
+++ b/src/BaseWithStorage/wip/MintableERC1155Token.sol
@@ -43,11 +43,11 @@ contract MintableERC1155Token is ERC1155BaseToken {
 
         uint256 balTo;
 
-        uint256 lastBin = 2**256 - 1;
+        uint256 lastBin = ~uint256(0);
         for (uint256 i = 0; i < ids.length; i++) {
             if (amounts[i] > 0) {
                 (uint256 bin, uint256 index) = ids[i].getTokenBinIndex();
-                if (lastBin == 2**256 - 1) {
+                if (lastBin == ~uint256(0)) {
                     lastBin = bin;
                     balTo = ObjectLib32.updateTokenBalance(_packedTokenBalance[to][bin], index, amounts[i], ObjectLib32.Operations.ADD);
                 } else {
@@ -61,7 +61,7 @@ contract MintableERC1155Token is ERC1155BaseToken {
                 }
             }
         }
-        if (lastBin != 2**256 - 1) {
+        if (lastBin != ~uint256(0)) {
             _packedTokenBalance[to][lastBin] = balTo;
         }
         emit TransferBatch(msg.sender, address(0), to, ids, amounts);

--- a/src/Catalyst/ERC20GroupCatalyst.sol
+++ b/src/Catalyst/ERC20GroupCatalyst.sol
@@ -6,6 +6,7 @@ import "./CatalystDataBase.sol";
 import "../BaseWithStorage/ERC20SubToken.sol";
 import "./CatalystValue.sol";
 
+
 contract ERC20GroupCatalyst is CatalystDataBase, ERC20Group {
     function addCatalysts(
         ERC20SubToken[] memory catalysts,

--- a/src/CatalystMinter.sol
+++ b/src/CatalystMinter.sol
@@ -261,7 +261,6 @@ contract CatalystMinter is MetaTransactionReceiver {
         _burnCatalysts(from, catalystsQuantities);
         _burnGems(from, gemsQuantities);
 
-        totalSandFee = 0;
         supplies = new uint256[](assets.length);
         maxGemsList = new uint16[](assets.length);
 

--- a/src/CatalystMinter.sol
+++ b/src/CatalystMinter.sol
@@ -9,6 +9,8 @@ import "./contracts_common/src/Libraries/SafeMathWithRequire.sol";
 import "./Catalyst/GemToken.sol";
 import "./Catalyst/CatalystToken.sol";
 import "./CatalystRegistry.sol";
+import "./BaseWithStorage/ERC20Group.sol";
+
 
 /// @notice Gateway to mint Asset with Catalyst, Gems and Sand
 contract CatalystMinter is MetaTransactionReceiver {
@@ -147,7 +149,7 @@ contract CatalystMinter is MetaTransactionReceiver {
         address to,
         bytes memory data
     ) public returns (uint256[] memory ids) {
-        require(assets.length > 0, "INVALID_0_ASSETS");
+        require(assets.length != 0, "INVALID_0_ASSETS");
         _checkAuthorization(from, to);
         return _mintMultiple(from, packId, metadataHash, gemsQuantities, catalystsQuantities, assets, to, data);
     }
@@ -177,7 +179,7 @@ contract CatalystMinter is MetaTransactionReceiver {
         AssetData[] memory assets,
         address to,
         bytes memory data
-    ) internal returns (uint256[] memory ids) {
+    ) internal returns (uint256[] memory) {
         (uint256 totalSandFee, uint256[] memory supplies, uint16[] memory maxGemsList) = _handleMultipleCatalysts(
             from,
             gemsQuantities,
@@ -192,8 +194,8 @@ contract CatalystMinter is MetaTransactionReceiver {
 
     function _chargeSand(address from, uint256 sandFee) internal {
         address feeCollector = _feeCollector;
-        if (feeCollector != address(0) && sandFee > 0) {
-            if (feeCollector == address(0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF)) {
+        if (feeCollector != address(0) && sandFee != 0) {
+            if (feeCollector == address(BURN_ADDRESS)) {
                 // special address for burn
                 _sand.burnFor(from, sandFee);
             } else {
@@ -224,11 +226,11 @@ contract CatalystMinter is MetaTransactionReceiver {
         internal
         view
         returns (
-            uint16 maxGems,
-            uint16 minQuantity,
-            uint16 maxQuantity,
-            uint256 sandMintingFee,
-            uint256 sandUpdateFee
+            uint16,
+            uint16,
+            uint16,
+            uint256,
+            uint256
         )
     {
         if (catalystId == 0) {
@@ -264,21 +266,21 @@ contract CatalystMinter is MetaTransactionReceiver {
         maxGemsList = new uint16[](assets.length);
 
         for (uint256 i = 0; i < assets.length; i++) {
-            require(catalystsQuantities[assets[i].catalystId] > 0, "INVALID_CATALYST_NOT_ENOUGH");
+            require(catalystsQuantities[assets[i].catalystId] != 0, "INVALID_CATALYST_NOT_ENOUGH");
             catalystsQuantities[assets[i].catalystId]--;
             gemsQuantities = _checkGemsQuantities(gemsQuantities, assets[i].gemIds);
             (uint16 maxGems, uint16 minQuantity, uint16 maxQuantity, uint256 sandMintingFee, ) = _getMintData(assets[i].catalystId);
             maxGemsList[i] = maxGems;
             require(minQuantity <= assets[i].quantity && assets[i].quantity <= maxQuantity, "INVALID_QUANTITY");
             supplies[i] = assets[i].quantity;
-            totalSandFee += sandMintingFee.mul(assets[i].quantity);
+            totalSandFee = totalSandFee.add(sandMintingFee.mul(assets[i].quantity));
             require(assets[i].gemIds.length <= maxGems, "INVALID_GEMS_TOO_MANY");
         }
     }
 
     function _checkGemsQuantities(uint256[] memory gemsQuantities, uint256[] memory gemIds) internal pure returns (uint256[] memory) {
         for (uint256 i = 0; i < gemIds.length; i++) {
-            require(gemsQuantities[gemIds[i]] > 0, "INVALID_GEMS_NOT_ENOUGH");
+            require(gemsQuantities[gemIds[i]] != 0, "INVALID_GEMS_NOT_ENOUGH");
             gemsQuantities[gemIds[i]]--;
         }
         return gemsQuantities;
@@ -342,7 +344,7 @@ contract CatalystMinter is MetaTransactionReceiver {
         uint256[] memory gemIds,
         address to
     ) internal {
-        require(assetId & IS_NFT > 0, "INVALID_NOT_NFT"); // Asset (ERC1155ERC721.sol) ensure NFT will return true here and non-NFT will reyrn false
+        require(assetId & IS_NFT != 0, "INVALID_NOT_NFT"); // Asset (ERC1155ERC721.sol) ensure NFT will return true here and non-NFT will reyrn false
         _catalystRegistry.addGems(assetId, gemIds);
         _chargeSand(from, gemIds.length.mul(_gemAdditionFee));
         _transfer(from, to, assetId);
@@ -390,20 +392,21 @@ contract CatalystMinter is MetaTransactionReceiver {
 
     // //////////////////////// DATA /////////////////////
     uint256 private constant IS_NFT = 0x0000000000000000000000000000000000000000800000000000000000000000;
+    address private constant BURN_ADDRESS = 0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF;
 
-    ERC20Extended immutable _sand;
-    AssetToken immutable _asset;
-    GemToken immutable _gems;
-    CatalystToken immutable _catalysts;
-    CatalystRegistry immutable _catalystRegistry;
-    address _feeCollector;
+    ERC20Extended internal immutable _sand;
+    AssetToken internal immutable _asset;
+    GemToken internal immutable _gems;
+    CatalystToken internal immutable _catalysts;
+    CatalystRegistry internal immutable _catalystRegistry;
+    address internal _feeCollector;
 
-    uint256 immutable _common_mint_data;
-    uint256 immutable _rare_mint_data;
-    uint256 immutable _epic_mint_data;
-    uint256 immutable _legendary_mint_data;
+    uint256 internal immutable _common_mint_data;
+    uint256 internal immutable _rare_mint_data;
+    uint256 internal immutable _epic_mint_data;
+    uint256 internal immutable _legendary_mint_data;
 
-    uint256 _gemAdditionFee;
+    uint256 internal _gemAdditionFee;
 
     // /////////////////// CONSTRUCTOR ////////////////////
     constructor(

--- a/src/CatalystRegistry.sol
+++ b/src/CatalystRegistry.sol
@@ -16,7 +16,7 @@ contract CatalystRegistry is Admin, CatalystValue {
         if (catalyst.set != 0) {
             return (true, catalyst.catalystId);
         }
-        if (assetId & IS_NFT > 0) {
+        if (assetId & IS_NFT != 0) {
             catalyst = _catalysts[_getCollectionId(assetId)];
             return (catalyst.set != 0, catalyst.catalystId);
         }
@@ -33,18 +33,15 @@ contract CatalystRegistry is Admin, CatalystValue {
         require(gemIds.length <= maxGems, "INVALID_GEMS_TOO_MANY");
         uint256 emptySockets = maxGems - gemIds.length;
         uint256 index = gemIds.length;
-        _catalysts[assetId].emptySockets = uint64(emptySockets);
-        _catalysts[assetId].index = uint64(index);
-        _catalysts[assetId].catalystId = uint64(catalystId);
-        _catalysts[assetId].set = 1;
+        _catalysts[assetId] = CatalystStored(uint64(emptySockets), uint64(index), uint64(catalystId), 1);
         uint64 blockNumber = _getBlockNumber();
         emit CatalystApplied(assetId, catalystId, _getSeed(assetId), gemIds, blockNumber);
     }
 
     function addGems(uint256 assetId, uint256[] calldata gemIds) external {
         require(msg.sender == _minter, "NOT_AUTHORIZED_MINTER");
-        require(assetId & IS_NFT > 0, "INVALID_NOT_NFT");
-        require(gemIds.length > 0, "INVALID_GEMS_0");
+        require(assetId & IS_NFT != 0, "INVALID_NOT_NFT");
+        require(gemIds.length != 0, "INVALID_GEMS_0");
         (uint256 emptySockets, uint256 index, uint256 seed) = _getSocketData(assetId);
         uint256 startIndex = index;
         require(emptySockets >= gemIds.length, "INVALID_GEMS_TOO_MANY");
@@ -86,7 +83,7 @@ contract CatalystRegistry is Admin, CatalystValue {
     uint256 private constant NOT_NFT_INDEX = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF800000007FFFFFFFFFFFFFFF;
 
     function _getSeed(uint256 assetId) internal pure returns (uint256) {
-        if (assetId & IS_NFT > 0) {
+        if (assetId & IS_NFT != 0) {
             return _getCollectionId(assetId);
         }
         return assetId;
@@ -106,7 +103,7 @@ contract CatalystRegistry is Admin, CatalystValue {
         if (catalyst.set != 0) {
             return (catalyst.emptySockets, catalyst.index, seed);
         }
-        if (assetId & IS_NFT > 0) {
+        if (assetId & IS_NFT != 0) {
             seed = _getCollectionId(assetId);
             catalyst = _catalysts[seed];
             return (catalyst.emptySockets, catalyst.index, seed);
@@ -141,8 +138,8 @@ contract CatalystRegistry is Admin, CatalystValue {
         uint64 catalystId;
         uint64 set;
     }
-    address _minter;
+    address internal _minter;
     AssetToken internal immutable _asset;
     CatalystValue internal immutable _catalystValue;
-    mapping(uint256 => CatalystStored) _catalysts;
+    mapping(uint256 => CatalystStored) internal _catalysts;
 }


### PR DESCRIPTION
This is the preliminary report : https://drive.google.com/file/d/1o2Z1WxLgW4feY9-jcnfXjPGWCg3-x4VX/view?usp=sharing

And I think it is a great oportunity to decide on some things as a team. Here you ll find my replies to their point with some of point of view. Would love to hear yours :

GE-01 : Decided to leave as is, I personally prefer require than modifiers as they are more clearly visible. What's your opinion ?

GE-02: updated

GE-03: I personally prefers our layout which put first everything user facing : so events , then external and public function
constructor is rarely user facing but is nice to easily find it, so it is put last
State variable are implementation details so are not put first.
And I do not think there is a clear consensus for following solidity recommendation
What do you think ?

CM-01: I like to have the name of the output parameter for external functions. I was planning to add natspec doc for all of them but hit some solidity bug. Need to revisit that later and potentially submit a bug report for solidity.

CM-02: I like explicitness but decided to update it as it is unecessary. what do you think ?

CM-03: I left it as is as creating one function made it less readable (and because Gem and Catalyst are different contract it caused interface issue) and the complexity is small enough that duplication is fine here in my opinion

CM-04: updated, agree that better be explicit

CM-05: I am not sure if the name is that bad. That function check the value by reducing each value, until it reaches zero. if it tries to reduce more, it means it did not pass the check. 
Note that because it modify the arry in place, it need to be called after it is used (like here : https://github.com/thesandboxgame/sandbox-private-contracts/blob/c8b677eda01e4b223a59cd7080eb235fb73231a4/src/CatalystMinter.sol#L261-L262)

CM-06: agreed and updated

CM-07: fixed 

CMD-01:  fixed in contracts_common planning to merge the submodule into this repo

CR-01: same as GE-01 except I modified the internal function

CR-02: It used to be that solidity for some reason did multiple storage when using struct assignment (how weird that sound) I guess they fixed it. going to check with Certik

CR-03: fixed

CR-04:  The name of NOT_IS_NFT might be misleading but it basically a bitwise NOT and this is used as it is used in the Asset contract to get the collectionId from an AssetID, see : https://github.com/thesandboxgame/sandbox-private-contracts/blob/34912fe7042e23f2c39a5455fc1da61f3588457e/old_src/Asset/ERC1155ERC721.sol#L725

EG-01: fixed

EG-02:  same as GE-01

EG-03: updated. I used to prefers 2**256 -1 but I now think ~uint256(0) is better. Maybe an even better alternative is to assign it to a constant MAX_UINT256 ?

EG-04: fixed

ET-01: The reason for that is to be able to use immutable variable which save on gas, but I guess this is not really important here. (Immutable do not support string yet)

ET-02: fixed

ET-03: not updated : uint8(0) is explicit enough here

ET-04: updated

ET-05: same as GE-01

GC-01: left as is because of the recent change, extracting would not be simpler





