### PR TITLE
Move _isValidMetaTx() from ERC721BaseToken to WithMetaTransaction

### DIFF
--- a/src/solc_0.7/common/BaseWithStorage/ERC721BaseToken.sol
+++ b/src/solc_0.7/common/BaseWithStorage/ERC721BaseToken.sol
@@ -428,23 +428,23 @@ contract ERC721BaseToken is ERC721Events, WithSuperOperators, WithMetaTransactio
         return (retval == _ERC721_BATCH_RECEIVED);
     }
 
-    /// @dev Function to test if a tx is a valid Sandbox or EIP-2771 metaTransaction
-    /// @param from The address passed as either "from" or "sender" to the external func which called this one
-    function _isValidMetaTx(address from) internal view returns (bool) {
-        uint256 processorType = _metaTransactionContracts[msg.sender];
-        if (msg.sender == from || processorType == 0) {
-            return false;
-        }
-        if (processorType == METATX_2771) {
-            if (from != _forceMsgSender()) {
-                return false;
-            } else {
-                return true;
-            }
-        } else if (processorType == METATX_SANDBOX) {
-            return true;
-        } else {
-            return false;
-        }
-    }
+    // /// @dev Function to test if a tx is a valid Sandbox or EIP-2771 metaTransaction
+    // /// @param from The address passed as either "from" or "sender" to the external func which called this one
+    // function _isValidMetaTx(address from) internal view returns (bool) {
+    //     uint256 processorType = _metaTransactionContracts[msg.sender];
+    //     if (msg.sender == from || processorType == 0) {
+    //         return false;
+    //     }
+    //     if (processorType == METATX_2771) {
+    //         if (from != _forceMsgSender()) {
+    //             return false;
+    //         } else {
+    //             return true;
+    //         }
+    //     } else if (processorType == METATX_SANDBOX) {
+    //         return true;
+    //     } else {
+    //         return false;
+    //     }
+    // }
 }

--- a/src/solc_0.7/common/BaseWithStorage/ERC721BaseToken.sol
+++ b/src/solc_0.7/common/BaseWithStorage/ERC721BaseToken.sol
@@ -427,24 +427,4 @@ contract ERC721BaseToken is ERC721Events, WithSuperOperators, WithMetaTransactio
         bytes4 retval = ERC721MandatoryTokenReceiver(to).onERC721BatchReceived(operator, from, ids, _data);
         return (retval == _ERC721_BATCH_RECEIVED);
     }
-
-    // /// @dev Function to test if a tx is a valid Sandbox or EIP-2771 metaTransaction
-    // /// @param from The address passed as either "from" or "sender" to the external func which called this one
-    // function _isValidMetaTx(address from) internal view returns (bool) {
-    //     uint256 processorType = _metaTransactionContracts[msg.sender];
-    //     if (msg.sender == from || processorType == 0) {
-    //         return false;
-    //     }
-    //     if (processorType == METATX_2771) {
-    //         if (from != _forceMsgSender()) {
-    //             return false;
-    //         } else {
-    //             return true;
-    //         }
-    //     } else if (processorType == METATX_SANDBOX) {
-    //         return true;
-    //     } else {
-    //         return false;
-    //     }
-    // }
 }

--- a/src/solc_0.7/common/BaseWithStorage/WithMetaTransaction.sol
+++ b/src/solc_0.7/common/BaseWithStorage/WithMetaTransaction.sol
@@ -61,4 +61,24 @@ contract WithMetaTransaction is WithAdmin {
             ret := shr(96, calldataload(sub(calldatasize(), 20)))
         }
     }
+
+    /// @dev Function to test if a tx is a valid Sandbox or EIP-2771 metaTransaction
+    /// @param from The address passed as either "from" or "sender" to the external func which called this one
+    function _isValidMetaTx(address from) internal view returns (bool) {
+        uint256 processorType = _metaTransactionContracts[msg.sender];
+        if (msg.sender == from || processorType == 0) {
+            return false;
+        }
+        if (processorType == METATX_2771) {
+            if (from != _forceMsgSender()) {
+                return false;
+            } else {
+                return true;
+            }
+        } else if (processorType == METATX_SANDBOX) {
+            return true;
+        } else {
+            return false;
+        }
+    }
 }


### PR DESCRIPTION
# Description
All in the title. I feel like other (non-ERC721) contracts will likely want to reuse the `_isValidMetaTx()` func, so this exposes it from the `WithMetaTransaction` contract.
<!--
Provide a summary of the changes made, and include some context, such as why the changes are needed. This is helpful to both reviewers, and for future reference.
-->

# Checklist:

- [ ] Pull Request references Jira issue
- [x] Pull Request applies to a single purpose
- [ ] I've added comments to my code where needed
- [ ] I've updated any relevant docs
- [ ] I've added tests to show that my changes achieve the desired results
- [x] I've reviewed my code
- [ ] I've followed established naming conventions and formatting
- [x] All tests are passing locally
