### PR TITLE
Adding permissions checks for burn functionality

### DIFF
--- a/src/solc_0.7/catalyst/GemsCatalystsRegistry.sol
+++ b/src/solc_0.7/catalyst/GemsCatalystsRegistry.sol
@@ -5,13 +5,13 @@ pragma experimental ABIEncoderV2;
 import "./Gem.sol";
 import "./CatalystToken.sol";
 import "./AssetAttributesRegistry.sol";
-import "../common/BaseWithStorage/WithAdmin.sol";
+import "../common/BaseWithStorage/WithSuperOperators.sol";
 
 /// @notice Contract managing the Gems and Catalysts
 /// Each Gems and Catalys must be registered here.
 /// Each new Gem get assigned a new id (starting at 1)
 /// Each new Catalyst get assigned a new id (starting at 1)
-contract GemsCatalystsRegistry is WithAdmin {
+contract GemsCatalystsRegistry is WithSuperOperators {
     Gem[] internal _gems;
     CatalystToken[] internal _catalysts;
 
@@ -116,6 +116,7 @@ contract GemsCatalystsRegistry is WithAdmin {
         uint16 catalystId,
         uint256 amount
     ) public {
+        require(msg.sender == from || isSuperOperator(msg.sender), "NOT_AUTHORIZED");
         CatalystToken catalyst = getCatalyst(catalystId);
         require(catalyst != CatalystToken(0), "CATALYST_DOES_NOT_EXIST");
         catalyst.burnFor(from, amount);
@@ -126,6 +127,7 @@ contract GemsCatalystsRegistry is WithAdmin {
         uint16 gemId,
         uint256 amount
     ) public {
+        require(msg.sender == from || isSuperOperator(msg.sender), "NOT_AUTHORIZED");
         Gem gem = getGem(gemId);
         require(gem != Gem(0), "GEM_DOES_NOT_EXIST");
         gem.burnFor(from, amount);

--- a/test/catalyst/fixtures.ts
+++ b/test/catalyst/fixtures.ts
@@ -4,7 +4,7 @@ import {
   getUnnamedAccounts,
   getNamedAccounts,
 } from 'hardhat';
-import {Contract, BigNumber} from 'ethers';
+import { Contract, BigNumber } from 'ethers';
 
 const exampleGemId = 6;
 const notInOrderGemId = 56;
@@ -30,6 +30,7 @@ export const setupGemsAndCatalysts = deployments.createFixture(async () => {
   } = await getNamedAccounts();
   const catalystOwner = users[0];
   const gemOwner = users[0];
+  const gemsCatalystsRegistrySuperOperator = users[1];
 
   await deployments.deploy(`Gem_Example`, {
     contract: 'Gem',
@@ -91,8 +92,13 @@ export const setupGemsAndCatalysts = deployments.createFixture(async () => {
     .connect(ethers.provider.getSigner(gemMinter))
     .setSuperOperator(gemsCatalystsRegistry.address, true);
 
+  await gemsCatalystsRegistry
+    .connect(ethers.provider.getSigner(gemsCatalystsRegistryAdmin))
+    .setSuperOperator(gemsCatalystsRegistrySuperOperator, true);
+
   return {
     gemsCatalystsRegistry,
+    gemsCatalystsRegistrySuperOperator,
     powerGem,
     defenseGem,
     speedGem,

--- a/test/catalyst/fixtures.ts
+++ b/test/catalyst/fixtures.ts
@@ -4,7 +4,7 @@ import {
   getUnnamedAccounts,
   getNamedAccounts,
 } from 'hardhat';
-import { Contract, BigNumber } from 'ethers';
+import {Contract, BigNumber} from 'ethers';
 
 const exampleGemId = 6;
 const notInOrderGemId = 56;

--- a/test/catalyst/gemsCatalystsRegistry.test.ts
+++ b/test/catalyst/gemsCatalystsRegistry.test.ts
@@ -39,6 +39,41 @@ describe('GemsCatalystsRegistry', function () {
     expect(totalSupplyAfter).to.equal(totalSupplyBefore.sub(burnAmount));
   });
 
+  it('burnCatalyst should burn 2 common catalysts from superOperator account', async function () {
+    const {
+      gemsCatalystsRegistry,
+      gemsCatalystsRegistrySuperOperator,
+      commonCatalyst,
+      catalystOwner,
+    } = await setupGemsAndCatalysts();
+    const catalystId = await commonCatalyst.catalystId();
+    const totalSupplyBefore = await commonCatalyst.totalSupply();
+    const balanceBeforeBurning = await commonCatalyst.balanceOf(catalystOwner);
+    const burnAmount = BigNumber.from('2');
+    await gemsCatalystsRegistry
+      .connect(ethers.provider.getSigner(gemsCatalystsRegistrySuperOperator))
+      .burnCatalyst(catalystOwner, catalystId, burnAmount);
+    const totalSupplyAfter = await commonCatalyst.totalSupply();
+    const balanceAfterBurning = await commonCatalyst.balanceOf(catalystOwner);
+    expect(balanceAfterBurning).to.equal(balanceBeforeBurning.sub(burnAmount));
+    expect(totalSupplyAfter).to.equal(totalSupplyBefore.sub(burnAmount));
+  });
+  it('burnCatalyst should fail for unauthorized account', async function () {
+    const {
+      gemsCatalystsRegistry,
+      commonCatalyst,
+      catalystOwner,
+    } = await setupGemsAndCatalysts();
+    const catalystId = await commonCatalyst.catalystId();
+    const burnAmount = BigNumber.from('2');
+    const users = await getUnnamedAccounts();
+    await expect(
+      gemsCatalystsRegistry
+        .connect(ethers.provider.getSigner(users[3]))
+        .burnCatalyst(catalystOwner, catalystId, burnAmount)
+    ).to.be.revertedWith('NOT_AUTHORIZED');
+  });
+
   it('burnCatalyst should fail for non existing catalystId', async function () {
     const {
       gemsCatalystsRegistry,
@@ -77,13 +112,13 @@ describe('GemsCatalystsRegistry', function () {
       gemsCatalystsRegistry,
       commonCatalyst,
     } = await setupGemsAndCatalysts();
-    const others = await getUnnamedAccounts();
+    const users = await getUnnamedAccounts();
     const catalystId = await commonCatalyst.catalystId();
     const burnAmount = BigNumber.from('200');
     await expect(
       gemsCatalystsRegistry
-        .connect(ethers.provider.getSigner(others[0]))
-        .burnGem(others[0], catalystId, burnAmount)
+        .connect(ethers.provider.getSigner(users[3]))
+        .burnGem(users[3], catalystId, burnAmount)
     ).to.be.revertedWith('Not enough funds');
   });
 
@@ -106,6 +141,41 @@ describe('GemsCatalystsRegistry', function () {
     expect(totalSupplyAfter).to.equal(totalSupplyBefore.sub(burnAmount));
   });
 
+  it('burnGem should burn 3 power gems from superOperator account', async function () {
+    const {
+      gemsCatalystsRegistry,
+      gemsCatalystsRegistrySuperOperator,
+      powerGem,
+      gemOwner,
+    } = await setupGemsAndCatalysts();
+    const gemId = await powerGem.gemId();
+    const totalSupplyBefore = await powerGem.totalSupply();
+    const balanceBeforeBurning = await powerGem.balanceOf(gemOwner);
+    const burnAmount = BigNumber.from('3');
+    await gemsCatalystsRegistry
+      .connect(ethers.provider.getSigner(gemsCatalystsRegistrySuperOperator))
+      .burnGem(gemOwner, gemId, burnAmount);
+    const balanceAfterBurning = await powerGem.balanceOf(gemOwner);
+    const totalSupplyAfter = await powerGem.totalSupply();
+    expect(balanceAfterBurning).to.equal(balanceBeforeBurning.sub(burnAmount));
+    expect(totalSupplyAfter).to.equal(totalSupplyBefore.sub(burnAmount));
+  });
+
+  it('burnGem should fail for unauthorized account', async function () {
+    const {
+      gemsCatalystsRegistry,
+      powerGem,
+      gemOwner,
+    } = await setupGemsAndCatalysts();
+    const gemId = await powerGem.gemId();
+    const burnAmount = BigNumber.from('2');
+    const users = await getUnnamedAccounts();
+    await expect(
+      gemsCatalystsRegistry
+        .connect(ethers.provider.getSigner(users[3]))
+        .burnGem(gemOwner, gemId, burnAmount)
+    ).to.be.revertedWith('NOT_AUTHORIZED');
+  });
   it('burnGem should fail for non existing gemId', async function () {
     const {gemsCatalystsRegistry, gemMinter} = await setupGemsAndCatalysts();
     const burnAmount = BigNumber.from('2');
@@ -133,13 +203,13 @@ describe('GemsCatalystsRegistry', function () {
 
   it('burnGem should fail for account with no gems', async function () {
     const {gemsCatalystsRegistry, powerGem} = await setupGemsAndCatalysts();
-    const others = await getUnnamedAccounts();
+    const users = await getUnnamedAccounts();
     const gemId = await powerGem.gemId();
     const burnAmount = BigNumber.from('200');
     expect(
       gemsCatalystsRegistry
-        .connect(ethers.provider.getSigner(others[0]))
-        .burnGem(others[0], gemId, burnAmount)
+        .connect(ethers.provider.getSigner(users[3]))
+        .burnGem(users[3], gemId, burnAmount)
     ).to.be.revertedWith('Not enough funds');
   });
 
@@ -215,10 +285,10 @@ describe('GemsCatalystsRegistry', function () {
 
   it('addGemsAndCatalysts should fail for unauthorized user', async function () {
     const {gemsCatalystsRegistry, gemExample} = await setupGemsAndCatalysts();
-    const others = await getUnnamedAccounts();
+    const users = await getUnnamedAccounts();
     await expect(
       gemsCatalystsRegistry
-        .connect(ethers.provider.getSigner(others[0]))
+        .connect(ethers.provider.getSigner(users[3]))
         .addGemsAndCatalysts([gemExample.address], [])
     ).to.be.revertedWith('NOT_AUTHORIZED');
   });

--- a/test/catalyst/gemsCatalystsRegistry.test.ts
+++ b/test/catalyst/gemsCatalystsRegistry.test.ts
@@ -15,7 +15,7 @@ describe('GemsCatalystsRegistry', function () {
 
   it('getMaxGems for non existing catalystId should fail', async function () {
     const {gemsCatalystsRegistry} = await setupGemsAndCatalysts();
-    expect(gemsCatalystsRegistry.getMaxGems(10)).to.be.revertedWith(
+    await expect(gemsCatalystsRegistry.getMaxGems(10)).to.be.revertedWith(
       'CATALYST_DOES_NOT_EXIST'
     );
   });
@@ -45,10 +45,15 @@ describe('GemsCatalystsRegistry', function () {
       gemsCatalystsRegistryAdmin,
     } = await setupGemsAndCatalysts();
     const burnAmount = BigNumber.from('2');
-    expect(
-      gemsCatalystsRegistry
-        .connect(ethers.provider.getSigner(gemsCatalystsRegistryAdmin))
-        .burnCatalyst(gemsCatalystsRegistryAdmin, 101, burnAmount)
+    const gemsCatalystsRegistryAsAdmin = await gemsCatalystsRegistry.connect(
+      ethers.provider.getSigner(gemsCatalystsRegistryAdmin)
+    );
+    await expect(
+      gemsCatalystsRegistryAsAdmin.burnCatalyst(
+        gemsCatalystsRegistryAdmin,
+        101,
+        burnAmount
+      )
     ).to.be.revertedWith('CATALYST_DOES_NOT_EXIST');
   });
 
@@ -60,7 +65,7 @@ describe('GemsCatalystsRegistry', function () {
     } = await setupGemsAndCatalysts();
     const catalystId = await commonCatalyst.catalystId();
     const burnAmount = BigNumber.from('200');
-    expect(
+    await expect(
       gemsCatalystsRegistry
         .connect(ethers.provider.getSigner(catalystMinter))
         .burnCatalyst(catalystMinter, catalystId, burnAmount)
@@ -75,7 +80,7 @@ describe('GemsCatalystsRegistry', function () {
     const others = await getUnnamedAccounts();
     const catalystId = await commonCatalyst.catalystId();
     const burnAmount = BigNumber.from('200');
-    expect(
+    await expect(
       gemsCatalystsRegistry
         .connect(ethers.provider.getSigner(others[0]))
         .burnGem(others[0], catalystId, burnAmount)
@@ -104,7 +109,7 @@ describe('GemsCatalystsRegistry', function () {
   it('burnGem should fail for non existing gemId', async function () {
     const {gemsCatalystsRegistry, gemMinter} = await setupGemsAndCatalysts();
     const burnAmount = BigNumber.from('2');
-    expect(
+    await expect(
       gemsCatalystsRegistry
         .connect(ethers.provider.getSigner(gemMinter))
         .burnGem(gemMinter, 101, burnAmount)
@@ -119,7 +124,7 @@ describe('GemsCatalystsRegistry', function () {
     } = await setupGemsAndCatalysts();
     const gemId = await powerGem.gemId();
     const burnAmount = BigNumber.from('200');
-    expect(
+    await expect(
       gemsCatalystsRegistry
         .connect(ethers.provider.getSigner(gemMinter))
         .burnGem(gemMinter, gemId, burnAmount)
@@ -145,7 +150,7 @@ describe('GemsCatalystsRegistry', function () {
       commonCatalyst,
       gemsCatalystsRegistryAdmin,
     } = await setupGemsAndCatalysts();
-    expect(
+    await expect(
       gemsCatalystsRegistry
         .connect(ethers.provider.getSigner(gemsCatalystsRegistryAdmin))
         .addGemsAndCatalysts([powerGem.address], [commonCatalyst.address])
@@ -158,7 +163,7 @@ describe('GemsCatalystsRegistry', function () {
       commonCatalyst,
       gemsCatalystsRegistryAdmin,
     } = await setupGemsAndCatalysts();
-    expect(
+    await expect(
       gemsCatalystsRegistry
         .connect(ethers.provider.getSigner(gemsCatalystsRegistryAdmin))
         .addGemsAndCatalysts([], [commonCatalyst.address])
@@ -201,7 +206,7 @@ describe('GemsCatalystsRegistry', function () {
       gemNotInOrder,
       gemsCatalystsRegistryAdmin,
     } = await setupGemsAndCatalysts();
-    expect(
+    await expect(
       gemsCatalystsRegistry
         .connect(ethers.provider.getSigner(gemsCatalystsRegistryAdmin))
         .addGemsAndCatalysts([gemNotInOrder.address], [])
@@ -211,11 +216,11 @@ describe('GemsCatalystsRegistry', function () {
   it('addGemsAndCatalysts should fail for unauthorized user', async function () {
     const {gemsCatalystsRegistry, gemExample} = await setupGemsAndCatalysts();
     const others = await getUnnamedAccounts();
-    expect(
+    await expect(
       gemsCatalystsRegistry
         .connect(ethers.provider.getSigner(others[0]))
         .addGemsAndCatalysts([gemExample.address], [])
-    ).to.be.revertedWith('GEM_ID_NOT_IN_ORDER');
+    ).to.be.revertedWith('NOT_AUTHORIZED');
   });
 
   it('burnDifferentGems for two different gem tokens', async function () {


### PR DESCRIPTION
# Description
burn functionality for gems and catalysts should be allowed only to token holders or super-operators.
Added tests to cover these cases.

# Checklist:

- [ ] Pull Request references Jira issue
- [x] Pull Request applies to a single purpose
- [ ] I've added comments to my code where needed
- [ ] I've updated any relevant docs
- [x] I've added tests to show that my changes achieve the desired results
- [x] I've reviewed my code
- [x] I've followed established naming conventions and formatting
- [x] All tests are passing locally
