### PR TITLE
Adding a price-change delay

### DIFF
--- a/src/StarterPack/StarterPackV1.sol
+++ b/src/StarterPack/StarterPackV1.sol
@@ -29,8 +29,6 @@ contract StarterPackV1 is Admin, MetaTransactionReceiver, PurchaseValidator {
     bool _etherEnabled;
     bool _daiEnabled;
 
-    // indicates whether a price change is in effect
-    bool public _priceChangeActive;
     uint256[] private _starterPackPrices;
     uint256[] private _previousStarterPackPrices;
 
@@ -174,7 +172,6 @@ contract StarterPackV1 is Admin, MetaTransactionReceiver, PurchaseValidator {
         require(msg.sender == _admin, "only admin can change StarterPack prices");
         _previousStarterPackPrices = _starterPackPrices;
         _starterPackPrices = prices;
-        _priceChangeActive = true;
         _priceChangeTimestamp = now;
         emit SetPrices(prices);
     }
@@ -244,19 +241,19 @@ contract StarterPackV1 is Admin, MetaTransactionReceiver, PurchaseValidator {
     }
 
     // @dev function to determine whether to use old or
-    // new prices based on state of _priceChangeActive
+    // new prices
     function _priceSelector() internal returns (uint256[] memory) {
         uint256[] memory prices;
-        // No price change active:
-        if (!_priceChangeActive) {
+        // No price change:
+        if (_priceChangeTimestamp == 0) {
             prices = _starterPackPrices;
         } else {
-            // No price change active, but bool not toggled off yet:
+            // Price change delay has expired.
             if (now > _priceChangeTimestamp + 1 hours) {
-                _priceChangeActive = false;
+                _priceChangeTimestamp = 0;
                 prices = _starterPackPrices;
             } else {
-                // Price change is active:
+                // Price change has occured:
                 prices = _previousStarterPackPrices;
             }
         }

--- a/src/StarterPack/StarterPackV1.sol
+++ b/src/StarterPack/StarterPackV1.sol
@@ -244,7 +244,7 @@ contract StarterPackV1 is Admin, MetaTransactionReceiver, PurchaseValidator {
     }
 
     // @dev function to determine whether to use old or
-    // new prices during the 1 hr delay after a price change
+    // new prices based on state of _priceChangeActive
     function _priceSelector() internal returns (uint256[] memory) {
         uint256[] memory prices;
         // No price change active:

--- a/src/StarterPack/StarterPackV1.sol
+++ b/src/StarterPack/StarterPackV1.sol
@@ -30,7 +30,7 @@ contract StarterPackV1 is Admin, MetaTransactionReceiver, PurchaseValidator {
     bool _daiEnabled;
 
     // indicates whether a price change is in effect
-    bool private _priceChangeActive;
+    bool public _priceChangeActive;
     uint256[] private _starterPackPrices;
     uint256[] private _previousStarterPackPrices;
 
@@ -181,6 +181,10 @@ contract StarterPackV1 is Admin, MetaTransactionReceiver, PurchaseValidator {
 
     function getStarterPackPrices() external view returns (uint256[] memory prices) {
         return _starterPackPrices;
+    }
+
+    function getPreviousPrices() external view returns (uint256[] memory prices) {
+        return _previousStarterPackPrices;
     }
 
     function checkCatalystBalance(uint256 tokenId) external view returns (uint256) {

--- a/src/StarterPack/StarterPackV1.sol
+++ b/src/StarterPack/StarterPackV1.sol
@@ -30,7 +30,7 @@ contract StarterPackV1 is Admin, MetaTransactionReceiver, PurchaseValidator {
     bool _daiEnabled;
 
     // indicates whether a price change is in effect
-    bool public _priceChangeActive;
+    bool private _priceChangeActive;
     uint256[] private _starterPackPrices;
     uint256[] private _previousStarterPackPrices;
 
@@ -181,10 +181,6 @@ contract StarterPackV1 is Admin, MetaTransactionReceiver, PurchaseValidator {
 
     function getStarterPackPrices() external view returns (uint256[] memory prices) {
         return _starterPackPrices;
-    }
-
-    function getPreviousPrices() external view returns (uint256[] memory prices) {
-        return _previousStarterPackPrices;
     }
 
     function checkCatalystBalance(uint256 tokenId) external view returns (uint256) {

--- a/test/starter-pack/testStarterPack.js
+++ b/test/starter-pack/testStarterPack.js
@@ -419,16 +419,6 @@ describe(":SetPricesEmptyStarterPack", function () {
     expect(latestPrices[3]).to.equal(80);
   });
 
-  it("should track both current and previous prices", async function () {
-    const {starterPackContractAsAdmin, starterPackContract} = setUp;
-    await starterPackContractAsAdmin.setPrices([3, 5, 8, 13]);
-    const currentPrices = await starterPackContract.getStarterPackPrices();
-    const previousPrices = await starterPackContract.getPreviousPrices();
-    for (i = 0; i < currentPrices.length; i++) {
-      expect(currentPrices[i]).to.not.equal(previousPrices[i]);
-    }
-  });
-
   it("price change should be implemented after a delay", async function () {
     let priceChangeActive;
     assert.notOk(priceChangeActive);

--- a/test/starter-pack/testStarterPack.js
+++ b/test/starter-pack/testStarterPack.js
@@ -419,6 +419,16 @@ describe(":SetPricesEmptyStarterPack", function () {
     expect(latestPrices[3]).to.equal(80);
   });
 
+  it("should track both current and previous prices", async function () {
+    const {starterPackContractAsAdmin, starterPackContract} = setUp;
+    await starterPackContractAsAdmin.setPrices([3, 5, 8, 13]);
+    const currentPrices = await starterPackContract.getStarterPackPrices();
+    const previousPrices = await starterPackContract.getPreviousPrices();
+    for (i = 0; i < currentPrices.length; i++) {
+      expect(currentPrices[i]).to.not.equal(previousPrices[i]);
+    }
+  });
+
   it("price change should be implemented after a delay", async function () {
     let priceChangeActive;
     assert.notOk(priceChangeActive);

--- a/test/starter-pack/testStarterPack.js
+++ b/test/starter-pack/testStarterPack.js
@@ -378,7 +378,7 @@ describe("StarterPack:PurchaseWithSandSuppliedStarterPack", function () {
   });
 });
 
-describe(":SetPricesEmptyStarterPack", function () {
+describe("StarterPack:SetPricesEmptyStarterPack", function () {
   let setUp;
   beforeEach(async function () {
     setUp = await supplyStarterPack();
@@ -420,50 +420,31 @@ describe(":SetPricesEmptyStarterPack", function () {
   });
 
   it("price change should be implemented after a delay", async function () {
-    let priceChangeActive;
-    assert.notOk(priceChangeActive);
-
     const {starterPackContractAsAdmin, starterPackContract, userWithSAND} = setUp;
     Message.buyer = userWithSAND.address;
     const dummySignature = signPurchaseMessage(privateKey, Message);
     await starterPackContractAsAdmin.setSANDEnabled(true);
-    priceChangeActive = await starterPackContract._priceChangeActive();
+    const newPrices = [3, 5, 8, 13];
+    await starterPackContractAsAdmin.setPrices(newPrices);
 
-    const oldPrices = await starterPackContract.getPreviousPrices();
-    const pricesToSet = [3, 5, 8, 13];
-    await starterPackContractAsAdmin.setPrices(pricesToSet);
-
-    const newPrices = await starterPackContract.getStarterPackPrices();
-    priceChangeActive = await starterPackContract._priceChangeActive();
-    // buyer should still pay the old price
+    // buyer should still pay the old price for 1 hour
     const receipt = await waitFor(
       userWithSAND.StarterPack.purchaseWithSand(userWithSAND.address, Message, dummySignature)
     );
     const eventsMatching = receipt.events.filter((event) => event.event === "Purchase");
     const totalExpectedPrice = 1600;
-    assert.ok(priceChangeActive);
     expect(eventsMatching[0].args[2]).to.equal(totalExpectedPrice);
-    const initPrices = [100, 200, 300, 1000];
-    for (i = 0; i < oldPrices.length; i++) {
-      expect(oldPrices[i]).to.equal(initPrices[i]);
-    }
-    for (i = 0; i < newPrices.length; i++) {
-      expect(newPrices[i]).to.equal(pricesToSet[i]);
-    }
-
-    Message.nonce++;
-    const dummySignature2 = signPurchaseMessage(privateKey, Message);
 
     // fast-forward 1 hour. now buyer should pay the new price
     await increaseTime(60 * 60);
+    Message.nonce++;
+    const dummySignature2 = signPurchaseMessage(privateKey, Message);
     const receipt2 = await waitFor(
       userWithSAND.StarterPack.purchaseWithSand(userWithSAND.address, Message, dummySignature2)
     );
     const eventsMatching2 = receipt2.events.filter((event) => event.event === "Purchase");
     const newTotalExpectedPrice = 29;
     expect(eventsMatching2[0].args[2]).to.equal(newTotalExpectedPrice);
-    priceChangeActive = await starterPackContract._priceChangeActive();
-    assert.notOk(priceChangeActive);
   });
 });
 

--- a/test/starter-pack/testStarterPack.js
+++ b/test/starter-pack/testStarterPack.js
@@ -378,7 +378,7 @@ describe("StarterPack:PurchaseWithSandSuppliedStarterPack", function () {
   });
 });
 
-describe(":SetPricesEmptyStarterPack", function () {
+describe("StarterPack:SetPricesEmptyStarterPack", function () {
   let setUp;
   beforeEach(async function () {
     setUp = await supplyStarterPack();
@@ -419,61 +419,32 @@ describe(":SetPricesEmptyStarterPack", function () {
     expect(latestPrices[3]).to.equal(80);
   });
 
-  it("should track both current and previous prices", async function () {
-    const {starterPackContractAsAdmin, starterPackContract} = setUp;
-    await starterPackContractAsAdmin.setPrices([3, 5, 8, 13]);
-    const currentPrices = await starterPackContract.getStarterPackPrices();
-    const previousPrices = await starterPackContract.getPreviousPrices();
-    for (i = 0; i < currentPrices.length; i++) {
-      expect(currentPrices[i]).to.not.equal(previousPrices[i]);
-    }
-  });
-
   it("price change should be implemented after a delay", async function () {
-    let priceChangeActive;
-    assert.notOk(priceChangeActive);
-
     const {starterPackContractAsAdmin, starterPackContract, userWithSAND} = setUp;
     Message.buyer = userWithSAND.address;
     const dummySignature = signPurchaseMessage(privateKey, Message);
     await starterPackContractAsAdmin.setSANDEnabled(true);
-    priceChangeActive = await starterPackContract._priceChangeActive();
+    const newPrices = [3, 5, 8, 13];
+    await starterPackContractAsAdmin.setPrices(newPrices);
 
-    const oldPrices = await starterPackContract.getPreviousPrices();
-    const pricesToSet = [3, 5, 8, 13];
-    await starterPackContractAsAdmin.setPrices(pricesToSet);
-
-    const newPrices = await starterPackContract.getStarterPackPrices();
-    priceChangeActive = await starterPackContract._priceChangeActive();
-    // buyer should still pay the old price
+    // buyer should still pay the old price for 1 hour
     const receipt = await waitFor(
       userWithSAND.StarterPack.purchaseWithSand(userWithSAND.address, Message, dummySignature)
     );
     const eventsMatching = receipt.events.filter((event) => event.event === "Purchase");
     const totalExpectedPrice = 1600;
-    assert.ok(priceChangeActive);
     expect(eventsMatching[0].args[2]).to.equal(totalExpectedPrice);
-    const initPrices = [100, 200, 300, 1000];
-    for (i = 0; i < oldPrices.length; i++) {
-      expect(oldPrices[i]).to.equal(initPrices[i]);
-    }
-    for (i = 0; i < newPrices.length; i++) {
-      expect(newPrices[i]).to.equal(pricesToSet[i]);
-    }
-
-    Message.nonce++;
-    const dummySignature2 = signPurchaseMessage(privateKey, Message);
 
     // fast-forward 1 hour. now buyer should pay the new price
     await increaseTime(60 * 60);
+    Message.nonce++;
+    const dummySignature2 = signPurchaseMessage(privateKey, Message);
     const receipt2 = await waitFor(
       userWithSAND.StarterPack.purchaseWithSand(userWithSAND.address, Message, dummySignature2)
     );
     const eventsMatching2 = receipt2.events.filter((event) => event.event === "Purchase");
     const newTotalExpectedPrice = 29;
     expect(eventsMatching2[0].args[2]).to.equal(newTotalExpectedPrice);
-    priceChangeActive = await starterPackContract._priceChangeActive();
-    assert.notOk(priceChangeActive);
   });
 });
 

--- a/test/starter-pack/testStarterPack.js
+++ b/test/starter-pack/testStarterPack.js
@@ -378,9 +378,8 @@ describe("StarterPack:PurchaseWithSandSuppliedStarterPack", function () {
   });
 });
 
-describe("StarterPack:SetPricesEmptyStarterPack", function () {
+describe(":SetPricesEmptyStarterPack", function () {
   let setUp;
-  // @review
   beforeEach(async function () {
     setUp = await supplyStarterPack();
     Message = {


### PR DESCRIPTION
I tried to do something a bit simpler for the delay but will need some feedback as I may be missing something here.

The general idea I had in mind with this was that price changes are not likely to happen often. 
For the majority of purchases, we will just want to use the prices stored in `_starterPackPrices` so I tried to optimize for that by using a bool `_priceChangeActive`. 
For all purchases, if `_priceChangeActive` is false, just uses the prices in `_starterPackPrices`

Of course, a price update may not update the prices for all catalysts at once. 
Eg: maybe only 1 catalyst price is being updated. 
This just means that for at least the next hour, `_priceChangeActive = true` and the `_previousStarterPackPrices` are used, 3 of which are the same as the current prices anyway.

Anyway, happy to revise/backtrack on this if this will not meet our objectives.