### PR TITLE
Adding gems to starterPack pricing - TSBBLOC-140

### DIFF
--- a/data/starterPack/index.js
+++ b/data/starterPack/index.js
@@ -5,4 +5,4 @@ function sandWei(amount) {
 }
 
 // sand price is in Sand unit (Sand has 18 decimals)
-module.exports.starterPackPrices = [sandWei(120), sandWei(361), sandWei(1205), sandWei(4819)];
+module.exports.starterPackPrices = [sandWei(18), sandWei(55), sandWei(182), sandWei(727)];

--- a/data/starterPack/index.js
+++ b/data/starterPack/index.js
@@ -6,3 +6,4 @@ function sandWei(amount) {
 
 // sand price is in Sand unit (Sand has 18 decimals)
 module.exports.starterPackPrices = [sandWei(18), sandWei(55), sandWei(182), sandWei(727)];
+module.exports.gemPrices = sandWei(42);

--- a/data/starterPack/index.js
+++ b/data/starterPack/index.js
@@ -6,4 +6,4 @@ function sandWei(amount) {
 
 // sand price is in Sand unit (Sand has 18 decimals)
 module.exports.starterPackPrices = [sandWei(18), sandWei(55), sandWei(182), sandWei(727)];
-module.exports.gemPrices = sandWei(42);
+module.exports.gemPrice = sandWei(42);

--- a/data/starterPack/index.js
+++ b/data/starterPack/index.js
@@ -6,4 +6,4 @@ function sandWei(amount) {
 
 // sand price is in Sand unit (Sand has 18 decimals)
 module.exports.starterPackPrices = [sandWei(18), sandWei(55), sandWei(182), sandWei(727)];
-module.exports.gemPrice = sandWei(42);
+module.exports.gemPrice = sandWei(18);

--- a/deploy/071_deploy_starterPack.js
+++ b/deploy/071_deploy_starterPack.js
@@ -1,5 +1,5 @@
 const {guard} = require("../lib");
-const {starterPackPrices} = require("../data/starterPack");
+const {starterPackPrices, gemPrice} = require("../data/starterPack");
 
 module.exports = async ({getNamedAccounts, deployments}) => {
   const {deploy} = deployments;
@@ -25,6 +25,7 @@ module.exports = async ({getNamedAccounts, deployments}) => {
       gemGroup.address,
       backendMessageSigner,
       starterPackPrices,
+      gemPrice,
     ],
     log: true,
   });

--- a/src/StarterPack/PurchaseValidator.sol
+++ b/src/StarterPack/PurchaseValidator.sol
@@ -40,7 +40,6 @@ contract PurchaseValidator is Admin {
         bytes memory signature
     ) public returns (bool) {
         require(_checkAndUpdateNonce(buyer, nonce), "INVALID_NONCE");
-        require(_validateGemAmounts(catalystIds, catalystQuantities, gemQuantities), "INVALID_GEMS");
         bytes32 hashedData = keccak256(abi.encodePacked(catalystIds, catalystQuantities, gemIds, gemQuantities, buyer, nonce));
 
         address signer = SigUtil.recover(keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", hashedData)), signature);
@@ -73,28 +72,6 @@ contract PurchaseValidator is Admin {
             return true;
         }
         return false;
-    }
-
-    /// @dev Function to ensure the gem amounts requested are valid.
-    /// @param catalystIds An array of Ids. Order cannot be assumed to be consistent.
-    /// @param catalystQuantities The quantitiy of each catalyst Id
-    /// @param gemQuantities The quantitiy of each type of gem.
-    /// @return bool - whether or not gem amounts are valid
-    function _validateGemAmounts(
-        uint256[] memory catalystIds,
-        uint256[] memory catalystQuantities,
-        uint256[] memory gemQuantities
-    ) private pure returns (bool) {
-        uint256 maxGemsAllowed;
-        uint256 requestedGems;
-        for (uint256 i = 0; i < catalystQuantities.length; i++) {
-            require(catalystIds[i] < 4, "ID_OUT_OF_BOUNDS");
-            maxGemsAllowed += catalystQuantities[i] * (catalystIds[i] + 1);
-        }
-        for (uint256 i = 0; i < gemQuantities.length; i++) {
-            requestedGems += gemQuantities[i];
-        }
-        return (requestedGems <= maxGemsAllowed);
     }
 
     constructor(address initialSigningWallet) public {

--- a/src/StarterPack/StarterPackV1.sol
+++ b/src/StarterPack/StarterPackV1.sol
@@ -15,7 +15,7 @@ import "./PurchaseValidator.sol";
 /// @notice This contract manages the purchase and distribution of StarterPacks (bundles of Catalysts and Gems)
 contract StarterPackV1 is Admin, MetaTransactionReceiver, PurchaseValidator {
     using SafeMathWithRequire for uint256;
-    uint256 internal constant DAI_PRICE = 8300000000000000;
+    uint256 internal constant DAI_PRICE = 55000000000000000;
 
     ERC20 internal immutable _sand;
     Medianizer private immutable _medianizer;

--- a/src/StarterPack/StarterPackV1.sol
+++ b/src/StarterPack/StarterPackV1.sol
@@ -104,6 +104,7 @@ contract StarterPackV1 is Admin, MetaTransactionReceiver, PurchaseValidator {
     /// @param buyer The destination address for the purchased Catalysts and Gems and the address that will pay for the purchase; if not metaTx then buyer must be equal to msg.sender
     /// @param message A message containing information about the Catalysts and Gems to be purchased
     /// @param signature A signed message specifying tx details
+    // @review
     function purchaseWithSand(
         address buyer,
         Message calldata message,
@@ -208,7 +209,8 @@ contract StarterPackV1 is Admin, MetaTransactionReceiver, PurchaseValidator {
     }
 
     /// @notice Enables admin to change the prices of the StarterPack bundles
-    /// @param prices Array of new prices that wil take effect after a delay period
+    /// @param prices Array of new prices that will take effect after a delay period
+    // @review
     function setPrices(uint256[] calldata prices) external {
         require(msg.sender == _admin, "NOT_AUTHORIZED");
         _previousStarterPackPrices = _starterPackPrices;
@@ -221,6 +223,7 @@ contract StarterPackV1 is Admin, MetaTransactionReceiver, PurchaseValidator {
     /// @return pricesBeforeSwitch Array of prices before price change
     /// @return pricesAfterSwitch Array of prices after price change
     /// @return switchTime The time the latest price change will take effect, being the time of the price change plus the price change delay
+    // @review
     function getPrices()
         external
         view
@@ -259,6 +262,7 @@ contract StarterPackV1 is Admin, MetaTransactionReceiver, PurchaseValidator {
     /// @param catalystIds Array of catalystIds to be purchase
     /// @param catalystQuantities Array of quantities of those catalystIds to be purchased
     /// @return Total price in SAND
+    // @review
     function _calculateTotalPriceInSand(uint256[] memory catalystIds, uint256[] memory catalystQuantities) internal returns (uint256) {
         uint256[] memory prices = _priceSelector();
         uint256 totalPrice;
@@ -272,6 +276,7 @@ contract StarterPackV1 is Admin, MetaTransactionReceiver, PurchaseValidator {
 
     /// @dev Function to determine whether to use old or new prices
     /// @return Array of prices
+    // @review
     function _priceSelector() internal returns (uint256[] memory) {
         uint256[] memory prices;
         // No price change:
@@ -303,7 +308,7 @@ contract StarterPackV1 is Admin, MetaTransactionReceiver, PurchaseValidator {
     }
 
     // /////////////////// CONSTRUCTOR ////////////////////
-
+    // @review
     constructor(
         address starterPackAdmin,
         address sandContractAddress,

--- a/test/starter-pack/subTests/_testHelper.js
+++ b/test/starter-pack/subTests/_testHelper.js
@@ -1,1 +1,25 @@
-module.exports.privateKey = "0x4242424242424242424242424242424242424242424242424242424242424242";
+const {BigNumber} = require("ethers");
+
+const privateKey = "0x4242424242424242424242424242424242424242424242424242424242424242";
+
+function priceCalculator(starterPackPrices, catalystQuantities, gemPrice, gemQuantities) {
+  let totalExpectedPrice = BigNumber.from(0);
+  for (i = 0; i < starterPackPrices.length; i++) {
+    let price = BigNumber.from(starterPackPrices[i]);
+    let quantity = BigNumber.from(catalystQuantities[i]);
+    let total = quantity.mul(price);
+    totalExpectedPrice = totalExpectedPrice.add(total);
+  }
+  let totalGems = BigNumber.from(0);
+  for (i = 0; i < gemQuantities.length; i++) {
+    totalGems = totalGems.add(gemQuantities[i]);
+  }
+  expectedGemsPrice = BigNumber.from(gemPrice).mul(totalGems);
+  totalExpectedPrice = totalExpectedPrice.add(expectedGemsPrice);
+  return totalExpectedPrice;
+}
+
+module.exports = {
+  privateKey,
+  priceCalculator,
+};

--- a/test/starter-pack/subTests/common_tests.js
+++ b/test/starter-pack/subTests/common_tests.js
@@ -115,12 +115,12 @@ function runCommonTests() {
 
     it("cannot set prices if not admin", async function () {
       const {users} = setUp;
-      await expectRevert(users[0].StarterPack.setPrices([50, 60, 70, 80]), "NOT_AUTHORIZED");
+      await expectRevert(users[0].StarterPack.setPrices([50, 60, 70, 80], 42), "NOT_AUTHORIZED");
     });
 
     it("can set prices if admin", async function () {
       const {starterPackContractAsAdmin, starterPackContract} = setUp;
-      const receipt = await waitFor(starterPackContractAsAdmin.setPrices([50, 60, 70, 80]));
+      const receipt = await waitFor(starterPackContractAsAdmin.setPrices([50, 60, 70, 80], 42));
 
       const eventsMatching = receipt.events.filter((event) => event.event === "SetPrices");
       expect(eventsMatching).to.have.lengthOf(1);
@@ -129,12 +129,14 @@ function runCommonTests() {
       expect(priceEvent.args[0][1]).to.equal(60);
       expect(priceEvent.args[0][2]).to.equal(70);
       expect(priceEvent.args[0][3]).to.equal(80);
+      expect(priceEvent.args[1]).to.equal(42);
 
       const latestPrices = await starterPackContract.getPrices();
       expect(latestPrices[1][0]).to.equal(50);
       expect(latestPrices[1][1]).to.equal(60);
       expect(latestPrices[1][2]).to.equal(70);
       expect(latestPrices[1][3]).to.equal(80);
+      expect(latestPrices[3]).to.equal(42);
     });
 
     it("cannot withdrawAll if not admin", async function () {
@@ -217,7 +219,7 @@ function runCommonTests() {
       expect(balanceLuckGemRemaining).to.equal(0);
     });
 
-    it("user can get the starterpack prices", async function () {
+    it("user can get the starterpack and Gem prices", async function () {
       const {users} = await setUp;
       const prices = await users[0].StarterPack.getPrices();
       const expectedPrices = starterPackPrices;
@@ -229,7 +231,7 @@ function runCommonTests() {
       expect(prices[1][1]).to.equal(expectedPrices[1]);
       expect(prices[1][2]).to.equal(expectedPrices[2]);
       expect(prices[1][3]).to.equal(expectedPrices[3]);
-      expect(prices[2]).to.equal(0);
+      expect(prices[2]).to.equal(BigNumber.from("42000000000000000000"));
     });
   });
 }

--- a/test/starter-pack/subTests/common_tests.js
+++ b/test/starter-pack/subTests/common_tests.js
@@ -4,7 +4,8 @@ const {getNamedAccounts} = require("@nomiclabs/buidler");
 const ethers = require("ethers");
 const {BigNumber} = ethers;
 const {waitFor, expectRevert, checERC20Balances} = require("local-utils");
-const {starterPackPrices} = require("../../../data/starterPack");
+const {priceCalculator} = require("./_testHelper");
+const {starterPackPrices, gemPrice} = require("../../../data/starterPack");
 
 function runCommonTests() {
   describe("StarterPack:Setup", function () {
@@ -231,7 +232,16 @@ function runCommonTests() {
       expect(prices[1][1]).to.equal(expectedPrices[1]);
       expect(prices[1][2]).to.equal(expectedPrices[2]);
       expect(prices[1][3]).to.equal(expectedPrices[3]);
-      expect(prices[2]).to.equal(BigNumber.from("42000000000000000000"));
+      expect(prices[2]).to.equal(gemPrice);
+    });
+
+    it("prices can be calculated locally", async function () {
+      // starterPackPrices = [sandWei(18), sandWei(55), sandWei(182), sandWei(727)];
+      // gemPrice = sandWei(18);
+      const catalystQuantities = [1, 2, 3, 4];
+      const gemQuantities = [7, 11, 2, 6];
+      const totalCalculatedPrice = priceCalculator(starterPackPrices, catalystQuantities, gemPrice, gemQuantities);
+      expect(totalCalculatedPrice).to.be.equal(BigNumber.from(4050).mul("1000000000000000000"));
     });
   });
 }

--- a/test/starter-pack/subTests/dai_tests.js
+++ b/test/starter-pack/subTests/dai_tests.js
@@ -6,7 +6,7 @@ const {BigNumber} = ethers;
 const {findEvents} = require("../../../lib/findEvents.js");
 const {signPurchaseMessage} = require("../../../lib/purchaseMessageSigner");
 const {privateKey} = require("./_testHelper");
-const {starterPackPrices, gemPrices} = require("../../../data/starterPack");
+const {starterPackPrices, gemPrice} = require("../../../data/starterPack");
 
 function runDaiTests() {
   describe("StarterPack:PurchaseWithDAIEmptyStarterPack", function () {
@@ -307,7 +307,8 @@ function runDaiTests() {
         BigNumber.from(800).mul("1000000000000000000"),
         BigNumber.from(1300).mul("1000000000000000000"),
       ];
-      await starterPackContractAsAdmin.setPrices(newPrices);
+      const newGemPrice = 11;
+      await starterPackContractAsAdmin.setPrices(newPrices, newGemPrice);
       // buyer should still pay the old price for 1 hour
       const receipt = await waitFor(
         userWithDAI.StarterPack.purchaseWithDAI(userWithDAI.address, Message, dummySignature)
@@ -323,14 +324,17 @@ function runDaiTests() {
       expect(prices[1][1]).to.equal(expectedPrices[1]);
       expect(prices[1][2]).to.equal(expectedPrices[2]);
       expect(prices[1][3]).to.equal(expectedPrices[3]);
+      expect(prices[3]).to.equal(newGemPrice);
 
       const expectedPreviousPrices = starterPackPrices;
+      const expectedPreviousGemPrice = gemPrice;
       expect(prices[0][0]).to.equal(expectedPreviousPrices[0]);
       expect(prices[0][1]).to.equal(expectedPreviousPrices[1]);
       expect(prices[0][2]).to.equal(expectedPreviousPrices[2]);
       expect(prices[0][3]).to.equal(expectedPreviousPrices[3]);
+      expect(prices[2]).to.equal(expectedPreviousGemPrice);
 
-      expect(prices[2]).not.to.equal(0);
+      expect(prices[4]).not.to.equal(0);
 
       // fast-forward 1 hour. now buyer should pay the new price
       await increaseTime(60 * 60);

--- a/test/starter-pack/subTests/dai_tests.js
+++ b/test/starter-pack/subTests/dai_tests.js
@@ -283,6 +283,16 @@ function runDaiTests() {
       );
     });
 
+    it("purchase will fail if catalystIds are invalid", async function () {
+      const {userWithDAI} = await setUp;
+      Message.catalystIds = [5, 6, 7, 8]; // currently any IDs > 3 are invalid
+      let dummySignature = signPurchaseMessage(privateKey, Message, userWithDAI.address);
+      await expectRevert(
+        userWithDAI.StarterPack.purchaseWithDAI(userWithDAI.address, Message, dummySignature),
+        "Transaction reverted without a reason"
+      );
+    });
+
     it("sequential purchases should succeed with new nonce (as long as there are enough catalysts and gems)", async function () {
       const {userWithDAI} = await setUp;
 

--- a/test/starter-pack/subTests/dai_tests.js
+++ b/test/starter-pack/subTests/dai_tests.js
@@ -6,7 +6,7 @@ const {BigNumber} = ethers;
 const {findEvents} = require("../../../lib/findEvents.js");
 const {signPurchaseMessage} = require("../../../lib/purchaseMessageSigner");
 const {privateKey} = require("./_testHelper");
-const {starterPackPrices} = require("../../../data/starterPack");
+const {starterPackPrices, gemPrices} = require("../../../data/starterPack");
 
 function runDaiTests() {
   describe("StarterPack:PurchaseWithDAIEmptyStarterPack", function () {

--- a/test/starter-pack/subTests/dai_tests.js
+++ b/test/starter-pack/subTests/dai_tests.js
@@ -5,7 +5,7 @@ const ethers = require("ethers");
 const {BigNumber} = ethers;
 const {findEvents} = require("../../../lib/findEvents.js");
 const {signPurchaseMessage} = require("../../../lib/purchaseMessageSigner");
-const {privateKey} = require("./_testHelper");
+const {privateKey, priceCalculator} = require("./_testHelper");
 const {starterPackPrices, gemPrice} = require("../../../data/starterPack");
 
 function runDaiTests() {
@@ -314,7 +314,12 @@ function runDaiTests() {
         userWithDAI.StarterPack.purchaseWithDAI(userWithDAI.address, Message, dummySignature)
       );
       const eventsMatching = receipt.events.filter((event) => event.event === "Purchase");
-      const totalExpectedPrice = starterPackPrices.reduce((p, v) => p.add(v), BigNumber.from(0));
+      const totalExpectedPrice = priceCalculator(
+        starterPackPrices,
+        Message.catalystQuantities,
+        gemPrice,
+        Message.gemQuantities
+      );
       expect(eventsMatching[0].args[2]).to.equal(totalExpectedPrice);
 
       // prices are set but the new prices do not take effect for purchases yet
@@ -344,7 +349,12 @@ function runDaiTests() {
         userWithDAI.StarterPack.purchaseWithDAI(userWithDAI.address, Message, dummySignature2)
       );
       const eventsMatching2 = receipt2.events.filter((event) => event.event === "Purchase");
-      const newTotalExpectedPrice = BigNumber.from(2900).mul("1000000000000000000");
+      const newTotalExpectedPrice = priceCalculator(
+        newPrices,
+        Message.catalystQuantities,
+        newGemPrice,
+        Message.gemQuantities
+      );
       expect(eventsMatching2[0].args[2]).to.equal(newTotalExpectedPrice);
     });
 

--- a/test/starter-pack/subTests/ether_tests.js
+++ b/test/starter-pack/subTests/ether_tests.js
@@ -291,6 +291,16 @@ function runEtherTests() {
       );
     });
 
+    it("purchase will fail if catalystIds are invalid", async function () {
+      const {users} = await setUp;
+      Message.catalystIds = [5, 6, 7, 8]; // currently any IDs > 3 are invalid
+      let dummySignature = signPurchaseMessage(privateKey, Message, users[0].address);
+      await expectRevert(
+        users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature),
+        "Transaction reverted without a reason"
+      );
+    });
+
     it("sequential purchases should succeed with new nonce (as long as there are enough catalysts and gems)", async function () {
       const {users} = await setUp;
 

--- a/test/starter-pack/subTests/ether_tests.js
+++ b/test/starter-pack/subTests/ether_tests.js
@@ -5,7 +5,7 @@ const {BigNumber} = require("ethers");
 const {findEvents} = require("../../../lib/findEvents.js");
 const {signPurchaseMessage} = require("../../../lib/purchaseMessageSigner");
 const {privateKey} = require("./_testHelper");
-const {starterPackPrices} = require("../../../data/starterPack");
+const {starterPackPrices, gemPrices} = require("../../../data/starterPack");
 
 function runEtherTests() {
   describe("StarterPack:PurchaseWithETHEmptyStarterPack", function () {

--- a/test/starter-pack/subTests/ether_tests.js
+++ b/test/starter-pack/subTests/ether_tests.js
@@ -383,9 +383,6 @@ function runEtherTests() {
         Message.gemQuantities
       );
       const eventsMatching2 = receipt2.events.filter((event) => event.event === "Purchase");
-
-      console.log(`event price: ${eventsMatching2[0].args[2]}`);
-      console.log(`newTotalExpectedPrice: ${newTotalExpectedPrice}`);
       expect(eventsMatching2[0].args[2]).to.equal(newTotalExpectedPrice);
     });
 

--- a/test/starter-pack/subTests/ether_tests.js
+++ b/test/starter-pack/subTests/ether_tests.js
@@ -5,7 +5,7 @@ const {BigNumber} = require("ethers");
 const {findEvents} = require("../../../lib/findEvents.js");
 const {signPurchaseMessage} = require("../../../lib/purchaseMessageSigner");
 const {privateKey} = require("./_testHelper");
-const {starterPackPrices, gemPrices} = require("../../../data/starterPack");
+const {starterPackPrices, gemPrice} = require("../../../data/starterPack");
 
 function runEtherTests() {
   describe("StarterPack:PurchaseWithETHEmptyStarterPack", function () {
@@ -319,7 +319,8 @@ function runEtherTests() {
         BigNumber.from(800).mul("1000000000000000000"),
         BigNumber.from(1300).mul("1000000000000000000"),
       ];
-      await starterPackContractAsAdmin.setPrices(newPrices);
+      const newGemPrice = 11;
+      await starterPackContractAsAdmin.setPrices(newPrices, newGemPrice);
       // buyer should still pay the old price for 1 hour
       const receipt = await waitFor(
         users[0].StarterPack.purchaseWithETH(users[0].address, Message, dummySignature, {
@@ -337,14 +338,17 @@ function runEtherTests() {
       expect(prices[1][1]).to.equal(expectedPrices[1]);
       expect(prices[1][2]).to.equal(expectedPrices[2]);
       expect(prices[1][3]).to.equal(expectedPrices[3]);
+      expect(prices[3]).to.equal(newGemPrice);
 
       const expectedPreviousPrices = starterPackPrices;
+      const expectedPreviousGemPrice = gemPrice;
       expect(prices[0][0]).to.equal(expectedPreviousPrices[0]);
       expect(prices[0][1]).to.equal(expectedPreviousPrices[1]);
       expect(prices[0][2]).to.equal(expectedPreviousPrices[2]);
       expect(prices[0][3]).to.equal(expectedPreviousPrices[3]);
+      expect(prices[2]).to.equal(expectedPreviousGemPrice);
 
-      expect(prices[2]).not.to.equal(0);
+      expect(prices[4]).not.to.equal(0);
 
       // fast-forward 1 hour. now buyer should pay the new price
       await increaseTime(60 * 60);

--- a/test/starter-pack/subTests/sand_tests.js
+++ b/test/starter-pack/subTests/sand_tests.js
@@ -5,7 +5,7 @@ const ethers = require("ethers");
 const {BigNumber} = ethers;
 const {findEvents} = require("../../../lib/findEvents.js");
 const {signPurchaseMessage} = require("../../../lib/purchaseMessageSigner");
-const {privateKey} = require("./_testHelper");
+const {privateKey, priceCalculator} = require("./_testHelper");
 const {starterPackPrices, gemPrice} = require("../../../data/starterPack");
 
 function runSandTests() {
@@ -324,7 +324,12 @@ function runSandTests() {
         userWithSAND.StarterPack.purchaseWithSand(userWithSAND.address, Message, dummySignature)
       );
       const eventsMatching = receipt.events.filter((event) => event.event === "Purchase");
-      const totalExpectedPrice = starterPackPrices.reduce((p, v) => p.add(v), BigNumber.from(0));
+      const totalExpectedPrice = priceCalculator(
+        starterPackPrices,
+        Message.catalystQuantities,
+        gemPrice,
+        Message.gemQuantities
+      );
       expect(eventsMatching[0].args[2]).to.equal(totalExpectedPrice);
 
       // prices are set but the new prices do not take effect for purchases yet
@@ -354,7 +359,12 @@ function runSandTests() {
         userWithSAND.StarterPack.purchaseWithSand(userWithSAND.address, Message, dummySignature2)
       );
       const eventsMatching2 = receipt2.events.filter((event) => event.event === "Purchase");
-      const newTotalExpectedPrice = BigNumber.from(2900).mul("1000000000000000000");
+      const newTotalExpectedPrice = priceCalculator(
+        newPrices,
+        Message.catalystQuantities,
+        newGemPrice,
+        Message.gemQuantities
+      );
       expect(eventsMatching2[0].args[2]).to.equal(newTotalExpectedPrice);
     });
 

--- a/test/starter-pack/subTests/sand_tests.js
+++ b/test/starter-pack/subTests/sand_tests.js
@@ -367,6 +367,57 @@ function runSandTests() {
       );
       expect(eventsMatching2[0].args[2]).to.equal(newTotalExpectedPrice);
     });
+    // @review
+    it("should allow users to purchase gems directly", async function () {
+      const {userWithSAND, catalystContract, gemContract} = await setUp;
+
+      const gemsOnlyMessage = {
+        catalystIds: [0, 1, 2, 3],
+        catalystQuantities: [0, 0, 0, 0],
+        gemIds: [0, 1, 2, 3, 4],
+        gemQuantities: [1, 1, 1, 1, 1],
+        nonce: 0,
+      };
+
+      const balancePowerGemBefore = await gemContract.balanceOf(userWithSAND.address, 0);
+      const balanceDefenseGemBefore = await gemContract.balanceOf(userWithSAND.address, 1);
+      const balanceSpeedGemBefore = await gemContract.balanceOf(userWithSAND.address, 2);
+      const balanceMagicGemBefore = await gemContract.balanceOf(userWithSAND.address, 3);
+      const balanceLuckGemBefore = await gemContract.balanceOf(userWithSAND.address, 4);
+      expect(balancePowerGemBefore).to.equal(0);
+      expect(balanceDefenseGemBefore).to.equal(0);
+      expect(balanceSpeedGemBefore).to.equal(0);
+      expect(balanceMagicGemBefore).to.equal(0);
+      expect(balanceLuckGemBefore).to.equal(0);
+
+      const dummySignature = signPurchaseMessage(privateKey, gemsOnlyMessage, userWithSAND.address);
+
+      // purchase gems from starterPack
+      const receipt = await waitFor(
+        userWithSAND.StarterPack.purchaseWithSand(userWithSAND.address, gemsOnlyMessage, dummySignature)
+      );
+      const eventsMatching = receipt.events.filter((event) => event.event === "Purchase");
+
+      const totalExpectedPrice = priceCalculator(
+        starterPackPrices,
+        gemsOnlyMessage.catalystQuantities,
+        gemPrice,
+        gemsOnlyMessage.gemQuantities
+      );
+
+      const balancePowerGemAfter = await gemContract.balanceOf(userWithSAND.address, 0);
+      const balanceDefenseGemAfter = await gemContract.balanceOf(userWithSAND.address, 1);
+      const balanceSpeedGemAfter = await gemContract.balanceOf(userWithSAND.address, 2);
+      const balanceMagicGemAfter = await gemContract.balanceOf(userWithSAND.address, 3);
+      const balanceLuckGemAfter = await gemContract.balanceOf(userWithSAND.address, 4);
+
+      expect(eventsMatching[0].args[2]).to.equal(totalExpectedPrice);
+      expect(balancePowerGemAfter).to.equal(1);
+      expect(balanceDefenseGemAfter).to.equal(1);
+      expect(balanceSpeedGemAfter).to.equal(1);
+      expect(balanceMagicGemAfter).to.equal(1);
+      expect(balanceLuckGemAfter).to.equal(1);
+    });
 
     it("Any user should be able to purchase when msg.sender == metaTx contract", async function () {
       const {starterPackContract, starterPackContractAsAdmin, userWithSAND, sandContract} = await setUp;

--- a/test/starter-pack/subTests/sand_tests.js
+++ b/test/starter-pack/subTests/sand_tests.js
@@ -6,7 +6,7 @@ const {BigNumber} = ethers;
 const {findEvents} = require("../../../lib/findEvents.js");
 const {signPurchaseMessage} = require("../../../lib/purchaseMessageSigner");
 const {privateKey} = require("./_testHelper");
-const {starterPackPrices} = require("../../../data/starterPack");
+const {starterPackPrices, gemPrices} = require("../../../data/starterPack");
 
 function runSandTests() {
   describe("StarterPack:PurchaseWithSandEmptyStarterPack", function () {

--- a/test/starter-pack/subTests/sand_tests.js
+++ b/test/starter-pack/subTests/sand_tests.js
@@ -283,6 +283,16 @@ function runSandTests() {
       );
     });
 
+    it("purchase will fail if catalystIds are invalid", async function () {
+      const {userWithSAND} = await setUp;
+      Message.catalystIds = [5, 6, 7, 8]; // currently any IDs > 3 are invalid
+      let dummySignature = signPurchaseMessage(privateKey, Message, userWithSAND.address);
+      await expectRevert(
+        userWithSAND.StarterPack.purchaseWithSand(userWithSAND.address, Message, dummySignature),
+        "Transaction reverted without a reason"
+      );
+    });
+
     it("sequential purchases should succeed with new nonce (as long as there are enough catalysts and gems)", async function () {
       const {userWithSAND} = await setUp;
 

--- a/test/starter-pack/subTests/sand_tests.js
+++ b/test/starter-pack/subTests/sand_tests.js
@@ -6,7 +6,7 @@ const {BigNumber} = ethers;
 const {findEvents} = require("../../../lib/findEvents.js");
 const {signPurchaseMessage} = require("../../../lib/purchaseMessageSigner");
 const {privateKey} = require("./_testHelper");
-const {starterPackPrices, gemPrices} = require("../../../data/starterPack");
+const {starterPackPrices, gemPrice} = require("../../../data/starterPack");
 
 function runSandTests() {
   describe("StarterPack:PurchaseWithSandEmptyStarterPack", function () {
@@ -317,7 +317,8 @@ function runSandTests() {
         BigNumber.from(800).mul("1000000000000000000"),
         BigNumber.from(1300).mul("1000000000000000000"),
       ];
-      await starterPackContractAsAdmin.setPrices(newPrices);
+      const newGemPrice = 11;
+      await starterPackContractAsAdmin.setPrices(newPrices, newGemPrice);
       // buyer should still pay the old price for 1 hour
       const receipt = await waitFor(
         userWithSAND.StarterPack.purchaseWithSand(userWithSAND.address, Message, dummySignature)
@@ -333,14 +334,17 @@ function runSandTests() {
       expect(prices[1][1]).to.equal(expectedPrices[1]);
       expect(prices[1][2]).to.equal(expectedPrices[2]);
       expect(prices[1][3]).to.equal(expectedPrices[3]);
+      expect(prices[3]).to.equal(newGemPrice);
 
       const expectedPreviousPrices = starterPackPrices;
+      const expectedPreviousGemPrice = gemPrice;
       expect(prices[0][0]).to.equal(expectedPreviousPrices[0]);
       expect(prices[0][1]).to.equal(expectedPreviousPrices[1]);
       expect(prices[0][2]).to.equal(expectedPreviousPrices[2]);
       expect(prices[0][3]).to.equal(expectedPreviousPrices[3]);
+      expect(prices[2]).to.equal(expectedPreviousGemPrice);
 
-      expect(prices[2]).not.to.equal(0);
+      expect(prices[4]).not.to.equal(0);
 
       // fast-forward 1 hour. now buyer should pay the new price
       await increaseTime(60 * 60);

--- a/test/starter-pack/testPurchaseValidator.js
+++ b/test/starter-pack/testPurchaseValidator.js
@@ -207,42 +207,6 @@ describe("PurchaseValidator", function () {
       );
     });
 
-    it("should fail if too many gems are requested", async function () {
-      Message.catalystQuantities = [1, 1, 1, 1];
-      // total gems allowed is max 10
-      Message.gemQuantities = [3, 2, 4, 2, 3];
-      const dummySignature = signPurchaseMessage(privateKey, Message, buyer);
-      await expectRevert(
-        starterPack.isPurchaseValid(
-          buyer,
-          Message.catalystIds,
-          Message.catalystQuantities,
-          Message.gemIds,
-          Message.gemQuantities,
-          Message.nonce,
-          dummySignature
-        ),
-        "INVALID_GEMS"
-      );
-    });
-
-    it("should fail if catalystIds are out of range", async function () {
-      Message.catalystIds = [5, 6, 7, 8];
-      const dummySignature = signPurchaseMessage(privateKey, Message, buyer);
-      await expectRevert(
-        starterPack.isPurchaseValid(
-          buyer,
-          Message.catalystIds,
-          Message.catalystQuantities,
-          Message.gemIds,
-          Message.gemQuantities,
-          Message.nonce,
-          dummySignature
-        ),
-        "ID_OUT_OF_BOUNDS"
-      );
-    });
-
     it("Should fail if anyone but Admin tries to update signing wallet", async function () {
       const newSigner = roles.others[0];
       await expectRevert(starterPack.updateSigningWallet(newSigner), "SENDER_NOT_ADMIN");


### PR DESCRIPTION
# Description

<!--
Provide a summary of the changes made, and include some context, such as why the changes are needed. This is helpful to both reviewers, and for future reference.
-->

This adds the price of gems to the starterpack pricing, alowing for creators to purchase an arbitrary number of gems and/or catalysts. Prior to this, the number of gems was determined by the catalysts selected. because of this change, `_validateGemAmounts(...)` is no longer needed.
- I've removed the limitation on the number of gems allowed to be purchased, allowing for an arbitrary amount of gems.
- the price is now the sum of all catalyst price + sum of all gems, so if I buy 1 legendary catalyst and 3 different gems, the cost would be:  1 * legendary_catalyst_cost + 3 * gem_cost
- users can now purchase gems directly (ie: I could purchase some gems, without purchasing any catalysts)
- all gems have the same price (final price to be confiremed. (currently set the same as a common catalyst)
- catalyst prices updated.
- all prices (including gems) can be retrieved by the frontend


Ref: https://sandboxgame.atlassian.net/browse/TSBBLOC-140

# Checklist:

- [x] Pull Request references Jira issue
- [x] Pull Request applies to a single purpose
- [x] I've added comments to my code where needed
- [ ] I've updated any relevant docs
- [x] I've added tests to show that my changes achieve the desired results
- [x] I've reviewed my code
- [x] I've followed established naming conventions and formatting
- [x] All tests are passing locally
