### PR TITLE
Task/set prices tidy

### DIFF
--- a/data/starterPack/index.js
+++ b/data/starterPack/index.js
@@ -1,1 +1,10 @@
-module.exports.starterPackPrices = [100, 200, 300, 1000];
+const ethers = require("ethers");
+const {BigNumber} = ethers;
+
+// sand price is in Sand unit (Sand has 18 decimals)
+module.exports.starterPackPrices = [
+  BigNumber.from(100),
+  BigNumber.from(200),
+  BigNumber.from(300),
+  BigNumber.from(1000),
+];

--- a/data/starterPack/index.js
+++ b/data/starterPack/index.js
@@ -1,10 +1,8 @@
 const ethers = require("ethers");
 const {BigNumber} = ethers;
+function sandWei(amount) {
+  return BigNumber.from(amount).mul("1000000000000000000").toString();
+}
 
 // sand price is in Sand unit (Sand has 18 decimals)
-module.exports.starterPackPrices = [
-  BigNumber.from(100),
-  BigNumber.from(200),
-  BigNumber.from(300),
-  BigNumber.from(1000),
-];
+module.exports.starterPackPrices = [sandWei(100), sandWei(200), sandWei(300), sandWei(1000)];

--- a/src/StarterPack/StarterPackV1.sol
+++ b/src/StarterPack/StarterPackV1.sol
@@ -178,7 +178,7 @@ contract StarterPackV1 is Admin, MetaTransactionReceiver, PurchaseValidator {
         require(message.buyer != address(this), "DESTINATION_STARTERPACKV1_CONTRACT");
         require(isPurchaseValid(from, message.catalystIds, message.catalystQuantities, message.gemIds, message.gemQuantities, message.buyer, message.nonce, signature), "INVALID_PURCHASE");
 
-        uint256 amountInSand = _calculateTotalPriceInSand();
+        uint256 amountInSand = _calculateTotalPriceInSand(message.catalystIds, message.catalystQuantities);
         uint256 DAIRequired = amountInSand.mul(DAI_PRICE).div(1000000000000000000);
         _handlePurchaseWithERC20(message.buyer, _wallet, address(_dai), DAIRequired);
         _erc20GroupCatalyst.batchTransferFrom(address(this), message.buyer, message.catalystIds, message.catalystQuantities);
@@ -192,7 +192,7 @@ contract StarterPackV1 is Admin, MetaTransactionReceiver, PurchaseValidator {
     }
 
     function setPrices(uint256[] calldata prices) external {
-        require(msg.sender == _admin, "only admin can change StarterPack prices");
+        require(msg.sender == _admin, "ONLY_ADMIN_CAN_CHANGE_STARTERPACK_PRICES");
         _previousStarterPackPrices = _starterPackPrices;
         _starterPackPrices = prices;
         _priceChangeTimestamp = now;

--- a/src/StarterPack/StarterPackV1.sol
+++ b/src/StarterPack/StarterPackV1.sol
@@ -61,14 +61,14 @@ contract StarterPackV1 is Admin, MetaTransactionReceiver, PurchaseValidator {
     /// @param newWallet address of the new receiving wallet
     function setReceivingWallet(address payable newWallet) external {
         require(newWallet != address(0), "WALLET_ZERO_ADDRESS");
-        require(msg.sender == _admin, "ONLY_ADMIN_CAN_CHANGE_WALLET");
+        require(msg.sender == _admin, "NOT_AUTHORIZED");
         _wallet = newWallet;
     }
 
     /// @dev enable/disable DAI payment for StarterPacks
     /// @param enabled whether to enable or disable
     function setDAIEnabled(bool enabled) external {
-        require(msg.sender == _admin, "ONLY_ADMIN_CAN_SET_DAI_ENABLED_OR_DISABLED");
+        require(msg.sender == _admin, "NOT_AUTHORIZED");
         _daiEnabled = enabled;
     }
 
@@ -81,7 +81,7 @@ contract StarterPackV1 is Admin, MetaTransactionReceiver, PurchaseValidator {
     /// @notice enable/disable ETH payment for StarterPacks
     /// @param enabled whether to enable or disable
     function setETHEnabled(bool enabled) external {
-        require(msg.sender == _admin, "ONLY_ADMIN_CAN_SET_ETH_ENABLED_OR_DISABLED");
+        require(msg.sender == _admin, "NOT_AUTHORIZED");
         _etherEnabled = enabled;
     }
 
@@ -94,7 +94,7 @@ contract StarterPackV1 is Admin, MetaTransactionReceiver, PurchaseValidator {
     /// @dev enable/disable the specific SAND payment for StarterPacks
     /// @param enabled whether to enable or disable
     function setSANDEnabled(bool enabled) external {
-        require(msg.sender == _admin, "ONLY_ADMIN_CAN_SET_SAND_ENABLED_OR_DISABLED");
+        require(msg.sender == _admin, "NOT_AUTHORIZED");
         _sandEnabled = enabled;
     }
 
@@ -187,13 +187,13 @@ contract StarterPackV1 is Admin, MetaTransactionReceiver, PurchaseValidator {
     }
 
     function withdrawAll(address to) external {
-        require(msg.sender == _admin, "ONLY_ADMIN_CAN_WITHDRAW_REMAINING_TOKENS");
+        require(msg.sender == _admin, "NOT_AUTHORIZED");
         // TODO: withdrawal
         // If curren token owner is address(this) then [batch]transfer ownership to new address
     }
 
     function setPrices(uint256[] calldata prices) external {
-        require(msg.sender == _admin, "ONLY_ADMIN_CAN_CHANGE_STARTERPACK_PRICES");
+        require(msg.sender == _admin, "NOT_AUTHORIZED");
         _previousStarterPackPrices = _starterPackPrices;
         _starterPackPrices = prices;
         _priceChangeTimestamp = now;

--- a/src/StarterPack/StarterPackV1.sol
+++ b/src/StarterPack/StarterPackV1.sol
@@ -204,10 +204,6 @@ contract StarterPackV1 is Admin, MetaTransactionReceiver, PurchaseValidator {
         return _starterPackPrices;
     }
 
-    function getPreviousPrices() external view returns (uint256[] memory prices) {
-        return _previousStarterPackPrices;
-    }
-
     /**
      * @notice Returns the amount of ETH for a specific amount of SAND
      * @param sandAmount An amount of SAND

--- a/src/StarterPack/StarterPackV1.sol
+++ b/src/StarterPack/StarterPackV1.sol
@@ -187,8 +187,9 @@ contract StarterPackV1 is Admin, MetaTransactionReceiver, PurchaseValidator {
     }
 
     function withdrawAll(address to) external {
-        require(msg.sender == _admin, "only admin can withdraw remaining tokens");
+        require(msg.sender == _admin, "ONLY_ADMIN_CAN_WITHDRAW_REMAINING_TOKENS");
         // TODO: withdrawal
+        // If curren token owner is address(this) then [batch]transfer ownership to new address
     }
 
     function setPrices(uint256[] calldata prices) external {
@@ -205,30 +206,6 @@ contract StarterPackV1 is Admin, MetaTransactionReceiver, PurchaseValidator {
 
     function getPreviousPrices() external view returns (uint256[] memory prices) {
         return _previousStarterPackPrices;
-    }
-
-    function checkCatalystBalance(uint256 tokenId) external view returns (uint256) {
-        return _erc20GroupCatalyst.balanceOf(address(this), tokenId);
-    }
-
-    function checkGemBalance(uint256 tokenId) external view returns (uint256) {
-        return _erc20GroupGem.balanceOf(address(this), tokenId);
-    }
-
-    function checkCatalystBatchBalances(uint256[] calldata tokenIds) external view returns (uint256[] memory balances) {
-        address[] memory owners = new address[](tokenIds.length);
-        for (uint256 i = 0; i < tokenIds.length; i++) {
-            owners[i] = address(this);
-        }
-        return _erc20GroupCatalyst.balanceOfBatch(owners, tokenIds);
-    }
-
-    function checkGemBatchBalances(uint256[] calldata tokenIds) external view returns (uint256[] memory balances) {
-        address[] memory owners = new address[](tokenIds.length);
-        for (uint256 i = 0; i < tokenIds.length; i++) {
-            owners[i] = address(this);
-        }
-        return _erc20GroupGem.balanceOfBatch(owners, tokenIds);
     }
 
     /**

--- a/test/starter-pack/subTests/common_tests.js
+++ b/test/starter-pack/subTests/common_tests.js
@@ -55,20 +55,28 @@ function runCommonTests() {
     });
 
     it("user can check the balance of a catalyst ID owned by StarterPackV1", async function () {
-      const {userWithSAND} = await setUp;
-      const balance = await userWithSAND.StarterPack.checkCatalystBalance(0);
+      const {catalystContract, starterPackContract} = await setUp;
+      const balance = await catalystContract.balanceOf(starterPackContract.address, 0);
       expect(balance).to.equal(8);
     });
 
     it("user can check the balance of a gem ID owned by StarterPackV1", async function () {
-      const {userWithSAND} = await setUp;
-      const balance = await userWithSAND.StarterPack.checkGemBalance(1);
+      const {gemContract, starterPackContract} = await setUp;
+      const balance = await gemContract.balanceOf(starterPackContract.address, 1);
       expect(balance).to.equal(100);
     });
 
     it("user can check batch balances of catalyst IDs owned by StarterPackV1", async function () {
-      const {userWithSAND} = await setUp;
-      const balances = await userWithSAND.StarterPack.checkCatalystBatchBalances([0, 1, 2, 3]);
+      const {catalystContract, starterPackContract} = await setUp;
+      const balances = await catalystContract.balanceOfBatch(
+        [
+          starterPackContract.address,
+          starterPackContract.address,
+          starterPackContract.address,
+          starterPackContract.address,
+        ],
+        [0, 1, 2, 3]
+      );
       expect(balances[0]).to.equal(BigNumber.from(8));
       expect(balances[1]).to.equal(BigNumber.from(6));
       expect(balances[2]).to.equal(BigNumber.from(4));
@@ -76,12 +84,22 @@ function runCommonTests() {
     });
 
     it("user can check batch balances of gem IDs owned by StarterPackV1", async function () {
-      const {users} = await setUp;
-      const balances = await users[0].StarterPack.checkGemBatchBalances([0, 1, 2, 3]);
+      const {gemContract, starterPackContract} = await setUp;
+      const balances = await gemContract.balanceOfBatch(
+        [
+          starterPackContract.address,
+          starterPackContract.address,
+          starterPackContract.address,
+          starterPackContract.address,
+          starterPackContract.address,
+        ],
+        [0, 1, 2, 3, 4]
+      );
       expect(balances[0]).to.equal(BigNumber.from(100));
       expect(balances[1]).to.equal(BigNumber.from(100));
       expect(balances[2]).to.equal(BigNumber.from(100));
       expect(balances[3]).to.equal(BigNumber.from(100));
+      expect(balances[4]).to.equal(BigNumber.from(100));
     });
 
     it("cannot set prices if not admin", async function () {

--- a/test/starter-pack/subTests/common_tests.js
+++ b/test/starter-pack/subTests/common_tests.js
@@ -104,7 +104,7 @@ function runCommonTests() {
 
     it("cannot set prices if not admin", async function () {
       const {users} = setUp;
-      await expectRevert(users[0].StarterPack.setPrices([50, 60, 70, 80]), "ONLY_ADMIN_CAN_CHANGE_STARTERPACK_PRICES");
+      await expectRevert(users[0].StarterPack.setPrices([50, 60, 70, 80]), "NOT_AUTHORIZED");
     });
 
     it("can set prices if admin", async function () {

--- a/test/starter-pack/subTests/dai_tests.js
+++ b/test/starter-pack/subTests/dai_tests.js
@@ -10,8 +10,9 @@ const {privateKey} = require("./_testHelper");
 function runDaiTests() {
   describe("StarterPack:PurchaseWithDAIEmptyStarterPack", function () {
     let setUp;
+    let Message;
 
-    const Message = {
+    const TestMessage = {
       catalystIds: [0, 1, 2, 3],
       catalystQuantities: [1, 1, 1, 1],
       gemIds: [0, 1, 2, 3, 4],
@@ -24,6 +25,7 @@ function runDaiTests() {
       setUp = await setupStarterPack();
       const {starterPackContractAsAdmin} = setUp;
       await starterPackContractAsAdmin.setDAIEnabled(true);
+      Message = {...TestMessage};
     });
 
     it("should revert if the user does not have enough DAI", async function () {
@@ -68,8 +70,9 @@ function runDaiTests() {
 
   describe("StarterPack:PurchaseWithDAISuppliedStarterPack", function () {
     let setUp;
+    let Message;
 
-    const Message = {
+    const TestMessage = {
       catalystIds: [0, 1, 2, 3],
       catalystQuantities: [1, 1, 1, 1],
       gemIds: [0, 1, 2, 3, 4],
@@ -82,6 +85,7 @@ function runDaiTests() {
       setUp = await supplyStarterPack();
       const {starterPackContractAsAdmin} = setUp;
       await starterPackContractAsAdmin.setDAIEnabled(true);
+      Message = {...TestMessage};
     });
 
     it("if StarterpackV1.sol owns Catalysts & Gems then listed purchasers should be able to purchase with DAI with 1 Purchase event", async function () {
@@ -298,7 +302,6 @@ function runDaiTests() {
     it("price change should be implemented after a delay", async function () {
       const {starterPackContractAsAdmin, userWithDAI} = setUp;
       Message.buyer = userWithDAI.address;
-      Message.nonce = 0;
       const dummySignature = signPurchaseMessage(privateKey, Message);
       await starterPackContractAsAdmin.setDAIEnabled(true);
       const newPrices = [

--- a/test/starter-pack/subTests/dai_tests.js
+++ b/test/starter-pack/subTests/dai_tests.js
@@ -308,7 +308,7 @@ function runDaiTests() {
         userWithDAI.StarterPack.purchaseWithDAI(userWithDAI.address, Message, dummySignature)
       );
       const eventsMatching = receipt.events.filter((event) => event.event === "Purchase");
-      const totalExpectedPrice = BigNumber.from(1600);
+      const totalExpectedPrice = 1600;
       expect(eventsMatching[0].args[2]).to.equal(totalExpectedPrice);
 
       // fast-forward 1 hour. now buyer should pay the new price

--- a/test/starter-pack/subTests/dai_tests.js
+++ b/test/starter-pack/subTests/dai_tests.js
@@ -301,14 +301,19 @@ function runDaiTests() {
       Message.nonce = 0;
       const dummySignature = signPurchaseMessage(privateKey, Message);
       await starterPackContractAsAdmin.setDAIEnabled(true);
-      const newPrices = [BigNumber.from(300), BigNumber.from(500), BigNumber.from(800), BigNumber.from(1300)];
+      const newPrices = [
+        BigNumber.from(300).mul("1000000000000000000"),
+        BigNumber.from(500).mul("1000000000000000000"),
+        BigNumber.from(800).mul("1000000000000000000"),
+        BigNumber.from(1300).mul("1000000000000000000"),
+      ];
       await starterPackContractAsAdmin.setPrices(newPrices);
       // buyer should still pay the old price for 1 hour
       const receipt = await waitFor(
         userWithDAI.StarterPack.purchaseWithDAI(userWithDAI.address, Message, dummySignature)
       );
       const eventsMatching = receipt.events.filter((event) => event.event === "Purchase");
-      const totalExpectedPrice = 1600;
+      const totalExpectedPrice = BigNumber.from(1600).mul("1000000000000000000");
       expect(eventsMatching[0].args[2]).to.equal(totalExpectedPrice);
 
       // fast-forward 1 hour. now buyer should pay the new price
@@ -319,7 +324,7 @@ function runDaiTests() {
         userWithDAI.StarterPack.purchaseWithDAI(userWithDAI.address, Message, dummySignature2)
       );
       const eventsMatching2 = receipt2.events.filter((event) => event.event === "Purchase");
-      const newTotalExpectedPrice = 2900;
+      const newTotalExpectedPrice = BigNumber.from(2900).mul("1000000000000000000");
       expect(eventsMatching2[0].args[2]).to.equal(newTotalExpectedPrice);
     });
   });

--- a/test/starter-pack/subTests/dai_tests.js
+++ b/test/starter-pack/subTests/dai_tests.js
@@ -62,7 +62,7 @@ function runDaiTests() {
     it("cannot enable/disable DAI if not admin", async function () {
       const {userWithoutDAI, starterPackContractAsAdmin} = setUp;
       await starterPackContractAsAdmin.setDAIEnabled(false);
-      await expectRevert(userWithoutDAI.StarterPack.setDAIEnabled(true), "ONLY_ADMIN_CAN_SET_DAI_ENABLED_OR_DISABLED");
+      await expectRevert(userWithoutDAI.StarterPack.setDAIEnabled(true), "NOT_AUTHORIZED");
     });
   });
 

--- a/test/starter-pack/subTests/ether_tests.js
+++ b/test/starter-pack/subTests/ether_tests.js
@@ -1,6 +1,8 @@
 const {setupStarterPack, supplyStarterPack} = require("./fixtures");
 const {assert, expect} = require("local-chai");
-const {waitFor, expectRevert, zeroAddress} = require("local-utils");
+const {waitFor, expectRevert, zeroAddress, increaseTime} = require("local-utils");
+const ethers = require("ethers");
+const {BigNumber} = ethers;
 const {findEvents} = require("../../../lib/findEvents.js");
 const {signPurchaseMessage} = require("../../../lib/purchaseMessageSigner");
 const {privateKey} = require("./_testHelper");
@@ -288,6 +290,34 @@ function runEtherTests() {
       dummySignature = signPurchaseMessage(privateKey, Message);
 
       await users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature, {value: 1000000});
+    });
+
+    it("price change should be implemented after a delay", async function () {
+      const {starterPackContractAsAdmin, users} = setUp;
+      Message.buyer = users[0].address;
+      Message.nonce = 0;
+      const dummySignature = signPurchaseMessage(privateKey, Message);
+      await starterPackContractAsAdmin.setETHEnabled(true);
+      const newPrices = [BigNumber.from(300), BigNumber.from(500), BigNumber.from(800), BigNumber.from(1300)];
+      await starterPackContractAsAdmin.setPrices(newPrices);
+      // buyer should still pay the old price for 1 hour
+      const receipt = await waitFor(
+        users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature, {value: 1000000})
+      );
+      const eventsMatching = receipt.events.filter((event) => event.event === "Purchase");
+      const totalExpectedPrice = BigNumber.from(1600);
+      expect(eventsMatching[0].args[2]).to.equal(totalExpectedPrice);
+
+      // fast-forward 1 hour. now buyer should pay the new price
+      await increaseTime(60 * 60);
+      Message.nonce++;
+      const dummySignature2 = signPurchaseMessage(privateKey, Message);
+      const receipt2 = await waitFor(
+        users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature2, {value: 1000000})
+      );
+      const eventsMatching2 = receipt2.events.filter((event) => event.event === "Purchase");
+      const newTotalExpectedPrice = 2900;
+      expect(eventsMatching2[0].args[2]).to.equal(newTotalExpectedPrice);
     });
   });
 }

--- a/test/starter-pack/subTests/ether_tests.js
+++ b/test/starter-pack/subTests/ether_tests.js
@@ -10,8 +10,9 @@ const {privateKey} = require("./_testHelper");
 function runEtherTests() {
   describe("StarterPack:PurchaseWithETHEmptyStarterPack", function () {
     let setUp;
+    let Message;
 
-    const Message = {
+    const TestMessage = {
       catalystIds: [0, 1, 2, 3],
       catalystQuantities: [10, 10, 10, 10],
       gemIds: [0, 1, 2, 3, 4],
@@ -24,6 +25,7 @@ function runEtherTests() {
       setUp = await setupStarterPack();
       const {starterPackContractAsAdmin} = setUp;
       await starterPackContractAsAdmin.setETHEnabled(true);
+      Message = {...TestMessage};
     });
 
     it("should revert if the user does not have enough ETH", async function () {
@@ -68,8 +70,9 @@ function runEtherTests() {
 
   describe("StarterPack:PurchaseWithETHSuppliedStarterPack", function () {
     let setUp;
+    let Message;
 
-    const Message = {
+    const TestMessage = {
       catalystIds: [0, 1, 2, 3],
       catalystQuantities: [1, 1, 1, 1],
       gemIds: [0, 1, 2, 3, 4],
@@ -82,6 +85,7 @@ function runEtherTests() {
       setUp = await supplyStarterPack();
       const {starterPackContractAsAdmin} = setUp;
       await starterPackContractAsAdmin.setETHEnabled(true);
+      Message = {...TestMessage};
     });
 
     it("if StarterpackV1.sol owns Catalysts & Gems then listed purchasers should be able to purchase with ETH with 1 Purchase event", async function () {
@@ -309,7 +313,6 @@ function runEtherTests() {
     it("price change should be implemented after a delay", async function () {
       const {starterPackContractAsAdmin, users} = setUp;
       Message.buyer = users[0].address;
-      Message.nonce = 0;
       const dummySignature = signPurchaseMessage(privateKey, Message);
       await starterPackContractAsAdmin.setETHEnabled(true);
       const newPrices = [

--- a/test/starter-pack/subTests/ether_tests.js
+++ b/test/starter-pack/subTests/ether_tests.js
@@ -62,7 +62,7 @@ function runEtherTests() {
     it("cannot enable/disable ETH if not admin", async function () {
       const {users, starterPackContractAsAdmin} = setUp;
       await starterPackContractAsAdmin.setETHEnabled(false);
-      await expectRevert(users[0].StarterPack.setETHEnabled(true), "ONLY_ADMIN_CAN_SET_ETH_ENABLED_OR_DISABLED");
+      await expectRevert(users[0].StarterPack.setETHEnabled(true), "NOT_AUTHORIZED");
     });
   });
 

--- a/test/starter-pack/subTests/ether_tests.js
+++ b/test/starter-pack/subTests/ether_tests.js
@@ -305,7 +305,7 @@ function runEtherTests() {
         users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature, {value: 1000000})
       );
       const eventsMatching = receipt.events.filter((event) => event.event === "Purchase");
-      const totalExpectedPrice = BigNumber.from(1600);
+      const totalExpectedPrice = 1600;
       expect(eventsMatching[0].args[2]).to.equal(totalExpectedPrice);
 
       // fast-forward 1 hour. now buyer should pay the new price

--- a/test/starter-pack/subTests/ether_tests.js
+++ b/test/starter-pack/subTests/ether_tests.js
@@ -41,7 +41,9 @@ function runEtherTests() {
       Message.buyer = users[0].address;
       const dummySignature = signPurchaseMessage(privateKey, Message);
       await expectRevert(
-        users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature, {value: 1000000}),
+        users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature, {
+          value: BigNumber.from(2).mul("1000000000000000000"),
+        }),
         "can't substract more than there is"
       );
     });
@@ -103,7 +105,9 @@ function runEtherTests() {
       const dummySignature = signPurchaseMessage(privateKey, Message);
 
       const receipt = await waitFor(
-        users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature, {value: 1000000})
+        users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature, {
+          value: BigNumber.from(2).mul("1000000000000000000"),
+        })
       );
       const eventsMatching = receipt.events.filter((event) => event.event === "Purchase");
       assert.equal(eventsMatching.length, 1);
@@ -259,7 +263,9 @@ function runEtherTests() {
       const dummySignature = signPurchaseMessage(privateKey, Message);
       const nonceBeforePurchase = await starterPackContract.getNonceByBuyer(users[0].address, 0);
       expect(nonceBeforePurchase).to.equal(0);
-      await users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature, {value: 1000000});
+      await users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature, {
+        value: BigNumber.from(2).mul("1000000000000000000"),
+      });
       const nonceAfterPurchase = await starterPackContract.getNonceByBuyer(users[0].address, 0);
       expect(nonceAfterPurchase).to.equal(1);
     });
@@ -270,9 +276,13 @@ function runEtherTests() {
 
       const dummySignature = signPurchaseMessage(privateKey, Message);
 
-      await users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature, {value: 1000000});
+      await users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature, {
+        value: BigNumber.from(2).mul("1000000000000000000"),
+      });
       await expectRevert(
-        users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature, {value: 1000000}),
+        users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature, {
+          value: BigNumber.from(2).mul("1000000000000000000"),
+        }),
         "INVALID_NONCE"
       );
     });
@@ -283,13 +293,17 @@ function runEtherTests() {
 
       let dummySignature = signPurchaseMessage(privateKey, Message);
 
-      await users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature, {value: 1000000});
+      await users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature, {
+        value: BigNumber.from(2).mul("1000000000000000000"),
+      });
 
       Message.nonce++;
 
       dummySignature = signPurchaseMessage(privateKey, Message);
 
-      await users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature, {value: 1000000});
+      await users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature, {
+        value: BigNumber.from(2).mul("1000000000000000000"),
+      });
     });
 
     it("price change should be implemented after a delay", async function () {
@@ -298,14 +312,21 @@ function runEtherTests() {
       Message.nonce = 0;
       const dummySignature = signPurchaseMessage(privateKey, Message);
       await starterPackContractAsAdmin.setETHEnabled(true);
-      const newPrices = [BigNumber.from(300), BigNumber.from(500), BigNumber.from(800), BigNumber.from(1300)];
+      const newPrices = [
+        BigNumber.from(300).mul("1000000000000000000"),
+        BigNumber.from(500).mul("1000000000000000000"),
+        BigNumber.from(800).mul("1000000000000000000"),
+        BigNumber.from(1300).mul("1000000000000000000"),
+      ];
       await starterPackContractAsAdmin.setPrices(newPrices);
       // buyer should still pay the old price for 1 hour
       const receipt = await waitFor(
-        users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature, {value: 1000000})
+        users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature, {
+          value: BigNumber.from(2).mul("1000000000000000000"),
+        })
       );
       const eventsMatching = receipt.events.filter((event) => event.event === "Purchase");
-      const totalExpectedPrice = 1600;
+      const totalExpectedPrice = BigNumber.from(1600).mul("1000000000000000000");
       expect(eventsMatching[0].args[2]).to.equal(totalExpectedPrice);
 
       // fast-forward 1 hour. now buyer should pay the new price
@@ -313,10 +334,12 @@ function runEtherTests() {
       Message.nonce++;
       const dummySignature2 = signPurchaseMessage(privateKey, Message);
       const receipt2 = await waitFor(
-        users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature2, {value: 1000000})
+        users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature2, {
+          value: BigNumber.from(2).mul("1000000000000000000"),
+        })
       );
       const eventsMatching2 = receipt2.events.filter((event) => event.event === "Purchase");
-      const newTotalExpectedPrice = 2900;
+      const newTotalExpectedPrice = BigNumber.from(2900).mul("1000000000000000000");
       expect(eventsMatching2[0].args[2]).to.equal(newTotalExpectedPrice);
     });
   });

--- a/test/starter-pack/subTests/sand_tests.js
+++ b/test/starter-pack/subTests/sand_tests.js
@@ -10,8 +10,9 @@ const {privateKey} = require("./_testHelper");
 function runSandTests() {
   describe("StarterPack:PurchaseWithSandEmptyStarterPack", function () {
     let setUp;
+    let Message;
 
-    const Message = {
+    const TestMessage = {
       catalystIds: [0, 1, 2, 3],
       catalystQuantities: [1, 1, 1, 1],
       gemIds: [0, 1, 2, 3, 4],
@@ -24,6 +25,7 @@ function runSandTests() {
       setUp = await setupStarterPack();
       const {starterPackContractAsAdmin} = setUp;
       await starterPackContractAsAdmin.setSANDEnabled(true);
+      Message = {...TestMessage};
     });
 
     it("should revert if the user does not have enough SAND", async function () {
@@ -68,8 +70,9 @@ function runSandTests() {
 
   describe("StarterPack:PurchaseWithSandSuppliedStarterPack", function () {
     let setUp;
+    let Message;
 
-    const Message = {
+    const TestMessage = {
       catalystIds: [0, 1, 2, 3],
       catalystQuantities: [1, 1, 1, 1],
       gemIds: [0, 1, 2, 3, 4],
@@ -82,6 +85,7 @@ function runSandTests() {
       setUp = await supplyStarterPack();
       const {starterPackContractAsAdmin} = setUp;
       await starterPackContractAsAdmin.setSANDEnabled(true);
+      Message = {...TestMessage};
     });
 
     it("if StarterpackV1.sol owns Catalysts & Gems then listed purchasers should be able to purchase with SAND with 1 Purchase event", async function () {
@@ -298,7 +302,6 @@ function runSandTests() {
     it("price change should be implemented after a delay", async function () {
       const {starterPackContractAsAdmin, userWithSAND} = setUp;
       Message.buyer = userWithSAND.address;
-      Message.nonce = 0;
       const dummySignature = signPurchaseMessage(privateKey, Message);
       await starterPackContractAsAdmin.setSANDEnabled(true);
       const newPrices = [

--- a/test/starter-pack/subTests/sand_tests.js
+++ b/test/starter-pack/subTests/sand_tests.js
@@ -304,14 +304,14 @@ function runSandTests() {
       Message.nonce = 0;
       const dummySignature = signPurchaseMessage(privateKey, Message);
       await starterPackContractAsAdmin.setSANDEnabled(true);
-      const newPrices = [3, 5, 8, 13];
+      const newPrices = [BigNumber.from(300), BigNumber.from(500), BigNumber.from(800), BigNumber.from(1300)];
       await starterPackContractAsAdmin.setPrices(newPrices);
       // buyer should still pay the old price for 1 hour
       const receipt = await waitFor(
         userWithSAND.StarterPack.purchaseWithSand(userWithSAND.address, Message, dummySignature)
       );
       const eventsMatching = receipt.events.filter((event) => event.event === "Purchase");
-      const totalExpectedPrice = 1600;
+      const totalExpectedPrice = BigNumber.from(1600);
       expect(eventsMatching[0].args[2]).to.equal(totalExpectedPrice);
 
       // fast-forward 1 hour. now buyer should pay the new price
@@ -322,7 +322,7 @@ function runSandTests() {
         userWithSAND.StarterPack.purchaseWithSand(userWithSAND.address, Message, dummySignature2)
       );
       const eventsMatching2 = receipt2.events.filter((event) => event.event === "Purchase");
-      const newTotalExpectedPrice = 29;
+      const newTotalExpectedPrice = 2900;
       expect(eventsMatching2[0].args[2]).to.equal(newTotalExpectedPrice);
     });
   });

--- a/test/starter-pack/subTests/sand_tests.js
+++ b/test/starter-pack/subTests/sand_tests.js
@@ -304,14 +304,19 @@ function runSandTests() {
       Message.nonce = 0;
       const dummySignature = signPurchaseMessage(privateKey, Message);
       await starterPackContractAsAdmin.setSANDEnabled(true);
-      const newPrices = [BigNumber.from(300), BigNumber.from(500), BigNumber.from(800), BigNumber.from(1300)];
+      const newPrices = [
+        BigNumber.from(300).mul("1000000000000000000"),
+        BigNumber.from(500).mul("1000000000000000000"),
+        BigNumber.from(800).mul("1000000000000000000"),
+        BigNumber.from(1300).mul("1000000000000000000"),
+      ];
       await starterPackContractAsAdmin.setPrices(newPrices);
       // buyer should still pay the old price for 1 hour
       const receipt = await waitFor(
         userWithSAND.StarterPack.purchaseWithSand(userWithSAND.address, Message, dummySignature)
       );
       const eventsMatching = receipt.events.filter((event) => event.event === "Purchase");
-      const totalExpectedPrice = 1600;
+      const totalExpectedPrice = BigNumber.from(1600).mul("1000000000000000000");
       expect(eventsMatching[0].args[2]).to.equal(totalExpectedPrice);
 
       // fast-forward 1 hour. now buyer should pay the new price
@@ -322,7 +327,7 @@ function runSandTests() {
         userWithSAND.StarterPack.purchaseWithSand(userWithSAND.address, Message, dummySignature2)
       );
       const eventsMatching2 = receipt2.events.filter((event) => event.event === "Purchase");
-      const newTotalExpectedPrice = 2900;
+      const newTotalExpectedPrice = BigNumber.from(2900).mul("1000000000000000000");
       expect(eventsMatching2[0].args[2]).to.equal(newTotalExpectedPrice);
     });
   });

--- a/test/starter-pack/subTests/sand_tests.js
+++ b/test/starter-pack/subTests/sand_tests.js
@@ -62,10 +62,7 @@ function runSandTests() {
     it("cannot enable/disable SAND if not admin", async function () {
       const {userWithoutSAND, starterPackContractAsAdmin} = setUp;
       await starterPackContractAsAdmin.setSANDEnabled(false);
-      await expectRevert(
-        userWithoutSAND.StarterPack.setSANDEnabled(true),
-        "ONLY_ADMIN_CAN_SET_SAND_ENABLED_OR_DISABLED"
-      );
+      await expectRevert(userWithoutSAND.StarterPack.setSANDEnabled(true), "NOT_AUTHORIZED");
     });
   });
 

--- a/test/starter-pack/subTests/sand_tests.js
+++ b/test/starter-pack/subTests/sand_tests.js
@@ -311,7 +311,7 @@ function runSandTests() {
         userWithSAND.StarterPack.purchaseWithSand(userWithSAND.address, Message, dummySignature)
       );
       const eventsMatching = receipt.events.filter((event) => event.event === "Purchase");
-      const totalExpectedPrice = BigNumber.from(1600);
+      const totalExpectedPrice = 1600;
       expect(eventsMatching[0].args[2]).to.equal(totalExpectedPrice);
 
       // fast-forward 1 hour. now buyer should pay the new price


### PR DESCRIPTION
Tidy up following merge of setPrices branch earlier today.
- Reinstate setPrices admin tests
- Add missing params to _calculateTotalPriceInSand in purchaseWithDAI function
- Increase initial starterPack prices in data folder
- Tests included for each of purchaseWithETH, purchaseWithDAI and purchaseWithSand that shows the correct price change taking effect after a delay