### PR TITLE
updates to starterpack price data

### DIFF
--- a/data/starterPack/index.js
+++ b/data/starterPack/index.js
@@ -5,4 +5,4 @@ function sandWei(amount) {
 }
 
 // sand price is in Sand unit (Sand has 18 decimals)
-module.exports.starterPackPrices = [sandWei(100), sandWei(200), sandWei(300), sandWei(1000)];
+module.exports.starterPackPrices = [sandWei(69), sandWei(208), sandWei(694), sandWei(2778)];

--- a/test/starter-pack/subTests/dai_tests.js
+++ b/test/starter-pack/subTests/dai_tests.js
@@ -316,7 +316,7 @@ function runDaiTests() {
         userWithDAI.StarterPack.purchaseWithDAI(userWithDAI.address, Message, dummySignature)
       );
       const eventsMatching = receipt.events.filter((event) => event.event === "Purchase");
-      const totalExpectedPrice = BigNumber.from(1600).mul("1000000000000000000");
+      const totalExpectedPrice = BigNumber.from(3749).mul("1000000000000000000");
       expect(eventsMatching[0].args[2]).to.equal(totalExpectedPrice);
 
       // fast-forward 1 hour. now buyer should pay the new price

--- a/test/starter-pack/subTests/ether_tests.js
+++ b/test/starter-pack/subTests/ether_tests.js
@@ -1,9 +1,7 @@
 const {setupStarterPack, supplyStarterPack} = require("./fixtures");
 const {assert, expect} = require("local-chai");
 const {waitFor, expectRevert, zeroAddress, increaseTime} = require("local-utils");
-const ethersForBigNumber = require("ethers");
-const {BigNumber} = ethersForBigNumber;
-const {ethers} = require("@nomiclabs/buidler");
+const {BigNumber} = require("ethers");
 const {findEvents} = require("../../../lib/findEvents.js");
 const {signPurchaseMessage} = require("../../../lib/purchaseMessageSigner");
 const {privateKey} = require("./_testHelper");

--- a/test/starter-pack/subTests/ether_tests.js
+++ b/test/starter-pack/subTests/ether_tests.js
@@ -1,8 +1,9 @@
 const {setupStarterPack, supplyStarterPack} = require("./fixtures");
 const {assert, expect} = require("local-chai");
 const {waitFor, expectRevert, zeroAddress, increaseTime} = require("local-utils");
-const ethers = require("ethers");
-const {BigNumber} = ethers;
+const ethersForBigNumber = require("ethers");
+const {BigNumber} = ethersForBigNumber;
+const {ethers} = require("@nomiclabs/buidler");
 const {findEvents} = require("../../../lib/findEvents.js");
 const {signPurchaseMessage} = require("../../../lib/purchaseMessageSigner");
 const {privateKey} = require("./_testHelper");
@@ -44,7 +45,7 @@ function runEtherTests() {
       const dummySignature = signPurchaseMessage(privateKey, Message);
       await expectRevert(
         users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature, {
-          value: BigNumber.from(2).mul("1000000000000000000"),
+          value: BigNumber.from(4).mul("1000000000000000000"),
         }),
         "can't substract more than there is"
       );
@@ -56,7 +57,9 @@ function runEtherTests() {
       const dummySignature = signPurchaseMessage(privateKey, Message);
       await starterPackContractAsAdmin.setETHEnabled(false);
       await expectRevert(
-        users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature, {value: 1000000}),
+        users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature, {
+          value: BigNumber.from(4).mul("1000000000000000000"),
+        }),
         "ETHER_IS_NOT_ENABLED"
       );
     });
@@ -110,7 +113,7 @@ function runEtherTests() {
 
       const receipt = await waitFor(
         users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature, {
-          value: BigNumber.from(2).mul("1000000000000000000"),
+          value: BigNumber.from(4).mul("1000000000000000000"),
         })
       );
       const eventsMatching = receipt.events.filter((event) => event.event === "Purchase");
@@ -268,7 +271,7 @@ function runEtherTests() {
       const nonceBeforePurchase = await starterPackContract.getNonceByBuyer(users[0].address, 0);
       expect(nonceBeforePurchase).to.equal(0);
       await users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature, {
-        value: BigNumber.from(2).mul("1000000000000000000"),
+        value: BigNumber.from(4).mul("1000000000000000000"),
       });
       const nonceAfterPurchase = await starterPackContract.getNonceByBuyer(users[0].address, 0);
       expect(nonceAfterPurchase).to.equal(1);
