### PR TITLE
Adding  _upgrader to AssetAttributesRegistry

### DIFF
--- a/deploy/04_catalyst/0063_deploy_asset_attributes_registry.ts
+++ b/deploy/04_catalyst/0063_deploy_asset_attributes_registry.ts
@@ -15,6 +15,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       GemsCatalystsRegistry.address,
       assetAttributesRegistryAdmin,
       assetAttributesRegistryAdmin,
+      assetAttributesRegistryAdmin,
     ],
   });
 };

--- a/deploy/9041_set_asset_attributes_registry_minter_upgrader.ts
+++ b/deploy/9041_set_asset_attributes_registry_minter_upgrader.ts
@@ -8,7 +8,9 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const {assetAttributesRegistryAdmin} = await getNamedAccounts();
 
   const registryMinter = await read('AssetAttributesRegistry', 'getMinter');
+  const registryUpgrader = await read('AssetAttributesRegistry', 'getUpgrader');
   const AssetMinter = await deployments.get('AssetMinter');
+  const AssetUpgrader = await deployments.get('AssetUpgrader');
 
   if (registryMinter !== AssetMinter.address) {
     await execute(
@@ -18,7 +20,20 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       AssetMinter.address
     );
   }
+
+  if (registryUpgrader !== AssetUpgrader.address) {
+    await execute(
+      'AssetAttributesRegistry',
+      {from: assetAttributesRegistryAdmin, log: true},
+      'changeUpgrader',
+      AssetUpgrader.address
+    );
+  }
 };
 export default func;
 func.tags = ['AssetAttributesRegistry', 'AssetAttributesRegistry_setup'];
-func.dependencies = ['AssetAttributesRegistry_deploy', 'AssetMinter_deploy'];
+func.dependencies = [
+  'AssetAttributesRegistry_deploy',
+  'AssetMinter_deploy',
+  'AssetUpgrader_deploy',
+];

--- a/src/solc_0.7/common/BaseWithStorage/WithUpgrader.sol
+++ b/src/solc_0.7/common/BaseWithStorage/WithUpgrader.sol
@@ -1,0 +1,31 @@
+//SPDX-License-Identifier: MIT
+pragma solidity 0.7.5;
+
+import "./WithAdmin.sol";
+
+contract WithUpgrader is WithAdmin {
+    address internal _upgrader;
+
+    /// @dev Emits when the Upgrader address is changed
+    /// @param oldUpgrader The previous Upgrader address
+    /// @param newUpgrader The new Upgrader address
+    event UpgraderChanged(address oldUpgrader, address newUpgrader);
+
+    modifier onlyUpgrader() {
+        require(msg.sender == _upgrader, "UPGRADER_ACCESS_DENIED");
+        _;
+    }
+
+    /// @dev Get the current upgrader of this contract.
+    /// @return The current upgrader of this contract.
+    function getUpgrader() external view returns (address) {
+        return _upgrader;
+    }
+
+    /// @dev Change the upgrader to be `newUpgrader`.
+    /// @param newUpgrader The address of the new upgrader.
+    function changeUpgrader(address newUpgrader) external onlyAdmin() {
+        emit UpgraderChanged(_upgrader, newUpgrader);
+        _upgrader = newUpgrader;
+    }
+}


### PR DESCRIPTION
# Description
I followed the pattern used for WithMinter to add a WithUpgrader contract.
It feels a bit like overkill as I don't foresee this being reused... but also the cleanest way to achieve what we need, which was to store an internal `_upgrader` address. This storage will likely need to same functionality as _minter (get, set, modifier, etc...) so seemed like the right approach.

Alternatives I considered included:
- using Openzeppelin's `accessControl` to enable RBAC here. Then we could just assign the minter role to multiple contracts. But it's better suited for when more granular access controls are needed. Our use-case is fairly simple.
- allowing the AssetUpgrader to access the AssetAttributesRegistry through the AssetMinter. I felt that this approach adds non-minter-specific functionality to the minter contract and that it's probably better/cleaner to keep these separate.

Note that this will require reworking some tests and fixtures/helpers in `/assetAttributesRegistry/` (ie: `/fixtures/setCatalyst`)
cc @CloverGuy 
<!--
Provide a summary of the changes made, and include some context, such as why the changes are needed. This is helpful to both reviewers, and for future reference.
-->

# Checklist:

- [ ] Pull Request references Jira issue
- [x] Pull Request applies to a single purpose
- [ ] I've added comments to my code where needed
- [ ] I've updated any relevant docs
- [ ] I've added tests to show that my changes achieve the desired results
- [ ] I've reviewed my code
- [ ] I've followed established naming conventions and formatting
- [ ] All tests are passing locally
