### PR TITLE
add buyer back in signed message

### DIFF
--- a/lib/purchaseMessageSigner.js
+++ b/lib/purchaseMessageSigner.js
@@ -2,10 +2,10 @@ const ethers = require("ethers");
 const {Wallet} = ethers;
 const {solidityKeccak256, arrayify} = ethers.utils;
 
-function signPurchaseMessage(privateKey, message) {
+function signPurchaseMessage(privateKey, message, buyer) {
   const hashedData = solidityKeccak256(
-    ["uint256[]", "uint256[]", "uint256[]", "uint256[]", "uint256"],
-    [message.catalystIds, message.catalystQuantities, message.gemIds, message.gemQuantities, message.nonce]
+    ["uint256[]", "uint256[]", "uint256[]", "uint256[]", "address", "uint256"],
+    [message.catalystIds, message.catalystQuantities, message.gemIds, message.gemQuantities, buyer, message.nonce]
   );
   const wallet = new Wallet(privateKey);
   return wallet.signMessage(arrayify(hashedData));

--- a/src/StarterPack/PurchaseValidator.sol
+++ b/src/StarterPack/PurchaseValidator.sol
@@ -41,7 +41,7 @@ contract PurchaseValidator is Admin {
     ) public returns (bool) {
         require(_checkAndUpdateNonce(buyer, nonce), "INVALID_NONCE");
         require(_validateGemAmounts(catalystIds, catalystQuantities, gemQuantities), "INVALID_GEMS");
-        bytes32 hashedData = keccak256(abi.encodePacked(catalystIds, catalystQuantities, gemIds, gemQuantities, nonce));
+        bytes32 hashedData = keccak256(abi.encodePacked(catalystIds, catalystQuantities, gemIds, gemQuantities, buyer, nonce));
 
         address signer = SigUtil.recover(keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", hashedData)), signature);
         return signer == _signingWallet;

--- a/test/starter-pack/subTests/dai_tests.js
+++ b/test/starter-pack/subTests/dai_tests.js
@@ -30,7 +30,7 @@ function runDaiTests() {
     it("should revert if the user does not have enough DAI", async function () {
       const {userWithoutDAI, daiContract} = setUp;
       const balance = await daiContract.balanceOf(userWithoutDAI.address);
-      const dummySignature = signPurchaseMessage(privateKey, Message);
+      const dummySignature = signPurchaseMessage(privateKey, Message, userWithoutDAI.address);
       assert.ok(balance.eq(BigNumber.from(0)));
       await expectRevert(
         userWithoutDAI.StarterPack.purchaseWithDAI(userWithoutDAI.address, Message, dummySignature),
@@ -40,7 +40,7 @@ function runDaiTests() {
 
     it("purchase should revert if StarterpackV1.sol does not own any Catalysts & Gems", async function () {
       const {userWithDAI} = setUp;
-      const dummySignature = signPurchaseMessage(privateKey, Message);
+      const dummySignature = signPurchaseMessage(privateKey, Message, userWithDAI.address);
       await expectRevert(
         userWithDAI.StarterPack.purchaseWithDAI(userWithDAI.address, Message, dummySignature),
         "can't substract more than there is"
@@ -49,7 +49,7 @@ function runDaiTests() {
 
     it("should throw if DAI is not enabled", async function () {
       const {userWithDAI, starterPackContractAsAdmin} = setUp;
-      const dummySignature = signPurchaseMessage(privateKey, Message);
+      const dummySignature = signPurchaseMessage(privateKey, Message, userWithDAI.address);
       await starterPackContractAsAdmin.setDAIEnabled(false);
       await expectRevert(
         userWithDAI.StarterPack.purchaseWithDAI(userWithDAI.address, Message, dummySignature),
@@ -65,7 +65,7 @@ function runDaiTests() {
 
     it("should revert if msg sender is not from or metaTX contract: DAI", async function () {
       const {userWithDAI, userWithoutDAI} = setUp;
-      const dummySignature = signPurchaseMessage(privateKey, Message);
+      const dummySignature = signPurchaseMessage(privateKey, Message, userWithDAI.address);
       await expectRevert(
         userWithoutDAI.StarterPack.purchaseWithSand(userWithDAI.address, Message, dummySignature),
         "INVALID_SENDER"
@@ -110,7 +110,7 @@ function runDaiTests() {
         daiContract,
       } = await setUp;
 
-      const dummySignature = signPurchaseMessage(privateKey, Message);
+      const dummySignature = signPurchaseMessage(privateKey, Message, userWithDAI.address);
 
       const receipt = await waitFor(
         userWithDAI.StarterPack.purchaseWithDAI(userWithDAI.address, Message, dummySignature)
@@ -262,7 +262,7 @@ function runDaiTests() {
     it("purchase should invalidate the nonce after 1 use", async function () {
       const {userWithDAI, starterPackContract} = await setUp;
 
-      const dummySignature = signPurchaseMessage(privateKey, Message);
+      const dummySignature = signPurchaseMessage(privateKey, Message, userWithDAI.address);
       const nonceBeforePurchase = await starterPackContract.getNonceByBuyer(userWithDAI.address, 0);
       expect(nonceBeforePurchase).to.equal(0);
       await userWithDAI.StarterPack.purchaseWithDAI(userWithDAI.address, Message, dummySignature);
@@ -273,7 +273,7 @@ function runDaiTests() {
     it("purchase should fail if the nonce is reused", async function () {
       const {userWithDAI} = await setUp;
 
-      const dummySignature = signPurchaseMessage(privateKey, Message);
+      const dummySignature = signPurchaseMessage(privateKey, Message, userWithDAI.address);
 
       await userWithDAI.StarterPack.purchaseWithDAI(userWithDAI.address, Message, dummySignature);
       await expectRevert(
@@ -285,20 +285,20 @@ function runDaiTests() {
     it("sequential purchases should succeed with new nonce (as long as there are enough catalysts and gems)", async function () {
       const {userWithDAI} = await setUp;
 
-      let dummySignature = signPurchaseMessage(privateKey, Message);
+      let dummySignature = signPurchaseMessage(privateKey, Message, userWithDAI.address);
 
       await userWithDAI.StarterPack.purchaseWithDAI(userWithDAI.address, Message, dummySignature);
 
       Message.nonce++;
 
-      dummySignature = signPurchaseMessage(privateKey, Message);
+      dummySignature = signPurchaseMessage(privateKey, Message, userWithDAI.address);
 
       await userWithDAI.StarterPack.purchaseWithDAI(userWithDAI.address, Message, dummySignature);
     });
 
     it("price change should be implemented after a delay", async function () {
       const {starterPackContractAsAdmin, userWithDAI} = setUp;
-      const dummySignature = signPurchaseMessage(privateKey, Message);
+      const dummySignature = signPurchaseMessage(privateKey, Message, userWithDAI.address);
       await starterPackContractAsAdmin.setDAIEnabled(true);
       const newPrices = [
         BigNumber.from(300).mul("1000000000000000000"),
@@ -318,7 +318,7 @@ function runDaiTests() {
       // fast-forward 1 hour. now buyer should pay the new price
       await increaseTime(60 * 60);
       Message.nonce++;
-      const dummySignature2 = signPurchaseMessage(privateKey, Message);
+      const dummySignature2 = signPurchaseMessage(privateKey, Message, userWithDAI.address);
       const receipt2 = await waitFor(
         userWithDAI.StarterPack.purchaseWithDAI(userWithDAI.address, Message, dummySignature2)
       );
@@ -337,7 +337,7 @@ function runDaiTests() {
         starterPackContract,
       } = setUp;
 
-      const dummySignature = signPurchaseMessage(privateKey, Message);
+      const dummySignature = signPurchaseMessage(privateKey, Message, userWithDAI.address);
 
       await userWithDAI.StarterPack.purchaseWithDAI(userWithDAI.address, Message, dummySignature);
 
@@ -389,7 +389,7 @@ function runDaiTests() {
     it("cannot withdrawAll after purchase if not admin", async function () {
       const {users, userWithDAI} = setUp;
 
-      const dummySignature = signPurchaseMessage(privateKey, Message);
+      const dummySignature = signPurchaseMessage(privateKey, Message, userWithDAI.address);
 
       await userWithDAI.StarterPack.purchaseWithDAI(userWithDAI.address, Message, dummySignature);
 

--- a/test/starter-pack/subTests/ether_tests.js
+++ b/test/starter-pack/subTests/ether_tests.js
@@ -28,7 +28,7 @@ function runEtherTests() {
 
     it("should revert if the user does not have enough ETH", async function () {
       const {users} = setUp;
-      const dummySignature = signPurchaseMessage(privateKey, Message);
+      const dummySignature = signPurchaseMessage(privateKey, Message, users[0].address);
       await expectRevert(
         users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature, {value: 0}),
         "NOT_ENOUGH_ETHER_SENT"
@@ -37,7 +37,7 @@ function runEtherTests() {
 
     it("purchase should revert if StarterpackV1.sol does not own any Catalysts & Gems", async function () {
       const {users} = setUp;
-      const dummySignature = signPurchaseMessage(privateKey, Message);
+      const dummySignature = signPurchaseMessage(privateKey, Message, users[0].address);
       await expectRevert(
         users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature, {
           value: BigNumber.from(4).mul("1000000000000000000"),
@@ -48,7 +48,7 @@ function runEtherTests() {
 
     it("should throw if ETH is not enabled", async function () {
       const {users, starterPackContractAsAdmin} = setUp;
-      const dummySignature = signPurchaseMessage(privateKey, Message);
+      const dummySignature = signPurchaseMessage(privateKey, Message, users[0].address);
       await starterPackContractAsAdmin.setETHEnabled(false);
       await expectRevert(
         users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature, {
@@ -66,7 +66,7 @@ function runEtherTests() {
 
     it("should revert if msg sender is not from or metaTX contract: ETH", async function () {
       const {users} = setUp;
-      const dummySignature = signPurchaseMessage(privateKey, Message);
+      const dummySignature = signPurchaseMessage(privateKey, Message, users[0].address);
       await expectRevert(
         users[1].StarterPack.purchaseWithSand(users[0].address, Message, dummySignature),
         "INVALID_SENDER"
@@ -110,7 +110,7 @@ function runEtherTests() {
         starterPackContract,
       } = await setUp;
 
-      const dummySignature = signPurchaseMessage(privateKey, Message);
+      const dummySignature = signPurchaseMessage(privateKey, Message, users[0].address);
 
       const receipt = await waitFor(
         users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature, {
@@ -264,7 +264,7 @@ function runEtherTests() {
     it("purchase should invalidate the nonce after 1 use", async function () {
       const {users, starterPackContract} = await setUp;
 
-      const dummySignature = signPurchaseMessage(privateKey, Message);
+      const dummySignature = signPurchaseMessage(privateKey, Message, users[0].address);
       const nonceBeforePurchase = await starterPackContract.getNonceByBuyer(users[0].address, 0);
       expect(nonceBeforePurchase).to.equal(0);
       await users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature, {
@@ -277,7 +277,7 @@ function runEtherTests() {
     it("purchase should fail if the nonce is reused", async function () {
       const {users} = await setUp;
 
-      const dummySignature = signPurchaseMessage(privateKey, Message);
+      const dummySignature = signPurchaseMessage(privateKey, Message, users[0].address);
 
       await users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature, {
         value: BigNumber.from(4).mul("1000000000000000000"),
@@ -293,7 +293,7 @@ function runEtherTests() {
     it("sequential purchases should succeed with new nonce (as long as there are enough catalysts and gems)", async function () {
       const {users} = await setUp;
 
-      let dummySignature = signPurchaseMessage(privateKey, Message);
+      let dummySignature = signPurchaseMessage(privateKey, Message, users[0].address);
 
       await users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature, {
         value: BigNumber.from(4).mul("1000000000000000000"),
@@ -301,7 +301,7 @@ function runEtherTests() {
 
       Message.nonce++;
 
-      dummySignature = signPurchaseMessage(privateKey, Message);
+      dummySignature = signPurchaseMessage(privateKey, Message, users[0].address);
 
       await users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature, {
         value: BigNumber.from(4).mul("1000000000000000000"),
@@ -310,7 +310,7 @@ function runEtherTests() {
 
     it("price change should be implemented after a delay", async function () {
       const {starterPackContractAsAdmin, users} = setUp;
-      const dummySignature = signPurchaseMessage(privateKey, Message);
+      const dummySignature = signPurchaseMessage(privateKey, Message, users[0].address);
       await starterPackContractAsAdmin.setETHEnabled(true);
       const newPrices = [
         BigNumber.from(300).mul("1000000000000000000"),
@@ -332,7 +332,7 @@ function runEtherTests() {
       // fast-forward 1 hour. now buyer should pay the new price
       await increaseTime(60 * 60);
       Message.nonce++;
-      const dummySignature2 = signPurchaseMessage(privateKey, Message);
+      const dummySignature2 = signPurchaseMessage(privateKey, Message, users[0].address);
       const receipt2 = await waitFor(
         users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature2, {
           value: BigNumber.from(4).mul("1000000000000000000"),
@@ -353,7 +353,7 @@ function runEtherTests() {
         starterPackContract,
       } = setUp;
 
-      const dummySignature = signPurchaseMessage(privateKey, Message);
+      const dummySignature = signPurchaseMessage(privateKey, Message, users[0].address);
 
       await users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature, {
         value: BigNumber.from(4).mul("1000000000000000000"),
@@ -407,7 +407,7 @@ function runEtherTests() {
     it("cannot withdrawAll after purchase if not admin", async function () {
       const {users} = setUp;
 
-      const dummySignature = signPurchaseMessage(privateKey, Message);
+      const dummySignature = signPurchaseMessage(privateKey, Message, users[0].address);
 
       await users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature, {
         value: BigNumber.from(4).mul("1000000000000000000"),

--- a/test/starter-pack/subTests/sand_tests.js
+++ b/test/starter-pack/subTests/sand_tests.js
@@ -29,7 +29,7 @@ function runSandTests() {
 
     it("should revert if the user does not have enough SAND", async function () {
       const {userWithoutSAND, sandContract} = setUp;
-      const dummySignature = signPurchaseMessage(privateKey, Message);
+      const dummySignature = signPurchaseMessage(privateKey, Message, userWithoutSAND.address);
       const balance = await sandContract.balanceOf(userWithoutSAND.address);
       assert.ok(balance.eq(BigNumber.from(0)));
       await expectRevert(
@@ -40,7 +40,7 @@ function runSandTests() {
 
     it("purchase should revert if StarterpackV1.sol does not own any Catalysts & Gems", async function () {
       const {userWithSAND} = setUp;
-      const dummySignature = signPurchaseMessage(privateKey, Message);
+      const dummySignature = signPurchaseMessage(privateKey, Message, userWithSAND.address);
       await expectRevert(
         userWithSAND.StarterPack.purchaseWithSand(userWithSAND.address, Message, dummySignature),
         "can't substract more than there is"
@@ -49,7 +49,7 @@ function runSandTests() {
 
     it("should throw if SAND is not enabled", async function () {
       const {userWithSAND, starterPackContractAsAdmin} = setUp;
-      const dummySignature = signPurchaseMessage(privateKey, Message);
+      const dummySignature = signPurchaseMessage(privateKey, Message, userWithSAND.address);
       await starterPackContractAsAdmin.setSANDEnabled(false);
       await expectRevert(
         userWithSAND.StarterPack.purchaseWithSand(userWithSAND.address, Message, dummySignature),
@@ -65,7 +65,7 @@ function runSandTests() {
 
     it("should revert if msg sender is not from or metaTX contract: SAND", async function () {
       const {userWithSAND, userWithoutSAND} = setUp;
-      const dummySignature = signPurchaseMessage(privateKey, Message);
+      const dummySignature = signPurchaseMessage(privateKey, Message, userWithoutSAND.address);
       await expectRevert(
         userWithoutSAND.StarterPack.purchaseWithSand(userWithSAND.address, Message, dummySignature),
         "INVALID_SENDER"
@@ -110,7 +110,7 @@ function runSandTests() {
         sandContract,
       } = await setUp;
 
-      const dummySignature = signPurchaseMessage(privateKey, Message);
+      const dummySignature = signPurchaseMessage(privateKey, Message, userWithSAND.address);
 
       const receipt = await waitFor(
         userWithSAND.StarterPack.purchaseWithSand(userWithSAND.address, Message, dummySignature)
@@ -262,7 +262,7 @@ function runSandTests() {
     it("purchase should invalidate the nonce after 1 use", async function () {
       const {userWithSAND, starterPackContract} = await setUp;
 
-      const dummySignature = signPurchaseMessage(privateKey, Message);
+      const dummySignature = signPurchaseMessage(privateKey, Message, userWithSAND.address);
       const nonceBeforePurchase = await starterPackContract.getNonceByBuyer(userWithSAND.address, 0);
       expect(nonceBeforePurchase).to.equal(0);
       await userWithSAND.StarterPack.purchaseWithSand(userWithSAND.address, Message, dummySignature);
@@ -273,7 +273,7 @@ function runSandTests() {
     it("purchase should fail if the nonce is reused", async function () {
       const {userWithSAND} = await setUp;
 
-      const dummySignature = signPurchaseMessage(privateKey, Message);
+      const dummySignature = signPurchaseMessage(privateKey, Message, userWithSAND.address);
 
       await userWithSAND.StarterPack.purchaseWithSand(userWithSAND.address, Message, dummySignature);
       await expectRevert(
@@ -285,20 +285,20 @@ function runSandTests() {
     it("sequential purchases should succeed with new nonce (as long as there are enough catalysts and gems)", async function () {
       const {userWithSAND} = await setUp;
 
-      let dummySignature = signPurchaseMessage(privateKey, Message);
+      let dummySignature = signPurchaseMessage(privateKey, Message, userWithSAND.address);
 
       await userWithSAND.StarterPack.purchaseWithSand(userWithSAND.address, Message, dummySignature);
 
       Message.nonce++;
 
-      dummySignature = signPurchaseMessage(privateKey, Message);
+      dummySignature = signPurchaseMessage(privateKey, Message, userWithSAND.address);
 
       await userWithSAND.StarterPack.purchaseWithSand(userWithSAND.address, Message, dummySignature);
     });
 
     it("price change should be implemented after a delay", async function () {
       const {starterPackContractAsAdmin, userWithSAND} = setUp;
-      const dummySignature = signPurchaseMessage(privateKey, Message);
+      const dummySignature = signPurchaseMessage(privateKey, Message, userWithSAND.address);
       await starterPackContractAsAdmin.setSANDEnabled(true);
       const newPrices = [
         BigNumber.from(300).mul("1000000000000000000"),
@@ -318,7 +318,7 @@ function runSandTests() {
       // fast-forward 1 hour. now buyer should pay the new price
       await increaseTime(60 * 60);
       Message.nonce++;
-      const dummySignature2 = signPurchaseMessage(privateKey, Message);
+      const dummySignature2 = signPurchaseMessage(privateKey, Message, userWithSAND.address);
       const receipt2 = await waitFor(
         userWithSAND.StarterPack.purchaseWithSand(userWithSAND.address, Message, dummySignature2)
       );
@@ -337,7 +337,7 @@ function runSandTests() {
         starterPackContract,
       } = setUp;
 
-      const dummySignature = signPurchaseMessage(privateKey, Message);
+      const dummySignature = signPurchaseMessage(privateKey, Message, userWithSAND.address);
 
       await userWithSAND.StarterPack.purchaseWithSand(userWithSAND.address, Message, dummySignature);
 
@@ -389,7 +389,7 @@ function runSandTests() {
     it("cannot withdrawAll after purchase if not admin", async function () {
       const {users, userWithSAND} = setUp;
 
-      const dummySignature = signPurchaseMessage(privateKey, Message);
+      const dummySignature = signPurchaseMessage(privateKey, Message, userWithSAND.address);
 
       await userWithSAND.StarterPack.purchaseWithSand(userWithSAND.address, Message, dummySignature);
 

--- a/test/starter-pack/testPurchaseValidator.js
+++ b/test/starter-pack/testPurchaseValidator.js
@@ -28,7 +28,7 @@ describe("PurchaseValidator", function () {
   describe("Validation", function () {
     it("Purchase validator function exists", async function () {
       Message.buyer = roles.others[1];
-      const dummySignature = signPurchaseMessage(privateKey, Message);
+      const dummySignature = signPurchaseMessage(privateKey, Message, buyer);
       assert.ok(
         await starterPack.isPurchaseValid(
           buyer,
@@ -45,7 +45,7 @@ describe("PurchaseValidator", function () {
     it("the order of catalystIds should't matter", async function () {
       Message.catalystIds = [2, 3, 0, 1];
       Message.gemQuantities = [0, 0, 1, 1, 0];
-      const dummySignature = signPurchaseMessage(privateKey, Message);
+      const dummySignature = signPurchaseMessage(privateKey, Message, buyer);
       assert.ok(
         await starterPack.isPurchaseValid(
           buyer,
@@ -99,7 +99,7 @@ describe("PurchaseValidator", function () {
   describe("Failures", function () {
     it("should fail if the nonce is re-used", async function () {
       ({starterPackContract: starterPack} = await setupStarterPack());
-      const dummySignature = signPurchaseMessage(privateKey, Message);
+      const dummySignature = signPurchaseMessage(privateKey, Message, buyer);
       assert.ok(
         await starterPack.isPurchaseValid(
           buyer,
@@ -131,7 +131,7 @@ describe("PurchaseValidator", function () {
       Message.catalystQuantities = [1, 1, 1, 1];
       // total gems allowed is max 10
       Message.gemQuantities = [3, 2, 4, 2, 3];
-      const dummySignature = signPurchaseMessage(privateKey, Message);
+      const dummySignature = signPurchaseMessage(privateKey, Message, buyer);
       await expectRevert(
         starterPack.isPurchaseValid(
           buyer,


### PR DESCRIPTION
# Description

add the buyer paramerer back in the signed message to ensure it cannot be replayed by other user

# Checklist:

- [X] Pull Request applies to a single purpose
- [ ] I've added comments to my code where needed
- [ ] I've updated any relevant docs
- [ ] I've added tests to show that my changes achieve the desired results
- [X] I've reviewed my code
- [ ] I've followed established naming conventions and formatting
- [X] All tests are passing locally
