### PR TITLE
fix catalyst seed issue

### DIFF
--- a/src/CatalystRegistry.sol
+++ b/src/CatalystRegistry.sol
@@ -35,7 +35,7 @@ contract CatalystRegistry is Admin, CatalystValue {
         uint256 index = gemIds.length;
         _catalysts[assetId] = CatalystStored(uint64(emptySockets), uint64(index), uint64(catalystId), 1);
         uint64 blockNumber = _getBlockNumber();
-        emit CatalystApplied(assetId, catalystId, _getSeed(assetId), gemIds, blockNumber);
+        emit CatalystApplied(assetId, catalystId, assetId, gemIds, blockNumber);
     }
 
     function addGems(uint256 assetId, uint256[] calldata gemIds) external {
@@ -82,13 +82,6 @@ contract CatalystRegistry is Admin, CatalystValue {
     uint256 private constant NOT_IS_NFT = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF7FFFFFFFFFFFFFFFFFFFFFFF;
     uint256 private constant NOT_NFT_INDEX = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF800000007FFFFFFFFFFFFFFF;
 
-    function _getSeed(uint256 assetId) internal pure returns (uint256) {
-        if (assetId & IS_NFT != 0) {
-            return _getCollectionId(assetId);
-        }
-        return assetId;
-    }
-
     function _getSocketData(uint256 assetId)
         internal
         view
@@ -101,8 +94,11 @@ contract CatalystRegistry is Admin, CatalystValue {
         seed = assetId;
         CatalystStored memory catalyst = _catalysts[assetId];
         if (catalyst.set != 0) {
+            // the gems are added to an asset who already get a specific catalyst.
+            // the seed is its id
             return (catalyst.emptySockets, catalyst.index, seed);
         }
+        // else the asset is only adding gems while keeping the sane seed (that of the original assetId)
         if (assetId & IS_NFT != 0) {
             seed = _getCollectionId(assetId);
             catalyst = _catalysts[seed];

--- a/test/catalyst/fixtures.js
+++ b/test/catalyst/fixtures.js
@@ -111,10 +111,18 @@ module.exports.setupCatalystSystem = deployments.createFixture(async (bre, optio
         const events = await findEvents(asset, "Transfer", receipt.blockHash);
         return {tokenId: events[0].args[2], receipt};
       },
+      changeCatalyst: async (tokenId, {catalyst, gemIds, to}) => {
+        const receipt = await waitFor(CatalystMinter.changeCatalyst(other, tokenId, catalyst, gemIds, to || other));
+        return {receipt};
+      },
       extractAndAddGems: async (tokenId, {newGemIds, to}) => {
         const receipt = await waitFor(CatalystMinter.extractAndAddGems(other, tokenId, newGemIds, to || other));
         const events = await findEvents(asset, "Transfer", receipt.blockHash);
         return {tokenId: events[0].args[2], receipt};
+      },
+      addGems: async (tokenId, {newGemIds, to}) => {
+        const receipt = await waitFor(CatalystMinter.addGems(other, tokenId, newGemIds, to || other));
+        return {receipt};
       },
       extractAsset: async (tokenId, to) => {
         const receipt = await waitFor(Asset.extractERC721(tokenId, to || other));


### PR DESCRIPTION
# Description

This PR fixes the issue where GemsAdded event would emit a different seed than the previous CatalystApplied event 
It adds test to ensure the event return the same seed.

The rules are as follow:

CatalystApplied events will always emit a seed equal to the corresponding assetId, so after extraction, the CatalystApplied event will not have the same seed as the original asset

GemsAdded events will emit the same seed as the latest CatalystApplied event for that assetId

The only special case is when GemsAdded is emitted after the original CatalystApplied event since in that case the seed is not equal to the assetId whose Gems are associated with. Instead the seed is the same as the original asset.
This is to ensure previous gems can reuse the same seed to preserve old values


# Checklist:

- [X] Pull Request applies to a single purpose
- [X] I've added comments to my code where needed
- [ ] I've updated any relevant docs
- [X] I've added tests to show that my changes achieve the desired results
- [X] I've reviewed my code
- [X] I've followed established naming conventions and formatting
- [X] All tests are passing locally
