### PR TITLE
Adding a check to prevent claiming excessive gems

### DIFF
--- a/src/StarterPack/PurchaseValidator.sol
+++ b/src/StarterPack/PurchaseValidator.sol
@@ -39,12 +39,10 @@ contract PurchaseValidator is Admin {
     ) public returns (bool) {
         require(from == buyer, "INVALID_SENDER");
         require(_checkAndUpdateNonce(buyer, nonce), "INVALID_NONCE");
-        require(from == message.buyer, "INVALID_SENDER");
-        require(checkAndUpdateNonce(message.buyer, message.nonce), "INVALID_NONCE");
-        require(_validateGemAmounts(message.catalystIds, message.catalystQuantities, message.gemQuantities), "INVALID_GEMS");
-        bytes32 hashedData = keccak256(
-            abi.encodePacked(message.catalystIds, message.catalystQuantities, message.gemIds, message.gemQuantities, message.buyer, message.nonce)
-        );
+        require(from == buyer, "INVALID_SENDER");
+        require(checkAndUpdateNonce(buyer, nonce), "INVALID_NONCE");
+        require(_validateGemAmounts(catalystIds, catalystQuantities, gemQuantities), "INVALID_GEMS");
+        bytes32 hashedData = keccak256(abi.encodePacked(catalystIds, catalystQuantities, gemIds, gemQuantities, buyer, nonce));
 
         address signer = SigUtil.recover(keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", hashedData)), signature);
         return signer == _signingWallet;

--- a/src/StarterPack/PurchaseValidator.sol
+++ b/src/StarterPack/PurchaseValidator.sol
@@ -39,8 +39,6 @@ contract PurchaseValidator is Admin {
     ) public returns (bool) {
         require(from == buyer, "INVALID_SENDER");
         require(_checkAndUpdateNonce(buyer, nonce), "INVALID_NONCE");
-        require(from == buyer, "INVALID_SENDER");
-        require(checkAndUpdateNonce(buyer, nonce), "INVALID_NONCE");
         require(_validateGemAmounts(catalystIds, catalystQuantities, gemQuantities), "INVALID_GEMS");
         bytes32 hashedData = keccak256(abi.encodePacked(catalystIds, catalystQuantities, gemIds, gemQuantities, buyer, nonce));
 

--- a/test/starter-pack/testPurchaseValidator.js
+++ b/test/starter-pack/testPurchaseValidator.js
@@ -30,6 +30,23 @@ describe("PurchaseValidator", function () {
         )
       );
     });
+
+    it("the order of catalystIds should't matter", async function () {
+      message.catalystIds = [2, 3, 0, 1];
+      message.gemQuantities = [0, 0, 1, 1, 0];
+      assert.ok(
+        await starterPack.isPurchaseValid(
+          message.buyer,
+          message.catalystIds,
+          message.catalystQuantities,
+          message.gemIds,
+          message.gemQuantities,
+          message.buyer,
+          message.nonce,
+          signature
+        )
+      );
+    });
   });
 
   describe("Failures", function () {

--- a/test/starter-pack/testPurchaseValidator.js
+++ b/test/starter-pack/testPurchaseValidator.js
@@ -1,4 +1,4 @@
-const {assert} = require("chai");
+const {assert} = require("local-chai");
 const {setupStarterPack} = require("./fixtures");
 const {expectRevert} = require("local-utils");
 const {getMsgAndSignature} = require("./_testHelper");
@@ -43,6 +43,22 @@ describe("PurchaseValidator", function () {
           message.gemQuantities,
           message.buyer,
           message.nonce,
+          signature
+        )
+      );
+
+      message.catalystIds = [3, 2, 1, 0];
+      message.catalystQuantities = [2, 1, 0, 3];
+      message.gemQuantities = [5, 2, 3, 1, 3];
+      assert.ok(
+        await starterPack.isPurchaseValid(
+          message.buyer,
+          message.catalystIds,
+          message.catalystQuantities,
+          message.gemIds,
+          message.gemQuantities,
+          message.buyer,
+          message.nonce + 1,
           signature
         )
       );

--- a/test/starter-pack/testPurchaseValidator.js
+++ b/test/starter-pack/testPurchaseValidator.js
@@ -4,88 +4,105 @@ const {expectRevert} = require("local-utils");
 const {getMsgAndSignature} = require("./_testHelper");
 const {getNamedAccounts} = require("@nomiclabs/buidler");
 
-describe("ValidatingPurchaseMessages", function () {
-  let starterPack;
-  let message;
-  let signature;
-  let roles;
+describe("PurchaseValidator", function () {
+  describe("Validation", function () {
+    let starterPack;
+    let message;
+    let signature;
+    let roles;
+    beforeEach(async function () {
+      ({starterPackContract: starterPack} = await setupStarterPack());
+      ({message, signature} = await getMsgAndSignature());
+      roles = await getNamedAccounts();
+    });
 
-  beforeEach(async function () {
-    ({starterPackContract: starterPack} = await setupStarterPack());
-    ({message, signature} = await getMsgAndSignature());
-    roles = await getNamedAccounts();
+    it("Purchase validator function exists", async function () {
+      assert.ok(
+        await starterPack.isPurchaseValid(
+          message.buyer,
+          message.catalystIds,
+          message.catalystQuantities,
+          message.gemIds,
+          message.gemQuantities,
+          message.buyer,
+          message.nonce,
+          signature
+        )
+      );
+    });
   });
 
-  it("Purchase validator function exists", async function () {
-    assert.ok(
-      await starterPack.isPurchaseValid(
-        message.buyer,
-        message.catalystIds,
-        message.catalystQuantities,
-        message.gemIds,
-        message.gemQuantities,
-        message.buyer,
-        message.nonce,
-        signature
-      )
-    );
-  });
+  describe("Failures", function () {
+    beforeEach(async function () {
+      ({message, signature} = await getMsgAndSignature());
+      roles = await getNamedAccounts();
+    });
+    it("should fail if the from address does not match", async function () {
+      ({starterPackContract: starterPack} = await setupStarterPack());
+      const wrongFromAddress = roles.others[1];
+      await expectRevert(
+        starterPack.isPurchaseValid(
+          wrongFromAddress,
+          message.catalystIds,
+          message.catalystQuantities,
+          message.gemIds,
+          message.gemQuantities,
+          message.buyer,
+          message.nonce,
+          signature
+        ),
+        "INVALID_SENDER"
+      );
+    });
 
-  it("should fail if the from address does not match", async function () {
-    const wrongFromAddress = roles.others[1];
-    await expectRevert(
-      starterPack.isPurchaseValid(
-        wrongFromAddress,
-        message.catalystIds,
-        message.catalystQuantities,
-        message.gemIds,
-        message.gemQuantities,
-        message.buyer,
-        message.nonce,
-        signature
-      ),
-      "INVALID_SENDER"
-    );
-  });
+    it("should fail if the nonce is re-used", async function () {
+      ({starterPackContract: starterPack} = await setupStarterPack());
+      assert.ok(
+        await starterPack.isPurchaseValid(
+          message.buyer,
+          message.catalystIds,
+          message.catalystQuantities,
+          message.gemIds,
+          message.gemQuantities,
+          message.buyer,
+          message.nonce,
+          signature
+        )
+      );
 
-  it("should fail if the nonce is re-used", async function () {
-    assert.ok(
-      await starterPack.isPurchaseValid(
-        message.buyer,
-        message.catalystIds,
-        message.catalystQuantities,
-        message.gemIds,
-        message.gemQuantities,
-        message.buyer,
-        message.nonce,
-        signature
-      )
-    );
+      await expectRevert(
+        starterPack.isPurchaseValid(
+          message.buyer,
+          message.catalystIds,
+          message.catalystQuantities,
+          message.gemIds,
+          message.gemQuantities,
+          message.buyer,
+          message.nonce,
+          signature
+        ),
+        "INVALID_NONCE"
+      );
+    });
 
-    await expectRevert(
-      starterPack.isPurchaseValid(
-        message.buyer,
-        message.catalystIds,
-        message.catalystQuantities,
-        message.gemIds,
-        message.gemQuantities,
-        message.buyer,
-        message.nonce,
-        signature
-      ),
-      "INVALID_NONCE"
-    );
-  });
-
-  it("should fail if too many gems are requested", async function () {
-    const {starterPackContract: starterPack} = await setupStarterPack();
-    const {others} = await getNamedAccounts();
-    const starterPackBuyer = others[0];
-    purchaseMessage.catalystQuantities = [1, 1, 1, 1];
-    // total gems allowed is max 10
-    purchaseMessage.gemQuantities = [3, 2, 4, 2, 3];
-    purchaseMessage.buyer = starterPackBuyer;
-    const sig = await signPurchaseMessage(privateKey, purchaseMessage);
-    await expectRevert(starterPack.isPurchaseValid(starterPackBuyer, purchaseMessage, sig), "INVALID_GEMS");
+    it("should fail if too many gems are requested", async function () {
+      ({starterPackContract: starterPack} = await setupStarterPack());
+      message.catalystQuantities = [1, 1, 1, 1];
+      // total gems allowed is max 10
+      message.gemQuantities = [3, 2, 4, 2, 3];
+      await expectRevert(
+        starterPack.isPurchaseValid(
+          message.buyer,
+          message.catalystIds,
+          message.catalystQuantities,
+          message.gemIds,
+          message.gemQuantities,
+          message.buyer,
+          message.nonce,
+          signature
+        ),
+        "INVALID_GEMS"
+      );
+    });
   });
 });

--- a/test/starter-pack/testPurchaseValidator.js
+++ b/test/starter-pack/testPurchaseValidator.js
@@ -76,4 +76,16 @@ describe("ValidatingPurchaseMessages", function () {
       "INVALID_NONCE"
     );
   });
+
+  it("should fail if too many gems are requested", async function () {
+    const {starterPackContract: starterPack} = await setupStarterPack();
+    const {others} = await getNamedAccounts();
+    const starterPackBuyer = others[0];
+    purchaseMessage.catalystQuantities = [1, 1, 1, 1];
+    // total gems allowed is max 10
+    purchaseMessage.gemQuantities = [3, 2, 4, 2, 3];
+    purchaseMessage.buyer = starterPackBuyer;
+    const sig = await signPurchaseMessage(privateKey, purchaseMessage);
+    await expectRevert(starterPack.isPurchaseValid(starterPackBuyer, purchaseMessage, sig), "INVALID_GEMS");
+  });
 });


### PR DESCRIPTION
- This adds a new private function `_validateGemAmounts` to prevent a malicious backend from a scenario such as:
paying for 1 catalyst, but passing an excessive amount of gems in the args and receiving free gems.
- I've also added a test for this case.

This will need a rebase( after #35 is done) prior to merging.