### PR TITLE
Hotfix for ERC721BaseToken - metaTXs

### DIFF
--- a/src/solc_0.7/common/BaseWithStorage/ERC721BaseToken.sol
+++ b/src/solc_0.7/common/BaseWithStorage/ERC721BaseToken.sol
@@ -432,11 +432,15 @@ contract ERC721BaseToken is ERC721Events, WithSuperOperators, WithMetaTransactio
     /// @param from The address passed as either "from" or "sender" to the external func which called this one
     function _isValidMetaTx(address from) internal view returns (bool) {
         uint256 processorType = _metaTransactionContracts[msg.sender];
-        require(processorType != 0, "INVALID SENDER");
-        require(msg.sender != from, "INVALID_META_TX");
+        if (msg.sender == from || processorType == 0) {
+            return false;
+        }
         if (processorType == METATX_2771) {
-            require(from == _forceMsgSender(), "INVALID_SENDER");
-            return true;
+            if (from != _forceMsgSender()) {
+                return false;
+            } else {
+                return true;
+            }
         } else if (processorType == METATX_SANDBOX) {
             return true;
         } else {


### PR DESCRIPTION
# Description
This fixes a bug in the `_isValidMetaTx()` function.
It is meant to return a `bool`, but under some conditions was reverting with `require` leading to unexpected results.
All `requires` have been replaced with `if` statements.

For context, noticed this bug when I started running the game token tests with these changes.
I'll be adding more metaTx-specific tests as I continue to work on the GameToken.
<!--
Provide a summary of the changes made, and include some context, such as why the changes are needed. This is helpful to both reviewers, and for future reference.
-->

# Checklist:

- [ ] Pull Request references Jira issue
- [x] Pull Request applies to a single purpose
- [ ] I've added comments to my code where needed
- [ ] I've updated any relevant docs
- [ ] I've added tests to show that my changes achieve the desired results
- [ ] I've reviewed my code
- [ ] I've followed established naming conventions and formatting
- [ ] All tests are passing locally
