### PR TITLE
Instant withdrawal for tokens that are not SAND

### DIFF
--- a/deploy/074_deploy_feeDistributors.js
+++ b/deploy/074_deploy_feeDistributors.js
@@ -9,10 +9,10 @@ module.exports = async ({getNamedAccounts, deployments}) => {
   for (const key of Object.keys(deploymentData)) {
     let {percentages, recipients, name} = deploymentData[key];
     let feeDistributionRecipients = [];
-    for (const name of recipients) {
-      const recipient = namedAccounts[name];
+    for (const rName of recipients) {
+      const recipient = namedAccounts[rName];
       if (!recipient) {
-        const deployedContract = await deployments.get(name);
+        const deployedContract = await deployments.get(rName);
         feeDistributionRecipients.push(deployedContract.address);
       } else {
         feeDistributionRecipients.push(recipient);

--- a/package.json
+++ b/package.json
@@ -75,5 +75,8 @@
     "rinkeby:run": "cross-env BUIDLER_NETWORK=rinkeby node",
     "rinkeby:test:run": "cross-env BUIDLER_NETWORK=rinkeby_test node",
     "mainnet:run": "cross-env BUIDLER_NETWORK=mainnet node"
+  },
+  "dependencies": {
+    "@openzeppelin/contracts": "^3.2.0"
   }
 }

--- a/src/FeeDistributor/FeeDistributor.sol
+++ b/src/FeeDistributor/FeeDistributor.sol
@@ -1,22 +1,23 @@
 pragma solidity 0.6.5;
 pragma experimental ABIEncoderV2;
 
-import "../common/interfaces/ERC20.sol";
 import "../common/Libraries/SafeMathWithRequire.sol";
+import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
 
 
 /// @title Fee distributor
 /// @notice Distributes all fees collected from platform activities to stakeholders
 contract FeeDistributor {
+    using SafeERC20 for IERC20;
     event Deposit(address token, address from, uint256 amount);
-    event Withdrawal(ERC20 token, address to, uint256 amount);
+    event Withdrawal(IERC20 token, address to, uint256 amount);
     mapping(address => uint256) public recipientsShares;
 
     /// @notice Enables fee holder to withdraw its share
     /// @notice Zero address reserved for ether withdrawal
     /// @param token the token that fee should be distributed in
     /// @return amount had withdrawn
-    function withdraw(ERC20 token) external returns (uint256 amount) {
+    function withdraw(IERC20 token) external returns (uint256 amount) {
         if (address(token) == address(0)) {
             amount = _etherWithdrawal();
         } else {
@@ -40,10 +41,10 @@ contract FeeDistributor {
         return amount;
     }
 
-    function _tokenWithdrawal(ERC20 token) private returns (uint256) {
-        uint256 amount = _calculateWithdrawalAmount(ERC20(token).balanceOf(address(this)), address(token));
+    function _tokenWithdrawal(IERC20 token) private returns (uint256) {
+        uint256 amount = _calculateWithdrawalAmount(token.balanceOf(address(this)), address(token));
         if (amount > 0) {
-            require(ERC20(token).transfer(msg.sender, amount), "FEE_WITHDRAWAL_FAILED");
+            token.safeTransfer(msg.sender, amount);
         }
         return amount;
     }

--- a/src/FeeDistributor/FeeDistributor.sol
+++ b/src/FeeDistributor/FeeDistributor.sol
@@ -17,11 +17,11 @@ contract FeeDistributor {
     /// @notice Zero address reserved for ether withdrawal
     /// @param token the token that fee should be distributed in
     /// @return amount had withdrawn
-    function withdraw(IERC20 token) external returns (uint256 amount) {
+    function withdraw(IERC20 token, address payable beneficiary) external returns (uint256 amount) {
         if (address(token) == address(0)) {
-            amount = _etherWithdrawal();
+            amount = _etherWithdrawal(beneficiary);
         } else {
-            amount = _tokenWithdrawal(token);
+            amount = _tokenWithdrawal(token, beneficiary);
         }
         if (amount != 0) {
             emit Withdrawal(token, msg.sender, amount);
@@ -33,18 +33,18 @@ contract FeeDistributor {
     }
 
     // //////////////////// INTERNALS ////////////////////
-    function _etherWithdrawal() private returns (uint256) {
+    function _etherWithdrawal(address payable beneficiary) private returns (uint256) {
         uint256 amount = _calculateWithdrawalAmount(address(this).balance, address(0));
         if (amount > 0) {
-            msg.sender.transfer(amount);
+            beneficiary.transfer(amount);
         }
         return amount;
     }
 
-    function _tokenWithdrawal(IERC20 token) private returns (uint256) {
+    function _tokenWithdrawal(IERC20 token, address payable beneficiary) private returns (uint256) {
         uint256 amount = _calculateWithdrawalAmount(token.balanceOf(address(this)), address(token));
         if (amount > 0) {
-            token.safeTransfer(msg.sender, amount);
+            token.safeTransfer(beneficiary, amount);
         }
         return amount;
     }

--- a/src/FeeDistributor/FeeDistributor.sol
+++ b/src/FeeDistributor/FeeDistributor.sol
@@ -16,7 +16,7 @@ contract FeeDistributor {
     /// @notice Enables fee holder to withdraw its share
     /// @notice Zero address reserved for ether withdrawal
     /// @param token the token that fee should be distributed in
-    /// @param beneficiary the address that receives fees
+    /// @param beneficiary the address that will receive fees
     /// @return amount had withdrawn
     function withdraw(IERC20 token, address payable beneficiary) external returns (uint256 amount) {
         if (address(token) == address(0)) {

--- a/src/FeeDistributor/FeeDistributor.sol
+++ b/src/FeeDistributor/FeeDistributor.sol
@@ -16,7 +16,7 @@ contract FeeDistributor {
     /// @notice Enables fee holder to withdraw its share
     /// @notice Zero address reserved for ether withdrawal
     /// @param token the token that fee should be distributed in
-    /// @param beneficiary
+    /// @param beneficiary the address that receives fees
     /// @return amount had withdrawn
     function withdraw(IERC20 token, address payable beneficiary) external returns (uint256 amount) {
         if (address(token) == address(0)) {

--- a/src/FeeDistributor/FeeDistributor.sol
+++ b/src/FeeDistributor/FeeDistributor.sol
@@ -16,6 +16,7 @@ contract FeeDistributor {
     /// @notice Enables fee holder to withdraw its share
     /// @notice Zero address reserved for ether withdrawal
     /// @param token the token that fee should be distributed in
+    /// @param beneficiary
     /// @return amount had withdrawn
     function withdraw(IERC20 token, address payable beneficiary) external returns (uint256 amount) {
         if (address(token) == address(0)) {

--- a/src/FeeDistributor/FeeTimeVault.sol
+++ b/src/FeeDistributor/FeeTimeVault.sol
@@ -10,18 +10,17 @@ import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
 /// @notice Holds tokens collected from fees in a locked state for a certain period of time
 contract FeeTimeVault is Ownable {
     using SafeERC20 for IERC20;
-    event Sync(address token, uint256 amount, uint256 timestamp);
     mapping(uint256 => uint256) public accumulatedAmountPerDay;
     FeeDistributor public feeDistributor;
 
     /// @notice Updates the total amount of fees collected alongside with the due date
-    function sync() external {
+    function sync() external returns (uint256) {
         uint256 timestamp = now;
         uint256 day = ((timestamp - _startTime) / 1 days);
         uint256 amount = feeDistributor.withdraw(_sandToken, address(this));
         accumulatedAmountPerDay[day] = accumulatedAmountPerDay[_lastDaySaved].add(amount);
         _lastDaySaved = day;
-        emit Sync(address(_sandToken), amount, timestamp);
+        return amount;
     }
 
     /// @notice Enables fee holder to withdraw its share after lock period expired

--- a/src/FeeDistributor/FeeTimeVault.sol
+++ b/src/FeeDistributor/FeeTimeVault.sol
@@ -18,7 +18,7 @@ contract FeeTimeVault is Ownable {
     function sync() external {
         uint256 timestamp = now;
         uint256 day = ((timestamp - _startTime) / 1 days);
-        uint256 amount = feeDistributor.withdraw(_sandToken);
+        uint256 amount = feeDistributor.withdraw(_sandToken, address(this));
         accumulatedAmountPerDay[day] = accumulatedAmountPerDay[_lastDaySaved].add(amount);
         _lastDaySaved = day;
         emit Sync(address(_sandToken), amount, timestamp);
@@ -42,14 +42,7 @@ contract FeeTimeVault is Ownable {
     /// @param token the token that fees are collected in
     function withdrawNoTimeLock(IERC20 token) external onlyOwner returns (uint256) {
         require(token != _sandToken, "SAND_TOKEN_WITHDRWAL_NOT_ALLOWED");
-        uint256 amount = feeDistributor.withdraw(token);
-        if (amount != 0) {
-            if (address(token) == address(0)) {
-                msg.sender.transfer(amount);
-            } else {
-                token.safeTransfer(msg.sender, amount);
-            }
-        }
+        uint256 amount = feeDistributor.withdraw(token, msg.sender);
         return amount;
     }
 

--- a/src/FeeDistributor/FeeTimeVault.sol
+++ b/src/FeeDistributor/FeeTimeVault.sol
@@ -25,7 +25,8 @@ contract FeeTimeVault is Ownable {
     }
 
     /// @notice Enables fee holder to withdraw its share after lock period expired
-    function withdraw() external onlyOwner returns (uint256) {
+    /// @param beneficiary the address that will receive fees
+    function withdraw(address payable beneficiary) external onlyOwner returns (uint256) {
         uint256 day = ((now - _startTime) / 1 days);
         uint256 lockPeriod = _lockPeriod;
         uint256 amount = lockPeriod > day ? 0 : accumulatedAmountPerDay[day - lockPeriod];
@@ -33,16 +34,17 @@ contract FeeTimeVault is Ownable {
             uint256 withdrawnAmount = _withdrawnAmount;
             amount = amount.sub(withdrawnAmount);
             _withdrawnAmount = withdrawnAmount.add(amount);
-            _sandToken.safeTransfer(msg.sender, amount);
+            _sandToken.safeTransfer(beneficiary, amount);
         }
         return amount;
     }
 
     /// @notice Enables fee holder to withdraw token fees with no time-lock for tokens other than SAND
     /// @param token the token that fees are collected in
-    function withdrawNoTimeLock(IERC20 token) external onlyOwner returns (uint256) {
+    /// @param beneficiary the address that will receive fees
+    function withdrawNoTimeLock(IERC20 token, address payable beneficiary) external onlyOwner returns (uint256) {
         require(token != _sandToken, "SAND_TOKEN_WITHDRWAL_NOT_ALLOWED");
-        uint256 amount = feeDistributor.withdraw(token, msg.sender);
+        uint256 amount = feeDistributor.withdraw(token, beneficiary);
         return amount;
     }
 

--- a/test/feeDistributor/testFeeDistributor.js
+++ b/test/feeDistributor/testFeeDistributor.js
@@ -6,7 +6,7 @@ const {expectRevert, zeroAddress} = require("local-utils");
 describe("FeeDistributor:ETH", function () {
   async function testEthFeeWithdrawal(account, percentage, amount, contract) {
     let balanceBefore = await ethers.provider.getBalance(account);
-    let tx = await contract.connect(ethers.provider.getSigner(account)).withdraw(zeroAddress);
+    let tx = await contract.connect(ethers.provider.getSigner(account)).withdraw(zeroAddress, account);
     let receipt = await tx.wait();
     let balanceAfter = await ethers.provider.getBalance(account);
     let txFee = tx.gasPrice.mul(receipt.gasUsed);
@@ -101,7 +101,7 @@ describe("FeeDistributor:ERC20", function () {
 
   async function testERC20FeeWithdrawal(account, percentage, amount, contract, erc20Contract) {
     let balanceBefore = await erc20Contract.balanceOf(account);
-    let tx = await contract.connect(ethers.provider.getSigner(account)).withdraw(erc20Contract.address);
+    let tx = await contract.connect(ethers.provider.getSigner(account)).withdraw(erc20Contract.address, account);
     await tx.wait();
     let balanceAfter = await erc20Contract.balanceOf(account);
     let distributionFee = balanceAfter.sub(balanceBefore);

--- a/test/feeDistributor/testFeeTimeVault.js
+++ b/test/feeDistributor/testFeeTimeVault.js
@@ -1,6 +1,7 @@
 const {ethers, getNamedAccounts} = require("@nomiclabs/buidler");
 const {BigNumber} = require("@ethersproject/bignumber");
 const {expect} = require("local-chai");
+const {zeroAddress, expectRevert} = require("local-utils");
 
 describe("FeeTimeVault", function () {
   async function initContracts(lockPeriod, percentages) {
@@ -28,10 +29,47 @@ describe("FeeTimeVault", function () {
     return contractRef;
   }
 
+  async function initContractsWithMockERC20(lockPeriod, percentages) {
+    const accounts = await getNamedAccounts();
+    let sandToken = await initContract("Sand", accounts.sandBeneficiary, [
+      accounts.sandBeneficiary,
+      accounts.sandBeneficiary,
+      accounts.sandBeneficiary,
+    ]);
+    let mockToken = await initContract("MockERC20", accounts.deployer, []);
+    let feeTimeVault = await initContract("FeeTimeVault", accounts.deployer, [
+      lockPeriod,
+      sandToken.address,
+      accounts.deployer,
+    ]);
+    let feeDist = await initContract("FeeDistributor", accounts.deployer, [
+      [accounts.others[0], accounts.others[1], feeTimeVault.address],
+      percentages,
+    ]);
+    await feeTimeVault.connect(ethers.provider.getSigner(accounts.deployer)).setFeeDistributor(feeDist.address);
+    return {feeTimeVault, feeDist, mockToken};
+  }
+
   async function fundContractWithSand(feeDistContractAdd, sandContract, beneficiary, amount) {
     let tx = await sandContract.connect(ethers.provider.getSigner(beneficiary)).transfer(feeDistContractAdd, amount);
     await tx.wait();
   }
+
+  async function fundContractWithETH(address, value) {
+    let accounts = await getNamedAccounts();
+    await deployments.rawTx({
+      to: address,
+      from: accounts.deployer,
+      value,
+    });
+  }
+
+  async function fundContractWithTokenFees(feeDistContractAdd, erc20Contract, amount) {
+    let accounts = await getNamedAccounts();
+    let tx = await erc20Contract.connect(ethers.provider.getSigner(accounts.deployer)).mint(feeDistContractAdd, amount);
+    await tx.wait();
+  }
+
   it("Single deposit with withdraw after lock period", async function () {
     let lockPeriod = 10;
     let percentages = [2000, 2000, 6000];
@@ -184,5 +222,48 @@ describe("FeeTimeVault", function () {
     await tx.wait();
     balanceAfter = await sandToken.balanceOf(deployer);
     expect(balanceAfter).to.equal(amount1.mul(BigNumber.from(percentages[2])).div(BigNumber.from(10000)));
+  });
+
+  it("Withdraw ETH fees with no time-lock", async function () {
+    let lockPeriod = 4;
+    let percentages = [2000, 2000, 6000];
+    let {deployer} = await getNamedAccounts();
+    let {feeTimeVault, feeDist} = await initContracts(lockPeriod, percentages);
+    let amount1 = BigNumber.from("1000000000000000000");
+    await fundContractWithETH(feeDist.address, amount1);
+    let balanceBefore = await ethers.provider.getBalance(deployer);
+    let tx = await feeTimeVault.connect(ethers.provider.getSigner(deployer)).withdrawNoTimeLock(zeroAddress);
+    let receipt = await tx.wait();
+    let txFee = tx.gasPrice.mul(receipt.gasUsed);
+    let balanceAfter = await ethers.provider.getBalance(deployer);
+    expect(balanceAfter.sub(balanceBefore).add(txFee)).to.equal(
+      amount1.mul(BigNumber.from(percentages[2])).div(BigNumber.from(10000))
+    );
+  });
+
+  it("Withdraw ERC20 fees with no time-lock", async function () {
+    let lockPeriod = 4;
+    let percentages = [2000, 2000, 6000];
+    let {deployer} = await getNamedAccounts();
+    let {feeTimeVault, feeDist, mockToken} = await initContractsWithMockERC20(lockPeriod, percentages);
+    let amount1 = BigNumber.from("1000000000000000000");
+    await fundContractWithTokenFees(feeDist.address, mockToken, amount1);
+    let balanceBefore = await mockToken.balanceOf(deployer);
+    let tx = await feeTimeVault.connect(ethers.provider.getSigner(deployer)).withdrawNoTimeLock(mockToken.address);
+    await tx.wait();
+    let balanceAfter = await mockToken.balanceOf(deployer);
+    expect(balanceAfter.sub(balanceBefore)).to.equal(
+      amount1.mul(BigNumber.from(percentages[2])).div(BigNumber.from(10000))
+    );
+  });
+
+  it("Withdraw SAND fees using withdrawNoTimeLock should fail", async function () {
+    let lockPeriod = 4;
+    let percentages = [2000, 2000, 6000];
+    let {deployer, sandBeneficiary} = await getNamedAccounts();
+    let {feeTimeVault, feeDist, sandToken} = await initContracts(lockPeriod, percentages);
+    let amount1 = BigNumber.from("1000000000000000000");
+    await fundContractWithSand(feeDist.address, sandToken, sandBeneficiary, amount1);
+    expectRevert(feeTimeVault.connect(ethers.provider.getSigner(deployer)).withdrawNoTimeLock(sandToken.address));
   });
 });

--- a/test/feeDistributor/testFeeTimeVault.js
+++ b/test/feeDistributor/testFeeTimeVault.js
@@ -82,7 +82,7 @@ describe("FeeTimeVault", function () {
     let {timestamp} = await ethers.provider.getBlock("latest");
     let threedaysInSecs = 60 * 60 * 24 * lockPeriod;
     await ethers.provider.send("evm_setNextBlockTimestamp", [timestamp + threedaysInSecs]);
-    tx = await feeTimeVault.connect(ethers.provider.getSigner(deployer)).withdraw();
+    tx = await feeTimeVault.connect(ethers.provider.getSigner(deployer)).withdraw(deployer);
     await tx.wait();
     let balanceAfter = await sandToken.balanceOf(deployer);
     expect(balanceAfter).to.equal(amount.mul(BigNumber.from(percentages[2])).div(BigNumber.from(10000)));
@@ -100,7 +100,7 @@ describe("FeeTimeVault", function () {
     let nineDaysInSecs = 60 * 60 * 24 * (lockPeriod - 1);
     await ethers.provider.send("evm_setNextBlockTimestamp", [timestamp + nineDaysInSecs]);
     let sandBalanceBefore = await sandToken.balanceOf(deployer);
-    tx = await feeTimeVault.connect(ethers.provider.getSigner(deployer)).withdraw();
+    tx = await feeTimeVault.connect(ethers.provider.getSigner(deployer)).withdraw(deployer);
     await tx.wait();
     let sandBalanceAfter = await sandToken.balanceOf(deployer);
     expect(sandBalanceBefore).to.equal(sandBalanceAfter);
@@ -125,13 +125,13 @@ describe("FeeTimeVault", function () {
     timestamp = (await ethers.provider.getBlock("latest")).timestamp;
     await ethers.provider.send("evm_setNextBlockTimestamp", [timestamp + (lockPeriod - 2) * dayInSecs]);
     let sandBalanceBefore = await sandToken.balanceOf(deployer);
-    tx = await feeTimeVault.connect(ethers.provider.getSigner(deployer)).withdraw();
+    tx = await feeTimeVault.connect(ethers.provider.getSigner(deployer)).withdraw(deployer);
     await tx.wait();
     let sandBalanceAfter = await sandToken.balanceOf(deployer);
     expect(sandBalanceBefore).to.equal(sandBalanceAfter);
     timestamp = (await ethers.provider.getBlock("latest")).timestamp;
     await ethers.provider.send("evm_setNextBlockTimestamp", [timestamp + 2 * dayInSecs]);
-    tx = await feeTimeVault.connect(ethers.provider.getSigner(deployer)).withdraw();
+    tx = await feeTimeVault.connect(ethers.provider.getSigner(deployer)).withdraw(deployer);
     await tx.wait();
     timestamp = (await ethers.provider.getBlock("latest")).timestamp;
     let balanceAfter = await sandToken.balanceOf(deployer);
@@ -155,7 +155,7 @@ describe("FeeTimeVault", function () {
     await ethers.provider.send("evm_setNextBlockTimestamp", [timestamp + lockPeriodInSecs]);
     tx = await feeTimeVault.connect(ethers.provider.getSigner(deployer)).sync();
     await tx.wait();
-    tx = await feeTimeVault.connect(ethers.provider.getSigner(deployer)).withdraw();
+    tx = await feeTimeVault.connect(ethers.provider.getSigner(deployer)).withdraw(deployer);
     await tx.wait();
     let balanceAfter = await sandToken.balanceOf(deployer);
     expect(balanceAfter).to.equal(amount1.mul(BigNumber.from(percentages[2])).div(BigNumber.from(10000)));
@@ -172,11 +172,11 @@ describe("FeeTimeVault", function () {
     let {timestamp} = await ethers.provider.getBlock("latest");
     let lockPeriodInSecs = 60 * 60 * 24 * lockPeriod;
     await ethers.provider.send("evm_setNextBlockTimestamp", [timestamp + lockPeriodInSecs]);
-    tx = await feeTimeVault.connect(ethers.provider.getSigner(deployer)).withdraw();
+    tx = await feeTimeVault.connect(ethers.provider.getSigner(deployer)).withdraw(deployer);
     await tx.wait();
     let balanceAfter1 = await sandToken.balanceOf(deployer);
     expect(balanceAfter1).to.equal(amount1.mul(BigNumber.from(percentages[2])).div(BigNumber.from(10000)));
-    tx = await feeTimeVault.connect(ethers.provider.getSigner(deployer)).withdraw();
+    tx = await feeTimeVault.connect(ethers.provider.getSigner(deployer)).withdraw(deployer);
     await tx.wait();
     let balanceAfter2 = await sandToken.balanceOf(deployer);
     expect(balanceAfter2).to.equal(balanceAfter1);
@@ -212,13 +212,13 @@ describe("FeeTimeVault", function () {
     let tx = await feeTimeVault.connect(ethers.provider.getSigner(deployer)).sync();
     await tx.wait();
     let balanceBefore = await sandToken.balanceOf(deployer);
-    tx = await feeTimeVault.connect(ethers.provider.getSigner(deployer)).withdraw();
+    tx = await feeTimeVault.connect(ethers.provider.getSigner(deployer)).withdraw(deployer);
     await tx.wait();
     let balanceAfter = await sandToken.balanceOf(deployer);
     expect(balanceBefore).to.equal(balanceAfter);
     timestamp = (await ethers.provider.getBlock("latest")).timestamp;
     await ethers.provider.send("evm_setNextBlockTimestamp", [timestamp + lockPeriod * oneDayInSecs]);
-    tx = await feeTimeVault.connect(ethers.provider.getSigner(deployer)).withdraw();
+    tx = await feeTimeVault.connect(ethers.provider.getSigner(deployer)).withdraw(deployer);
     await tx.wait();
     balanceAfter = await sandToken.balanceOf(deployer);
     expect(balanceAfter).to.equal(amount1.mul(BigNumber.from(percentages[2])).div(BigNumber.from(10000)));
@@ -232,7 +232,7 @@ describe("FeeTimeVault", function () {
     let amount1 = BigNumber.from("1000000000000000000");
     await fundContractWithETH(feeDist.address, amount1);
     let balanceBefore = await ethers.provider.getBalance(deployer);
-    let tx = await feeTimeVault.connect(ethers.provider.getSigner(deployer)).withdrawNoTimeLock(zeroAddress);
+    let tx = await feeTimeVault.connect(ethers.provider.getSigner(deployer)).withdrawNoTimeLock(zeroAddress, deployer);
     let receipt = await tx.wait();
     let txFee = tx.gasPrice.mul(receipt.gasUsed);
     let balanceAfter = await ethers.provider.getBalance(deployer);
@@ -249,7 +249,9 @@ describe("FeeTimeVault", function () {
     let amount1 = BigNumber.from("1000000000000000000");
     await fundContractWithTokenFees(feeDist.address, mockToken, amount1);
     let balanceBefore = await mockToken.balanceOf(deployer);
-    let tx = await feeTimeVault.connect(ethers.provider.getSigner(deployer)).withdrawNoTimeLock(mockToken.address);
+    let tx = await feeTimeVault
+      .connect(ethers.provider.getSigner(deployer))
+      .withdrawNoTimeLock(mockToken.address, deployer);
     await tx.wait();
     let balanceAfter = await mockToken.balanceOf(deployer);
     expect(balanceAfter.sub(balanceBefore)).to.equal(
@@ -264,6 +266,8 @@ describe("FeeTimeVault", function () {
     let {feeTimeVault, feeDist, sandToken} = await initContracts(lockPeriod, percentages);
     let amount1 = BigNumber.from("1000000000000000000");
     await fundContractWithSand(feeDist.address, sandToken, sandBeneficiary, amount1);
-    expectRevert(feeTimeVault.connect(ethers.provider.getSigner(deployer)).withdrawNoTimeLock(sandToken.address));
+    expectRevert(
+      feeTimeVault.connect(ethers.provider.getSigner(deployer)).withdrawNoTimeLock(sandToken.address, deployer)
+    );
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -894,6 +894,11 @@
     widest-line "^2.0.1"
     wrap-ansi "^4.0.0"
 
+"@openzeppelin/contracts@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.2.0.tgz#3e6b3a7662d8ed64271ade96ef42655db983fd9d"
+  integrity sha512-bUOmkSoPkjnUyMiKo6RYnb0VHBk5D9KKDAgNLzF41aqAM3TeE0yGdFF5dVRcV60pZdJLlyFT/jjXIZCWyyEzAQ==
+
 "@sentry/apm@5.20.1":
   version "5.20.1"
   resolved "https://registry.yarnpkg.com/@sentry/apm/-/apm-5.20.1.tgz#2126407ec8ecc6f78f42a8a8de99b90dec982036"


### PR DESCRIPTION
# Description

Let the FeeTimeVault's owner to withdraw fees collected in tokens that are not SAND with no time-lock.

# Checklist:

- [ ] Pull Request references Jira issue
- [x] Pull Request applies to a single purpose
- [x] I've added comments to my code where needed
- [ ] I've updated any relevant docs
- [x] I've added tests to show that my changes achieve the desired results
- [x] I've reviewed my code
- [x] I've followed established naming conventions and formatting
- [x] All tests are passing locally
