### PR TITLE
SAND multiplier in EstateSaleWithFee.sol

### DIFF
--- a/src/EstateSale/EstateSaleWithFee.sol
+++ b/src/EstateSale/EstateSaleWithFee.sol
@@ -27,9 +27,18 @@ contract EstateSaleWithFee is MetaTransactionReceiver, ReferralValidator {
     /// @notice set the wallet receiving the proceeds
     /// @param newWallet address of the new receiving wallet
     function setReceivingWallet(address payable newWallet) external {
-        require(newWallet != address(0), "receiving wallet cannot be zero address");
-        require(msg.sender == _admin, "only admin can change the receiving wallet");
+        require(newWallet != address(0), "ZERO_ADDRESS");
+        require(msg.sender == _admin, "NOT_AUTHORIZED");
         _wallet = newWallet;
+    }
+
+    function rebalanceSand(uint256 newMultiplier) external {
+        require(msg.sender == _admin, "NOT_AUTHORIZED");
+        _multiplier = newMultiplier;
+    }
+
+    function getSandMultiplier() external view returns (uint256) {
+        return _multiplier;
     }
 
     /// @notice buy Land with SAND using the merkle proof associated with it
@@ -49,14 +58,15 @@ contract EstateSaleWithFee is MetaTransactionReceiver, ReferralValidator {
         uint256 y,
         uint256 size,
         uint256 priceInSand,
+        uint256 adjustedPriceInSand,
         bytes32 salt,
         uint256[] calldata assetIds,
         bytes32[] calldata proof,
         bytes calldata referral
     ) external {
         _checkValidity(buyer, reserved, x, y, size, priceInSand, salt, assetIds, proof);
-        _handleFeeAndReferral(buyer, priceInSand, referral);
-        _mint(buyer, to, x, y, size, priceInSand, address(_sand), priceInSand);
+        _handleFeeAndReferral(buyer, adjustedPriceInSand, referral);
+        _mint(buyer, to, x, y, size, adjustedPriceInSand, address(_sand), adjustedPriceInSand);
         _sendAssets(to, assetIds);
     }
 
@@ -126,12 +136,12 @@ contract EstateSaleWithFee is MetaTransactionReceiver, ReferralValidator {
         bytes32[] memory proof
     ) internal view {
         /* solium-disable-next-line security/no-block-members */
-        require(block.timestamp < _expiryTime, "sale is over");
-        require(buyer == msg.sender || _metaTransactionContracts[msg.sender], "not authorized");
-        require(reserved == address(0) || reserved == buyer, "cannot buy reserved Land");
+        require(block.timestamp < _expiryTime, "SALE_IS_OVER");
+        require(buyer == msg.sender || _metaTransactionContracts[msg.sender], "NOT_AUTHORIZED");
+        require(reserved == address(0) || reserved == buyer, "RESERVED_LAND");
         bytes32 leaf = _generateLandHash(x, y, size, price, reserved, salt, assetIds);
 
-        require(_verify(proof, leaf), "Invalid land provided");
+        require(_verify(proof, leaf), "INVALID_LAND");
     }
 
     function _mint(
@@ -211,6 +221,8 @@ contract EstateSaleWithFee is MetaTransactionReceiver, ReferralValidator {
     bytes32 internal immutable _merkleRoot;
 
     uint256 private constant FEE = 5; // percentage of land sale price to be diverted to a specially configured instance of FeeDistributor, shown as an integer
+
+    uint256 private _multiplier = 1000; // multiplier used for rebalancing SAND values, 3 decimal places
 
     constructor(
         address landAddress,

--- a/src/EstateSale/EstateSaleWithFee.sol
+++ b/src/EstateSale/EstateSaleWithFee.sol
@@ -64,6 +64,7 @@ contract EstateSaleWithFee is MetaTransactionReceiver, ReferralValidator {
         bytes32[] calldata proof,
         bytes calldata referral
     ) external {
+        _checkPrices(priceInSand, adjustedPriceInSand);
         _checkValidity(buyer, reserved, x, y, size, priceInSand, salt, assetIds, proof);
         _handleFeeAndReferral(buyer, adjustedPriceInSand, referral);
         _mint(buyer, to, x, y, size, adjustedPriceInSand, address(_sand), adjustedPriceInSand);
@@ -122,6 +123,13 @@ contract EstateSaleWithFee is MetaTransactionReceiver, ReferralValidator {
             values[i] = 1;
         }
         _asset.safeBatchTransferFrom(address(this), to, assetIds, values, "");
+    }
+
+    function _checkPrices(
+        uint256 priceInSand,
+        uint256 adjustedPriceInSand
+    ) internal {
+        require(adjustedPriceInSand == priceInSand.mul(_multiplier).div(MULTIPLIER_DECIMALS), "INVALID_PRICE");
     }
 
     function _checkValidity(
@@ -223,6 +231,7 @@ contract EstateSaleWithFee is MetaTransactionReceiver, ReferralValidator {
     uint256 private constant FEE = 5; // percentage of land sale price to be diverted to a specially configured instance of FeeDistributor, shown as an integer
 
     uint256 private _multiplier = 1000; // multiplier used for rebalancing SAND values, 3 decimal places
+    uint256 private constant MULTIPLIER_DECIMALS = 1000;
 
     constructor(
         address landAddress,

--- a/src/EstateSale/EstateSaleWithFee.sol
+++ b/src/EstateSale/EstateSaleWithFee.sol
@@ -125,10 +125,7 @@ contract EstateSaleWithFee is MetaTransactionReceiver, ReferralValidator {
         _asset.safeBatchTransferFrom(address(this), to, assetIds, values, "");
     }
 
-    function _checkPrices(
-        uint256 priceInSand,
-        uint256 adjustedPriceInSand
-    ) internal {
+    function _checkPrices(uint256 priceInSand, uint256 adjustedPriceInSand) internal {
         require(adjustedPriceInSand == priceInSand.mul(_multiplier).div(MULTIPLIER_DECIMALS), "INVALID_PRICE");
     }
 

--- a/test/estate/fixtures.js
+++ b/test/estate/fixtures.js
@@ -3,7 +3,6 @@ const {BigNumber} = require("ethers");
 const EstateTestHelper = require("./_testHelper");
 const MerkleTree = require("../../lib/merkleTree");
 const {createDataArray, calculateLandHash} = require("../../lib/merkleTreeHelper");
-const {BigNumber} = require("ethers");
 
 module.exports.setupEstate = deployments.createFixture(async () => {
   const namedAccounts = await getNamedAccounts();
@@ -56,11 +55,6 @@ module.exports.setupEstateSale = deployments.createFixture(async () => {
   const lands = landSaleDeployment.linkedData;
   const landHashArray = createDataArray(lands);
   const merkleTree = new MerkleTree(landHashArray);
-
-  await sandContract.connect(sandContract.provider.getSigner(sandAdmin)).setSuperOperator(saleContract.address, true);
-  await sandContract
-    .connect(sandContract.provider.getSigner(sandAdmin))
-    .transfer(user0, BigNumber.from("1000000000000000000000000"));
 
   return {
     estateContract,

--- a/test/estate/fixtures.js
+++ b/test/estate/fixtures.js
@@ -1,4 +1,5 @@
 const {ethers, deployments, getNamedAccounts} = require("@nomiclabs/buidler");
+const {BigNumber} = require("ethers");
 const EstateTestHelper = require("./_testHelper");
 const MerkleTree = require("../../lib/merkleTree");
 const {createDataArray, calculateLandHash} = require("../../lib/merkleTreeHelper");
@@ -55,6 +56,11 @@ module.exports.setupEstateSale = deployments.createFixture(async () => {
   const lands = landSaleDeployment.linkedData;
   const landHashArray = createDataArray(lands);
   const merkleTree = new MerkleTree(landHashArray);
+
+  await sandContract.connect(sandContract.provider.getSigner(sandAdmin)).setSuperOperator(saleContract.address, true);
+  await sandContract
+    .connect(sandContract.provider.getSigner(sandAdmin))
+    .transfer(user0, BigNumber.from("1000000000000000000000000"));
 
   return {
     estateContract,

--- a/test/estate/fixtures.js
+++ b/test/estate/fixtures.js
@@ -1,8 +1,8 @@
 const {ethers, deployments, getNamedAccounts} = require("@nomiclabs/buidler");
-const {BigNumber} = require("ethers");
 const EstateTestHelper = require("./_testHelper");
 const MerkleTree = require("../../lib/merkleTree");
 const {createDataArray, calculateLandHash} = require("../../lib/merkleTreeHelper");
+const {BigNumber} = require("ethers");
 
 module.exports.setupEstate = deployments.createFixture(async () => {
   const namedAccounts = await getNamedAccounts();

--- a/test/estate/testSales.js
+++ b/test/estate/testSales.js
@@ -31,6 +31,7 @@ describe("Estate:Sales", function () {
         y,
         size,
         sandPrice,
+        sandPrice,
         salt,
         [],
         proof,

--- a/test/estateSale/subTests/common_tests.js
+++ b/test/estateSale/subTests/common_tests.js
@@ -1,4 +1,5 @@
-const {assert} = require("local-chai");
+const {assert, expect} = require("local-chai");
+const {expectRevert} = require("local-utils");
 const {setupEstateSale} = require("./fixtures");
 const {calculateLandHash} = require("../../../lib/merkleTreeHelper");
 
@@ -25,6 +26,24 @@ function runCommonTests(landSaleName) {
           ),
         "Leaf not found"
       );
+    });
+
+    it("admin can set a SAND price multiplier", async function () {
+      const {SandAdmin, users} = await setupEstateSale(landSaleName, "lands");
+      await SandAdmin.EstateSale.rebalanceSand("1432");
+      const result = await users[0].EstateSale.getSandMultiplier();
+      expect(result).to.equal("1432");
+    });
+
+    it("CANNOT set a SAND price multiplier if not admin", async function () {
+      const {users} = await setupEstateSale(landSaleName, "lands");
+      await expectRevert(users[0].EstateSale.rebalanceSand("1432"), "NOT_AUTHORIZED");
+    });
+
+    it("can get the SAND price multiplier", async function () {
+      const {users} = await setupEstateSale(landSaleName, "lands");
+      const result = await users[0].EstateSale.getSandMultiplier();
+      expect(result).to.equal("1000");
     });
   });
 }

--- a/test/estateSale/subTests/sand_tests.js
+++ b/test/estateSale/subTests/sand_tests.js
@@ -30,6 +30,7 @@ function runSandTests(landSaleName) {
           land.y,
           land.size,
           land.price,
+          land.price,
           land.salt,
           [],
           proof,
@@ -89,6 +90,7 @@ function runSandTests(landSaleName) {
           land.x,
           land.y,
           land.size,
+          land.price,
           land.price,
           land.salt,
           [],
@@ -180,6 +182,7 @@ function runSandTests(landSaleName) {
           land.y,
           land.size,
           land.price,
+          land.price,
           land.salt,
           [],
           proof,
@@ -232,6 +235,7 @@ function runSandTests(landSaleName) {
           land.x,
           land.y,
           land.size,
+          land.price,
           land.price,
           land.salt,
           [],
@@ -304,6 +308,7 @@ function runSandTests(landSaleName) {
           land.y,
           land.size,
           land.price,
+          land.price,
           land.salt,
           [],
           proof,
@@ -327,6 +332,7 @@ function runSandTests(landSaleName) {
             land.x,
             land.y,
             land.size,
+            land.price,
             land.price,
             land.salt,
             [],
@@ -353,6 +359,7 @@ function runSandTests(landSaleName) {
             land.y,
             land.size,
             land.price,
+            land.price,
             land.salt,
             [],
             proof,
@@ -378,6 +385,7 @@ function runSandTests(landSaleName) {
             land.y,
             land.size,
             land.price,
+            land.price,
             land.salt,
             [],
             proof,
@@ -402,6 +410,7 @@ function runSandTests(landSaleName) {
           land.y,
           land.size,
           land.price,
+          land.price,
           land.salt,
           [],
           proof,
@@ -423,12 +432,13 @@ function runSandTests(landSaleName) {
             land.y,
             land.size,
             land.price,
+            land.price,
             land.salt,
             [],
             proof,
             emptyReferral
           ),
-          "Invalid land provided"
+          "INVALID_LAND"
         );
       });
 
@@ -448,6 +458,7 @@ function runSandTests(landSaleName) {
             land.x,
             land.y,
             land.size,
+            land.price,
             land.price,
             land.salt,
             [],
@@ -471,6 +482,7 @@ function runSandTests(landSaleName) {
           land.y,
           land.size,
           land.price,
+          land.price,
           land.salt,
           [],
           proof,
@@ -485,6 +497,7 @@ function runSandTests(landSaleName) {
             land.x,
             land.y,
             land.size,
+            land.price,
             land.price,
             land.salt,
             [],
@@ -513,12 +526,13 @@ function runSandTests(landSaleName) {
             land.y,
             land.size,
             land.price,
+            land.price,
             land.salt,
             [],
             proof,
             emptyReferral
           ),
-          "Invalid land provided"
+          "INVALID_LAND"
         );
       });
 
@@ -536,12 +550,13 @@ function runSandTests(landSaleName) {
             land.y,
             land.size,
             land.price,
+            land.price,
             land.salt,
             [],
             proof,
             emptyReferral
           ),
-          "Invalid land provided"
+          "INVALID_LAND"
         );
       });
 
@@ -556,6 +571,7 @@ function runSandTests(landSaleName) {
           land.x,
           land.y,
           land.size,
+          land.price,
           land.price,
           land.salt,
           [],
@@ -589,6 +605,7 @@ function runSandTests(landSaleName) {
             land.y,
             land.size,
             land.price,
+            land.price,
             land.salt,
             [],
             proof,
@@ -618,12 +635,13 @@ function runSandTests(landSaleName) {
             land.y,
             land.size,
             land.price,
+            land.price,
             land.salt,
             [],
             proof,
             emptyReferral
           ),
-          "Invalid land provided"
+          "INVALID_LAND"
         );
       });
 
@@ -638,6 +656,7 @@ function runSandTests(landSaleName) {
           land.x,
           land.y,
           land.size,
+          land.price,
           land.price,
           land.salt,
           [],
@@ -659,6 +678,7 @@ function runSandTests(landSaleName) {
           land.x,
           land.y,
           land.size,
+          land.price,
           land.price,
           land.salt,
           [],
@@ -688,6 +708,7 @@ function runSandTests(landSaleName) {
           land.y,
           land.size,
           land.price,
+          land.price,
           land.salt,
           [],
           proof,
@@ -708,6 +729,7 @@ function runSandTests(landSaleName) {
           land.x,
           land.y,
           land.size,
+          land.price,
           land.price,
           land.salt,
           [],
@@ -739,12 +761,13 @@ function runSandTests(landSaleName) {
                 land.y,
                 land.size,
                 land.price,
+                land.price,
                 land.salt,
                 land.assetIds,
                 proof,
                 emptyReferral
               ),
-              "cannot buy reserved Land"
+              "RESERVED_LAND"
             );
           } else {
             try {
@@ -755,6 +778,7 @@ function runSandTests(landSaleName) {
                 land.x,
                 land.y,
                 land.size,
+                land.price,
                 land.price,
                 land.salt,
                 land.assetIds,
@@ -789,6 +813,7 @@ function runSandTests(landSaleName) {
           land.y,
           land.size,
           land.price,
+          land.price,
           land.salt,
           land.assetIds,
           proof,
@@ -816,6 +841,7 @@ function runSandTests(landSaleName) {
           land.y,
           land.size,
           land.price,
+          land.price,
           land.salt,
           land.assetIds,
           proof,
@@ -837,12 +863,13 @@ function runSandTests(landSaleName) {
             land.y,
             land.size,
             land.price,
+            land.price,
             land.salt,
             [],
             proof,
             emptyReferral
           ),
-          "Invalid land provided"
+          "INVALID_LAND"
         );
       });
 


### PR DESCRIPTION
# Description


See [Jira ticket](https://sandboxgame.atlassian.net/browse/TSBBLOC-135) 

Setter & getter functions for new multiplier in `EstateSaleWithFee.sol`
New argument `adjustedLandPrice` added to `buyLandWithSand` function
Updates to tests

NOTES:
- front end now need to call buyLandWithSand with the original land price in SAND as well as the adjusted land price. 
- if no adjustment is to be applied, then the adjusted land price should be the same as the original land price

# Checklist:

- [x] Pull Request references Jira issue
- [x] Pull Request applies to a single purpose
- [x] I've added comments to my code where needed
- [x] I've updated any relevant docs
- [x] I've added tests to show that my changes achieve the desired results
- [x] I've reviewed my code
- [x] I've followed established naming conventions and formatting
- [x] All tests are passing locally
