### PR TITLE
add addTrustlessGiveaway

### DIFF
--- a/src/solc_0.7/Utils/Clones.sol
+++ b/src/solc_0.7/Utils/Clones.sol
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.7.5;
+
+// adapted from https://github.com/OpenZeppelin/openzeppelin-contracts/blob/ee6348a7a0b08f82344f2b61e903788aa9dcf36c/contracts/proxy/Clones.sol
+
+/**
+ * @dev https://eips.ethereum.org/EIPS/eip-1167[EIP 1167] is a standard for
+ * deploying minimal proxy contracts, also known as "clones".
+ *
+ * > To simply and cheaply clone contract functionality in an immutable way, this standard specifies
+ * > a minimal bytecode implementation that delegates all calls to a known, fixed address.
+ *
+ * The library includes functions to deploy a proxy using either `create` (traditional deployment) or `create2`
+ * (salted deterministic deployment). It also includes functions to predict the addresses of clones deployed using the
+ * deterministic method.
+ *
+ * _Available since v3.4._
+ */
+library Clones {
+    /**
+     * @dev Deploys and returns the address of a clone that mimics the behaviour of `master`.
+     *
+     * This function uses the create opcode, which should never revert.
+     */
+    function clone(address master) internal returns (address instance) {
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            let ptr := mload(0x40)
+            mstore(ptr, 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000000000000000000000)
+            mstore(add(ptr, 0x14), shl(0x60, master))
+            mstore(add(ptr, 0x28), 0x5af43d82803e903d91602b57fd5bf30000000000000000000000000000000000)
+            instance := create(0, ptr, 0x37)
+        }
+        require(instance != address(0), "ERC1167: create failed");
+    }
+
+    /**
+     * @dev Deploys and returns the address of a clone that mimics the behaviour of `master`.
+     *
+     * This function uses the create2 opcode and a `salt` to deterministically deploy
+     * the clone. Using the same `master` and `salt` multiple time will revert, since
+     * the clones cannot be deployed twice at the same address.
+     */
+    function cloneDeterministic(address master, bytes32 salt) internal returns (address instance) {
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            let ptr := mload(0x40)
+            mstore(ptr, 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000000000000000000000)
+            mstore(add(ptr, 0x14), shl(0x60, master))
+            mstore(add(ptr, 0x28), 0x5af43d82803e903d91602b57fd5bf30000000000000000000000000000000000)
+            instance := create2(0, ptr, 0x37, salt)
+        }
+        require(instance != address(0), "ERC1167: create2 failed");
+    }
+
+    /**
+     * @dev Computes the address of a clone deployed using {Clones-cloneDeterministic}.
+     */
+    function predictDeterministicAddress(
+        address master,
+        bytes32 salt,
+        address deployer
+    ) internal pure returns (address predicted) {
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            let ptr := mload(0x40)
+            mstore(ptr, 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000000000000000000000)
+            mstore(add(ptr, 0x14), shl(0x60, master))
+            mstore(add(ptr, 0x28), 0x5af43d82803e903d91602b57fd5bf3ff00000000000000000000000000000000)
+            mstore(add(ptr, 0x38), shl(0x60, deployer))
+            mstore(add(ptr, 0x4c), salt)
+            mstore(add(ptr, 0x6c), keccak256(ptr, 0x37))
+            predicted := keccak256(add(ptr, 0x37), 0x55)
+        }
+    }
+
+    /**
+     * @dev Computes the address of a clone deployed using {Clones-cloneDeterministic}.
+     */
+    function predictDeterministicAddress(address master, bytes32 salt) internal view returns (address predicted) {
+        return predictDeterministicAddress(master, salt, address(this));
+    }
+}

--- a/src/solc_0.7/claims/MultiGiveaway/ImmutableHolder.sol
+++ b/src/solc_0.7/claims/MultiGiveaway/ImmutableHolder.sol
@@ -1,0 +1,31 @@
+//SPDX-License-Identifier: MIT
+pragma solidity 0.7.5;
+
+import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
+import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+contract ImmutableHolder {
+    uint256 internal constant MAX_UINT256 = 2**256 - 1;
+    bool internal _initialized;
+
+    function approve(
+        IERC721[] calldata erc721s,
+        IERC1155[] calldata erc1155s,
+        IERC20[] calldata erc20s
+    ) external {
+        require(!_initialized, "ALREADY_INITIALISED");
+        _initialized = true;
+        for (uint256 i = 0; i < erc721s.length; i++) {
+            erc721s[i].setApprovalForAll(msg.sender, true);
+        }
+        for (uint256 i = 0; i < erc1155s.length; i++) {
+            erc1155s[i].setApprovalForAll(msg.sender, true);
+        }
+        for (uint256 i = 0; i < erc20s.length; i++) {
+            erc20s[i].approve(msg.sender, MAX_UINT256);
+        }
+    }
+}

--- a/src/solc_0.7/claims/MultiGiveaway/MultiGiveaway.sol
+++ b/src/solc_0.7/claims/MultiGiveaway/MultiGiveaway.sol
@@ -6,6 +6,15 @@ import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 import "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
 import "./ClaimERC1155ERC721ERC20.sol";
 import "../../common/BaseWithStorage/WithAdmin.sol";
