### PR TITLE
remove unecessary asset from constructor

### DIFF
--- a/deploy/052_deploy_catalyst_registry.js
+++ b/deploy/052_deploy_catalyst_registry.js
@@ -10,7 +10,7 @@ module.exports = async ({getNamedAccounts, deployments}) => {
     from: deployer,
     args: [
       catalyst.address,
-      deployer, // is to to catalystRegistryAdmin later
+      deployer, // is set to catalystRegistryAdmin later (see 810_set_catalystRegistry_admin.js)
     ],
     log: true,
   });

--- a/deploy/052_deploy_catalyst_registry.js
+++ b/deploy/052_deploy_catalyst_registry.js
@@ -1,25 +1,18 @@
 const {guard} = require("../lib");
 
 module.exports = async ({getNamedAccounts, deployments}) => {
-  const {deployIfDifferent, log} = deployments;
+  const {deploy} = deployments;
   const {deployer} = await getNamedAccounts();
 
-  const asset = await deployments.get("Asset");
   const catalyst = await deployments.get("Catalyst");
 
-  const catalystRegistry = await deployIfDifferent(
-    ["data"],
-    "CatalystRegistry",
-    {from: deployer, gas: 3000000},
-    "CatalystRegistry",
-    asset.address,
-    catalyst.address,
-    deployer // is to to catalystRegistryAdmin later
-  );
-  if (catalystRegistry.newlyDeployed) {
-    log(` - CatalystRegistry deployed at :  ${catalystRegistry.address} for gas: ${catalystRegistry.receipt.gasUsed}`);
-  } else {
-    log(`reusing CatalystRegistry at ${catalystRegistry.address}`);
-  }
+  await deploy("CatalystRegistry", {
+    from: deployer,
+    args: [
+      catalyst.address,
+      deployer, // is to to catalystRegistryAdmin later
+    ],
+    log: true,
+  });
 };
-module.exports.skip = guard(["1", "314159"]); // TODO
+module.exports.skip = guard(["1", "314159"]); // TODO enable for mainnet

--- a/src/CatalystRegistry.sol
+++ b/src/CatalystRegistry.sol
@@ -120,12 +120,7 @@ contract CatalystRegistry is Admin, CatalystValue {
     }
 
     // CONSTRUCTOR ////
-    constructor(
-        AssetToken asset,
-        CatalystValue catalystValue,
-        address admin
-    ) public {
-        _asset = asset;
+    constructor(CatalystValue catalystValue, address admin) public {
         _admin = admin;
         _catalystValue = catalystValue;
     }
@@ -139,7 +134,6 @@ contract CatalystRegistry is Admin, CatalystValue {
         uint64 set;
     }
     address internal _minter;
-    AssetToken internal immutable _asset;
     CatalystValue internal immutable _catalystValue;
     mapping(uint256 => CatalystStored) internal _catalysts;
 }


### PR DESCRIPTION
# Description

The Asset contract address was passed in the Catalyst Registry constructor but it is never used.
This PR removes it and update the deploy script to take that into consideration

# Checklist:

- [X] Pull Request applies to a single purpose
- [X] I've added comments to my code where needed
- [X] I've updated any relevant docs
- [X] I've added tests to show that my changes achieve the desired results
- [X] I've reviewed my code
- [X] I've followed established naming conventions and formatting
- [X] All tests are passing locally