@@ -281,11 +284,11 @@ function runEtherTests() {
       const dummySignature = signPurchaseMessage(privateKey, Message);
 
       await users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature, {
-        value: BigNumber.from(2).mul("1000000000000000000"),
+        value: BigNumber.from(4).mul("1000000000000000000"),
       });
       await expectRevert(
         users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature, {
-          value: BigNumber.from(2).mul("1000000000000000000"),
+          value: BigNumber.from(4).mul("1000000000000000000"),
         }),
         "INVALID_NONCE"
       );
@@ -298,7 +301,7 @@ function runEtherTests() {
       let dummySignature = signPurchaseMessage(privateKey, Message);
 
       await users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature, {
-        value: BigNumber.from(2).mul("1000000000000000000"),
+        value: BigNumber.from(4).mul("1000000000000000000"),
       });
 
       Message.nonce++;
@@ -306,7 +309,7 @@ function runEtherTests() {
       dummySignature = signPurchaseMessage(privateKey, Message);
 
       await users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature, {
-        value: BigNumber.from(2).mul("1000000000000000000"),
+        value: BigNumber.from(4).mul("1000000000000000000"),
       });
     });
 
@@ -325,11 +328,11 @@ function runEtherTests() {
       // buyer should still pay the old price for 1 hour
       const receipt = await waitFor(
         users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature, {
-          value: BigNumber.from(2).mul("1000000000000000000"),
+          value: BigNumber.from(4).mul("1000000000000000000"),
         })
       );
       const eventsMatching = receipt.events.filter((event) => event.event === "Purchase");
-      const totalExpectedPrice = BigNumber.from(1600).mul("1000000000000000000");
+      const totalExpectedPrice = BigNumber.from(3749).mul("1000000000000000000");
       expect(eventsMatching[0].args[2]).to.equal(totalExpectedPrice);
 
       // fast-forward 1 hour. now buyer should pay the new price
@@ -338,7 +341,7 @@ function runEtherTests() {
       const dummySignature2 = signPurchaseMessage(privateKey, Message);
       const receipt2 = await waitFor(
         users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature2, {
-          value: BigNumber.from(2).mul("1000000000000000000"),
+          value: BigNumber.from(4).mul("1000000000000000000"),
         })
       );
       const eventsMatching2 = receipt2.events.filter((event) => event.event === "Purchase");
@@ -361,7 +364,7 @@ function runEtherTests() {
       const dummySignature = signPurchaseMessage(privateKey, Message);
 
       await users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature, {
-        value: BigNumber.from(2).mul("1000000000000000000"),
+        value: BigNumber.from(4).mul("1000000000000000000"),
       });
 
       await starterPackContractAsAdmin.withdrawAll(starterPackAdmin, [0, 1, 2, 3], [0, 1, 2, 3, 4]);
@@ -417,7 +420,7 @@ function runEtherTests() {
       const dummySignature = signPurchaseMessage(privateKey, Message);
 
       await users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature, {
-        value: BigNumber.from(2).mul("1000000000000000000"),
+        value: BigNumber.from(4).mul("1000000000000000000"),
       });
 
       await expectRevert(

--- a/test/starter-pack/subTests/sand_tests.js
+++ b/test/starter-pack/subTests/sand_tests.js
@@ -316,7 +316,7 @@ function runSandTests() {
         userWithSAND.StarterPack.purchaseWithSand(userWithSAND.address, Message, dummySignature)
       );
       const eventsMatching = receipt.events.filter((event) => event.event === "Purchase");
-      const totalExpectedPrice = BigNumber.from(1600).mul("1000000000000000000");
+      const totalExpectedPrice = BigNumber.from(3749).mul("1000000000000000000");
       expect(eventsMatching[0].args[2]).to.equal(totalExpectedPrice);
 
       // fast-forward 1 hour. now buyer should pay the new price


### PR DESCRIPTION
StarterPack prices have been updated to reflect info provided today by @wighawag 
- StarterPack price data has been updated
- StarterPack purchaseWithETH tests have been updated to use a higher value
- Tests showing initial total value have been updated

# Checklist:

- [x] Pull Request applies to a single purpose
- [ ] I've added comments to my code where needed
- [ ] I've updated any relevant docs
- [ ] I've added tests to show that my changes achieve the desired results
- [x] I've reviewed my code
- [x] I've followed established naming conventions and formatting
- [x] All tests are passing locally