+import "../../Utils/Clones.sol";
+
+interface Holder {
+    function approve(
+        IERC721[] calldata erc721s,
+        IERC1155[] calldata erc1155s,
+        IERC20[] calldata erc20s
+    ) external;
+}
 
 /// @title MultiGiveaway contract.
 /// @notice This contract manages claims for multiple token types.
@@ -15,8 +24,13 @@ contract MultiGiveaway is WithAdmin, ClaimERC1155ERC721ERC20 {
     bytes4 internal constant ERC721_RECEIVED = 0x150b7a02;
     bytes4 internal constant ERC721_BATCH_RECEIVED = 0x4b808c46;
 
+    struct MerkleRootInfo {
+        uint96 expiryTime;
+        address holder;
+    }
+
     mapping(address => mapping(bytes32 => bool)) public claimed; // TODO: change to index mapping - see uniswap
-    mapping(bytes32 => uint256) internal _expiryTime;
+    mapping(bytes32 => MerkleRootInfo) internal _merkleRoots;
 
     constructor(address admin) {
         _admin = admin;
@@ -25,14 +39,36 @@ contract MultiGiveaway is WithAdmin, ClaimERC1155ERC721ERC20 {
     /// @notice Function to set the merkle root hash for the claim data.
     /// @param merkleRoot The merkle root hash of the claim data.
     /// @param expiryTime The expiry time for the giveaway.
-    function addNewGiveaway(bytes32 merkleRoot, uint256 expiryTime) external onlyAdmin {
-        _expiryTime[merkleRoot] = expiryTime;
+    function addNewGiveaway(bytes32 merkleRoot, uint96 expiryTime) external onlyAdmin {
+        _merkleRoots[merkleRoot] = MerkleRootInfo(expiryTime, address(this));
+        // TODO emit event
+    }
+
+    /// @notice Function to set the merkle root hash for the claim data.
+    /// @param merkleRoot The merkle root hash of the claim data.
+    /// @param expiryTime The expiry time for the giveaway.
+    /// @param holderCodeAddress the contract to clone from
+    /// @param erc721s list of erc721 to be approved by the holder (not that if one is missing the claim will not work)
+    /// @param erc1155s list of erc1155 to be approved by the holder (not that if one is missing the claim will not work)
+    /// @param erc20s list of erc20 to be approved by the holder (not that if one is missing the claim will not work)
+    function addGiveawayWithSeparateHolder(
+        bytes32 merkleRoot,
+        uint96 expiryTime,
+        address holderCodeAddress,
+        IERC721[] calldata erc721s,
+        IERC1155[] calldata erc1155s,
+        IERC20[] calldata erc20s
+    ) external onlyAdmin {
+        address holder = Clones.cloneDeterministic(holderCodeAddress, merkleRoot);
+        Holder(holder).approve(erc721s, erc1155s, erc20s);
+        _merkleRoots[merkleRoot] = MerkleRootInfo(expiryTime, holder);
+        // TODO emit event
     }
 
     /// @notice Function to check which giveaways have been claimed by a particular user.
     /// @param user The user (destination) address.
     /// @param rootHashes The array of giveaway root hashes to check.
-    function getClaimedStatus(address user, bytes32[] calldata rootHashes) external returns (bool[] memory) {
+    function getClaimedStatus(address user, bytes32[] calldata rootHashes) external view returns (bool[] memory) {
         bool[] memory claimedGiveaways = new bool[](rootHashes.length);
         for (uint256 i = 0; i < rootHashes.length; i++) {
             claimedGiveaways[i] = claimed[user][rootHashes[i]];
@@ -60,11 +96,12 @@ contract MultiGiveaway is WithAdmin, ClaimERC1155ERC721ERC20 {
     ) private {
         require(claim.to != address(0), "INVALID_TO_ZERO_ADDRESS");
         require(claim.to != address(this), "DESTINATION_MULTIGIVEAWAY_CONTRACT");
-        require(_expiryTime[merkleRoot] != 0, "GIVEAWAY_DOES_NOT_EXIST");
-        require(block.timestamp < _expiryTime[merkleRoot], "CLAIM_PERIOD_IS_OVER");
+        MerkleRootInfo memory info = _merkleRoots[merkleRoot];
+        require(info.expiryTime != 0, "GIVEAWAY_DOES_NOT_EXIST");
+        require(block.timestamp < info.expiryTime, "CLAIM_PERIOD_IS_OVER");
         require(claimed[claim.to][merkleRoot] == false, "DESTINATION_ALREADY_CLAIMED");
         claimed[claim.to][merkleRoot] = true;
-        _claimERC1155ERC721ERC20(merkleRoot, claim, proof);
+        _claimERC1155ERC721ERC20(info.holder, merkleRoot, claim, proof);
     }
 
     function onERC721Received(


### PR DESCRIPTION
# Description

This add a mechanism by which we can create trusltess claims while still have one contract to manage them all.
this is achieved through the creation of deterministic clone of a contract holder.
The holder code is initialised with a set of token contract  (that must matches the one used by claims) and it cannot be changed, ensuring only user of the claim can withdraw

# Checklist:

- [ ] Pull Request references Jira issue
- [ ] Pull Request applies to a single purpose
- [ ] I've added comments to my code where needed
- [ ] I've updated any relevant docs
- [ ] I've added tests to show that my changes achieve the desired results
- [ ] I've reviewed my code
- [ ] I've followed established naming conventions and formatting
- [ ] All tests are passing locally
