### PR TITLE
Refactor of Asset metaTx support

### DIFF
--- a/deploy/06_asset/06_upgrade_to_asset_v2.ts
+++ b/deploy/06_asset/06_upgrade_to_asset_v2.ts
@@ -10,48 +10,6 @@ const func: DeployFunction = async function (
 
   const forwarder = await deployments.get('TestMetaTxForwarder');
 
-  /**
-  const {deployments, getNamedAccounts, getChainId} = hre;
-  const chainId = await getChainId();
-
-  class Minter {
-    minter: string;
-    allowedToMint: boolean;
-    constructor(address: string, allowed: boolean) {
-      this.minter = address;
-      this.allowedToMint = allowed;
-    }
-  }
-
-  for hardhat-network testing we set some simple EOA minters as expected by tests:
-  const dummyMinter = otherAccounts[0];
-  const dummyMinter1 = otherAccounts[1];
-
-  async function getNetworkMinters(chain: string): Promise<Minter[]> {
-    const minterArray: Minter[] = [];
-    let allowed: boolean[];
-    let addresses: string[];
-
-    if (chain == '31337') {
-      addresses = [assetMinter.address, dummyMinter, dummyMinter1];
-      allowed = [true, true, true];
-      for (let i = 0; i < addresses.length; i++) {
-        minterArray.push(new Minter(addresses[i], allowed[i]));
-      }
-    } else {
-      addresses = [assetMinter.address];
-      allowed = [true];
-      for (let i = 0; i < addresses.length; i++) {
-        minterArray.push(new Minter(addresses[i], allowed[i]));
-      }
-    }
-    return minterArray;
-  }
-
-  const networkMinters = await getNetworkMinters(chainId);
-
-
-  */
   await deploy('Asset', {
     from: deployer,
     contract: 'AssetV2',

--- a/deploy/06_asset/07_set_assetV2_bouncers.ts
+++ b/deploy/06_asset/07_set_assetV2_bouncers.ts
@@ -29,7 +29,6 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     );
   }
   // @review do we want this on new asset, or just for testing?
-  // probably need to set up a dummy-asset on hardhat network
   if (!isCatalystMinterBouncer) {
     await execute(
       'Asset',

--- a/deploy/06_asset/07_set_assetV2_bouncers.ts
+++ b/deploy/06_asset/07_set_assetV2_bouncers.ts
@@ -1,0 +1,48 @@
+import {HardhatRuntimeEnvironment} from 'hardhat/types';
+import {DeployFunction} from 'hardhat-deploy/types';
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const {deployments, getNamedAccounts} = hre;
+  const {execute, read} = deployments;
+
+  const {assetBouncerAdmin} = await getNamedAccounts();
+  const assetMinter = await deployments.get('AssetMinter');
+  const catalystMinter = await deployments.get('OldCatalystMinter');
+  const isAssetMinterBouncer = await read(
+    'Asset',
+    'isBouncer',
+    assetMinter.address
+  );
+  const isCatalystMinterBouncer = await read(
+    'Asset',
+    'isBouncer',
+    catalystMinter.address
+  );
+
+  if (!isAssetMinterBouncer) {
+    await execute(
+      'Asset',
+      {from: assetBouncerAdmin, log: true},
+      'setBouncer',
+      assetMinter.address,
+      true
+    );
+  }
+  // @review do we want this on new asset, or just for testing?
+  // probably need to set up a dummy-asset on hardhat network
+  if (!isCatalystMinterBouncer) {
+    await execute(
+      'Asset',
+      {from: assetBouncerAdmin, log: true},
+      'setBouncer',
+      catalystMinter.address,
+      true
+    );
+  }
+};
+export default func;
+func.runAtTheEnd = true;
+func.tags = ['AssetV2', 'AssetV2_setup'];
+func.dependencies = ['AssetV2_deploy'];
+func.skip = async (hre) => hre.network.name !== 'hardhat'; // disabled for now
+// TODO should move it as part of catalyst deploy scripts folder

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "mocha": "^8.1.1",
     "prando": "^5.1.2",
     "prettier": "^2.0.5",
-    "prettier-plugin-solidity": "^1.0.0-beta.6 ",
+    "prettier-plugin-solidity": "^1.0.0-beta.10 ",
     "readline": "^1.3.0",
     "solhint": "^3.3.4",
     "solhint-plugin-prettier": "^0.0.5",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "mocha": "^8.1.1",
     "prando": "^5.1.2",
     "prettier": "^2.0.5",
-    "prettier-plugin-solidity": "^1.0.0-beta.10 ",
+    "prettier-plugin-solidity": "^1.0.0-beta.6 ",
     "readline": "^1.3.0",
     "solhint": "^3.3.4",
     "solhint-plugin-prettier": "^0.0.5",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@openzeppelin/contracts": "^3.2.1-solc-0.7",
     "@openzeppelin/contracts-0.6": "npm:@openzeppelin/contracts@latest",
     "@openzeppelin/contracts-0.8": "npm:@openzeppelin/contracts@4.0.0",
+    "@openzeppelin/contracts-upgradeable": "^4.0.0",
     "@openzeppelin/hardhat-upgrades": "^1.4.3",
     "@types/chai": "^4.2.11",
     "@types/fs-extra": "^9.0.6",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "mocha": "^8.1.1",
     "prando": "^5.1.2",
     "prettier": "^2.0.5",
-    "prettier-plugin-solidity": "^1.0.0-beta.6 ",
+    "prettier-plugin-solidity": "^1.0.0-beta.6",
     "readline": "^1.3.0",
     "solhint": "^3.3.4",
     "solhint-plugin-prettier": "^0.0.5",

--- a/src/solc_0.8/asset/ERC1155ERC721.sol
+++ b/src/solc_0.8/asset/ERC1155ERC721.sol
@@ -200,7 +200,7 @@ contract ERC1155ERC721 is WithSuperOperators, IERC1155, IERC721, ERC2771Context 
         require(to != address(0), "TO==0");
         require(from != address(0), "FROM==0");
         address sender = _msgSender();
-        bool metaTx = isTrustedForwarder(sender);
+        bool metaTx = isTrustedForwarder(msg.sender);
         bool authorized = from == sender || isApprovedForAll(from, sender);
 
         _batchTransferFrom(from, to, ids, values, authorized);
@@ -374,7 +374,7 @@ contract ERC1155ERC721 is WithSuperOperators, IERC1155, IERC721, ERC2771Context 
         address to
     ) external returns (uint256 newId) {
         address msgSender = _msgSender();
-        bool metaTx = isTrustedForwarder(msgSender);
+        bool metaTx = isTrustedForwarder(msg.sender);
         require(sender == msgSender || isApprovedForAll(sender, msgSender), "!AUTHORIZED");
         return _extractERC721From(metaTx ? sender : msgSender, sender, id, to);
     }
@@ -879,7 +879,7 @@ contract ERC1155ERC721 is WithSuperOperators, IERC1155, IERC721, ERC2771Context 
         require(to != address(0), "TO==0");
         require(from != address(0), "FROM==0");
         address sender = _msgSender();
-        metaTx = isTrustedForwarder(sender);
+        metaTx = isTrustedForwarder(msg.sender);
         bool authorized = from == sender || isApprovedForAll(from, sender);
 
         if (id & IS_NFT > 0) {

--- a/src/solc_0.8/asset/ERC1155ERC721.sol
+++ b/src/solc_0.8/asset/ERC1155ERC721.sol
@@ -14,7 +14,6 @@ import "../common/interfaces/IERC721TokenReceiver.sol";
 import "../common/BaseWithStorage/WithSuperOperators.sol";
 import "../common/Libraries/ERC2771Context.sol";
 
-
 contract ERC1155ERC721 is WithSuperOperators, IERC1155, IERC721, ERC2771Context {
     using Address for address;
     using ObjectLib32 for ObjectLib32.Operations;
@@ -87,7 +86,6 @@ contract ERC1155ERC721 is WithSuperOperators, IERC1155, IERC721, ERC2771Context 
         _admin = admin;
         _bouncerAdmin = bouncerAdmin;
         ERC2771Context.initialize(trustedForwarder);
-
     }
 
     /// @notice Change the minting administrator to be `newBouncerAdmin`.
@@ -179,7 +177,7 @@ contract ERC1155ERC721 is WithSuperOperators, IERC1155, IERC721, ERC2771Context 
         }
         bool metaTx = _transferFrom(from, to, id, value);
         require(
-            _checkERC1155AndCallSafeTransfer(metaTx? from : msg.sender, from, to, id, value, data, false, false),
+            _checkERC1155AndCallSafeTransfer(metaTx ? from : msg.sender, from, to, id, value, data, false, false),
             "1155_TRANSFER_REJECTED"
         );
     }
@@ -285,7 +283,7 @@ contract ERC1155ERC721 is WithSuperOperators, IERC1155, IERC721, ERC2771Context 
         address owner = _ownerOf(id);
         address sender = _msgSender();
         require(owner != address(0), "NFT_!EXIST");
-        require(owner ==sender || isApprovedForAll(owner, sender), "!AUTHORIZED");
+        require(owner == sender || isApprovedForAll(owner, sender), "!AUTHORIZED");
         _erc721operators[id] = operator;
         emit Approval(owner, operator, id);
     }

--- a/src/solc_0.8/asset/ERC1155ERC721.sol
+++ b/src/solc_0.8/asset/ERC1155ERC721.sol
@@ -12,9 +12,9 @@ import "../common/interfaces/IERC721.sol";
 import "../common/interfaces/IERC721TokenReceiver.sol";
 
 import "../common/BaseWithStorage/WithSuperOperators.sol";
-import "../common/Libraries/ERC2771Context.sol";
+import "../common/Libraries/ERC2771Handler.sol";
 
-contract ERC1155ERC721 is WithSuperOperators, IERC1155, IERC721, ERC2771Context {
+contract ERC1155ERC721 is WithSuperOperators, IERC1155, IERC721, ERC2771Handler {
     using Address for address;
     using ObjectLib32 for ObjectLib32.Operations;
     using ObjectLib32 for uint256;
@@ -85,7 +85,7 @@ contract ERC1155ERC721 is WithSuperOperators, IERC1155, IERC721, ERC2771Context 
         _checkInit(2);
         _admin = admin;
         _bouncerAdmin = bouncerAdmin;
-        ERC2771Context.initialize(trustedForwarder);
+        ERC2771Handler.__ERC2771Handler_initialize(trustedForwarder);
     }
 
     /// @notice Change the minting administrator to be `newBouncerAdmin`.

--- a/src/solc_0.8/asset/ERC1155ERC721.sol
+++ b/src/solc_0.8/asset/ERC1155ERC721.sol
@@ -782,10 +782,10 @@ contract ERC1155ERC721 is WithSuperOperators, IERC1155, IERC721, ERC2771Context 
         address sender = _msgSender();
         if ((id & IS_NFT) > 0) {
             require(amount == 1, "AMOUNT!=1");
-            _burnERC721(isTrustedForwarder(sender) ? from : sender, from, id);
+            _burnERC721(isTrustedForwarder(msg.sender) ? from : sender, from, id);
         } else {
             require(amount > 0 && amount <= MAX_SUPPLY, "INVALID_AMOUNT");
-            _burnERC1155(isTrustedForwarder(sender) ? from : sender, from, id, uint32(amount));
+            _burnERC1155(isTrustedForwarder(msg.sender) ? from : sender, from, id, uint32(amount));
         }
     }
 
@@ -1003,7 +1003,7 @@ contract ERC1155ERC721 is WithSuperOperators, IERC1155, IERC721, ERC2771Context 
     /// @return whether authorized or not.
     function _isAuthorized(address from) internal view returns (bool) {
         address sender = _msgSender();
-        require(sender == from || isTrustedForwarder(sender), "AUTH_ACCESS_DENIED");
+        require(sender == from || isTrustedForwarder(msg.sender), "AUTH_ACCESS_DENIED");
         return true;
     }
 

--- a/src/solc_0.8/asset/ERC1155ERC721.sol
+++ b/src/solc_0.8/asset/ERC1155ERC721.sol
@@ -220,7 +220,8 @@ contract ERC1155ERC721 is WithSuperOperators, IERC1155, IERC721, ERC2771Context 
         address original,
         address to
     ) external {
-        require(sender == _msgSender() || _superOperators[_msgSender()], "!AUTHORIZED");
+        address msgSender = _msgSender();
+        require(sender == msgSender || _superOperators[msgSender], "!AUTHORIZED");
         require(sender != address(0), "SENDER==0");
         require(to != address(0), "TO==0");
         address current = _creatorship[original];
@@ -247,7 +248,8 @@ contract ERC1155ERC721 is WithSuperOperators, IERC1155, IERC721, ERC2771Context 
         address operator,
         bool approved
     ) external {
-        require(sender == _msgSender() || _superOperators[_msgSender()], "!AUTHORIZED");
+        address msgSender = _msgSender();
+        require(sender == msgSender || _superOperators[msgSender], "!AUTHORIZED");
         _setApprovalForAll(sender, operator, approved);
     }
 
@@ -269,8 +271,9 @@ contract ERC1155ERC721 is WithSuperOperators, IERC1155, IERC721, ERC2771Context 
         uint256 id
     ) external {
         address owner = _ownerOf(id);
+        address msgSender = _msgSender();
         require(sender != address(0), "SENDER==0");
-        require(sender == _msgSender() || isApprovedForAll(sender, _msgSender()), "!AUTHORIZED");
+        require(sender == msgSender || isApprovedForAll(sender, msgSender), "!AUTHORIZED");
         require(owner == sender, "OWNER!=SENDER");
         _erc721operators[id] = operator;
         emit Approval(owner, operator, id);

--- a/src/solc_0.8/asset/ERC1155ERC721.sol
+++ b/src/solc_0.8/asset/ERC1155ERC721.sol
@@ -220,7 +220,7 @@ contract ERC1155ERC721 is WithSuperOperators, IERC1155, IERC721, ERC2771Context 
         address original,
         address to
     ) external {
-        require(_isAuthorized(sender) || _superOperators[_msgSender()], "!AUTHORIZED");
+        require(sender == _msgSender() || _superOperators[_msgSender()], "!AUTHORIZED");
         require(sender != address(0), "SENDER==0");
         require(to != address(0), "TO==0");
         address current = _creatorship[original];
@@ -247,7 +247,7 @@ contract ERC1155ERC721 is WithSuperOperators, IERC1155, IERC721, ERC2771Context 
         address operator,
         bool approved
     ) external {
-        require(_isAuthorized(sender) || _superOperators[_msgSender()], "!AUTHORIZED");
+        require(sender == _msgSender() || _superOperators[_msgSender()], "!AUTHORIZED");
         _setApprovalForAll(sender, operator, approved);
     }
 
@@ -270,7 +270,7 @@ contract ERC1155ERC721 is WithSuperOperators, IERC1155, IERC721, ERC2771Context 
     ) external {
         address owner = _ownerOf(id);
         require(sender != address(0), "SENDER==0");
-        require(_isAuthorized(sender) || isApprovedForAll(sender, _msgSender()), "!AUTHORIZED");
+        require(sender == _msgSender() || isApprovedForAll(sender, _msgSender()), "!AUTHORIZED");
         require(owner == sender, "OWNER!=SENDER");
         _erc721operators[id] = operator;
         emit Approval(owner, operator, id);
@@ -326,8 +326,7 @@ contract ERC1155ERC721 is WithSuperOperators, IERC1155, IERC721, ERC2771Context 
         uint256 id,
         uint256 amount
     ) external {
-        require(from != address(0), "FROM==0");
-        require(_isAuthorized(from) || isApprovedForAll(from, _msgSender()), "!AUTHORIZED");
+        require(from == _msgSender() || isApprovedForAll(from, _msgSender()), "!AUTHORIZED");
         _burn(from, id, amount);
     }
 
@@ -996,15 +995,6 @@ contract ERC1155ERC721 is WithSuperOperators, IERC1155, IERC721, ERC2771Context 
         // (10000 / 63) "not enough for supportsInterface(...)" // consume all gas, so caller can potentially know that there was not enough gas
         assert(gasleft() > 158);
         return success && result;
-    }
-
-    /// @dev Check if address from is authorized to perform an action.
-    /// @param from The address to check from.
-    /// @return whether authorized or not.
-    function _isAuthorized(address from) internal view returns (bool) {
-        address sender = _msgSender();
-        require(sender == from || isTrustedForwarder(msg.sender), "AUTH_ACCESS_DENIED");
-        return true;
     }
 
     function _checkEnoughBalance(

--- a/src/solc_0.8/common/Libraries/ERC2771Context.sol
+++ b/src/solc_0.8/common/Libraries/ERC2771Context.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+/// @dev upgradable variant of openzeppelin contract.
+/// src: https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/metatx/ERC2771Context.sol
+
+contract ERC2771Context {
+    address internal _trustedForwarder;
+
+    function initialize(address forwarder) internal {
+      _trustedForwarder = forwarder;
+    }
+
+    function isTrustedForwarder(address forwarder) public view virtual returns(bool) {
+        return forwarder == _trustedForwarder;
+    }
+
+    function _msgSender() internal view virtual returns (address sender) {
+        if (isTrustedForwarder(msg.sender)) {
+            // The assembly code is more direct than the Solidity version using `abi.decode`.
+            assembly { sender := shr(96, calldataload(sub(calldatasize(), 20))) }
+        } else {
+            return msg.sender;
+        }
+    }
+
+    function _msgData() internal view virtual returns (bytes calldata) {
+        if (isTrustedForwarder(msg.sender)) {
+            return msg.data[:msg.data.length-20];
+        } else {
+            return msg.data;
+        }
+    }
+}

--- a/src/solc_0.8/common/Libraries/ERC2771Context.sol
+++ b/src/solc_0.8/common/Libraries/ERC2771Context.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-
+// solhint-disable-next-line compiler-version
 pragma solidity ^0.8.0;
 
 /// @dev upgradable variant of openzeppelin contract.
@@ -12,20 +12,21 @@ contract ERC2771Context {
       _trustedForwarder = forwarder;
     }
 
-    function isTrustedForwarder(address forwarder) public view virtual returns(bool) {
+    function isTrustedForwarder(address forwarder) public view returns(bool) {
         return forwarder == _trustedForwarder;
     }
 
-    function _msgSender() internal view virtual returns (address sender) {
+    function _msgSender() internal view returns (address sender) {
         if (isTrustedForwarder(msg.sender)) {
             // The assembly code is more direct than the Solidity version using `abi.decode`.
+            // solhint-disable-next-line no-inline-assembly
             assembly { sender := shr(96, calldataload(sub(calldatasize(), 20))) }
         } else {
             return msg.sender;
         }
     }
 
-    function _msgData() internal view virtual returns (bytes calldata) {
+    function _msgData() internal view returns (bytes calldata) {
         if (isTrustedForwarder(msg.sender)) {
             return msg.data[:msg.data.length-20];
         } else {

--- a/src/solc_0.8/common/Libraries/ERC2771Context.sol
+++ b/src/solc_0.8/common/Libraries/ERC2771Context.sol
@@ -9,10 +9,10 @@ contract ERC2771Context {
     address internal _trustedForwarder;
 
     function initialize(address forwarder) internal {
-      _trustedForwarder = forwarder;
+        _trustedForwarder = forwarder;
     }
 
-    function isTrustedForwarder(address forwarder) public view returns(bool) {
+    function isTrustedForwarder(address forwarder) public view returns (bool) {
         return forwarder == _trustedForwarder;
     }
 
@@ -20,7 +20,9 @@ contract ERC2771Context {
         if (isTrustedForwarder(msg.sender)) {
             // The assembly code is more direct than the Solidity version using `abi.decode`.
             // solhint-disable-next-line no-inline-assembly
-            assembly { sender := shr(96, calldataload(sub(calldatasize(), 20))) }
+            assembly {
+                sender := shr(96, calldataload(sub(calldatasize(), 20)))
+            }
         } else {
             return msg.sender;
         }
@@ -28,7 +30,7 @@ contract ERC2771Context {
 
     function _msgData() internal view returns (bytes calldata) {
         if (isTrustedForwarder(msg.sender)) {
-            return msg.data[:msg.data.length-20];
+            return msg.data[:msg.data.length - 20];
         } else {
             return msg.data;
         }

--- a/src/solc_0.8/common/Libraries/ERC2771Handler.sol
+++ b/src/solc_0.8/common/Libraries/ERC2771Handler.sol
@@ -2,13 +2,13 @@
 // solhint-disable-next-line compiler-version
 pragma solidity ^0.8.0;
 
-/// @dev upgradable variant of openzeppelin contract.
-/// src: https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/metatx/ERC2771Context.sol
+/// @dev minimal ERC2771 handler to keep bytecode-size down.
+/// based on: https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/metatx/ERC2771Context.sol
 
-contract ERC2771Context {
+contract ERC2771Handler {
     address internal _trustedForwarder;
 
-    function initialize(address forwarder) internal {
+    function __ERC2771Handler_initialize(address forwarder) internal {
         _trustedForwarder = forwarder;
     }
 

--- a/src/solc_0.8/common/Libraries/ObjectLib32.sol
+++ b/src/solc_0.8/common/Libraries/ObjectLib32.sol
@@ -17,9 +17,7 @@ library ObjectLib32 {
     /// @return bin Bin number.
     /// @return index ID's index within that bin.
     function getTokenBinIndex(uint256 tokenId) internal pure returns (uint256 bin, uint256 index) {
-        unchecked {
-            bin = (tokenId * TYPES_BITS_SIZE) / 256;
-        }
+        unchecked {bin = (tokenId * TYPES_BITS_SIZE) / 256;}
         index = tokenId % TYPES_PER_UINT256;
         return (bin, index);
     }

--- a/test/asset/asset.test.ts
+++ b/test/asset/asset.test.ts
@@ -76,12 +76,24 @@ describe('Asset.sol', function () {
   });
 
   describe('Asset: MetaTransactions', function () {
-    it('metaaaaaa-TTT-X!', async function () {
-      const {Asset, users} = await setupAsset();
-      const {to, data} = await Asset.populateTransaction.mint();
-      console.log('yo!');
+    it('can transfer by metaTx', async function () {
+      const {Asset, users, mintAsset, forwarder} = await setupAsset();
+      const tokenId = await mintAsset(users[1].address, 11);
+      // await waitFor(
+      //   users[0].Asset[
+      //     'safeTransferFrom(address,address,uint256,uint256,bytes)'
+      //   ](users[1].address, users[2].address, tokenId, 10, '0x')
+      // );
+      const {to, data} = await Asset.populateTransaction[
+        'safeTransferFrom(address,address,uint256,uint256,bytes)'
+      ](users[1].address, users[2].address, tokenId, 10, '0x');
 
-      // await sendMetaTx();
+      await sendMetaTx(to, forwarder, data, users[1].address);
+      const balance = await Asset['balanceOf(address,uint256)'](
+        users[2].address,
+        tokenId
+      );
+      expect(balance).to.be.equal(10);
     });
   });
 });

--- a/test/asset/asset.test.ts
+++ b/test/asset/asset.test.ts
@@ -1,6 +1,7 @@
 import {setupAsset} from './fixtures';
 import {waitFor} from '../utils';
 import {expect} from '../chai-setup';
+import {sendMetaTx} from './sendMetaTx';
 
 describe('Asset.sol', function () {
   it('user sending asset to itself keep the same balance', async function () {
@@ -72,5 +73,15 @@ describe('Asset.sol', function () {
         '0x'
       )
     ).to.be.revertedWith(`BALANCE_TOO_LOW`);
+  });
+
+  describe('Asset: MetaTransactions', function () {
+    it('metaaaaaa-TTT-X!', async function () {
+      const {Asset, users} = await setupAsset();
+      const {to, data} = await Asset.populateTransaction.mint();
+      console.log('yo!');
+
+      // await sendMetaTx();
+    });
   });
 });

--- a/test/asset/fixtures.ts
+++ b/test/asset/fixtures.ts
@@ -24,6 +24,7 @@ export const setupAsset = deployments.createFixture(async function () {
   );
   await waitFor(assetContractAsBouncerAdmin.setBouncer(minter, true));
   const Asset = await ethers.getContract('Asset', minter);
+  const forwarder = await ethers.getContract('TestMetaTxForwarder');
 
   let id = 0;
   const ipfsHashString =
@@ -63,5 +64,6 @@ export const setupAsset = deployments.createFixture(async function () {
     Asset,
     users,
     mintAsset,
+    forwarder,
   };
 });

--- a/test/asset/sendMetaTx.ts
+++ b/test/asset/sendMetaTx.ts
@@ -1,0 +1,29 @@
+import {ethers} from 'hardhat';
+import {Contract} from 'ethers';
+import {data712} from '../forwardRequestData712';
+
+export async function sendMetaTx(
+  to = '',
+  forwarder: Contract,
+  data = '',
+  signer: string,
+  gas = '100000',
+  value = '0'
+): Promise<void> {
+  const message = {
+    from: signer,
+    to: to,
+    value: value,
+    gas: gas,
+    nonce: Number(await forwarder.getNonce(signer)),
+    data: data,
+  };
+
+  const forwardRequestData = await data712(forwarder, message);
+  const signedData = await ethers.provider.send('eth_signTypedData_v4', [
+    signer,
+    forwardRequestData,
+  ]);
+
+  await forwarder.execute(message, signedData);
+}

--- a/test/forwardRequestData712.ts
+++ b/test/forwardRequestData712.ts
@@ -1,0 +1,85 @@
+type Message = {
+  from: string;
+  to: string;
+  value: string;
+  gas: string;
+  nonce: number;
+  data: string;
+};
+
+type Contract = {
+  address: string;
+};
+
+type Data712 = {
+  types: {
+    EIP712Domain: [
+      {
+        name: 'name';
+        type: 'string';
+      },
+      {
+        name: 'version';
+        type: 'string';
+      },
+      {
+        name: 'verifyingContract';
+        type: 'address';
+      }
+    ];
+    ForwardRequest: [
+      {name: 'from'; type: 'address'},
+      {name: 'to'; type: 'address'},
+      {name: 'value'; type: 'uint256'},
+      {name: 'gas'; type: 'uint256'},
+      {name: 'nonce'; type: 'uint256'},
+      {name: 'data'; type: 'bytes'}
+    ];
+  };
+  primaryType: 'ForwardRequest';
+  domain: {
+    name: 'The Sandbox';
+    version: '1';
+    verifyingContract: string;
+  };
+  message: Message;
+};
+
+export const data712 = async function (
+  verifyingContract: Contract,
+  message: Message
+): Promise<Data712> {
+  return {
+    types: {
+      EIP712Domain: [
+        {
+          name: 'name',
+          type: 'string',
+        },
+        {
+          name: 'version',
+          type: 'string',
+        },
+        {
+          name: 'verifyingContract',
+          type: 'address',
+        },
+      ],
+      ForwardRequest: [
+        {name: 'from', type: 'address'},
+        {name: 'to', type: 'address'},
+        {name: 'value', type: 'uint256'},
+        {name: 'gas', type: 'uint256'},
+        {name: 'nonce', type: 'uint256'},
+        {name: 'data', type: 'bytes'},
+      ],
+    },
+    primaryType: 'ForwardRequest',
+    domain: {
+      name: 'The Sandbox',
+      version: '1',
+      verifyingContract: verifyingContract.address,
+    },
+    message: message,
+  };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -7799,7 +7799,7 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-"prettier-plugin-solidity@^1.0.0-beta.6 ":
+"prettier-plugin-solidity@^1.0.0-beta.10 ":
   version "1.0.0-beta.10"
   resolved "https://registry.yarnpkg.com/prettier-plugin-solidity/-/prettier-plugin-solidity-1.0.0-beta.10.tgz#f2a249002733826b08d981b599335ddb7e93af8d"
   integrity sha512-55UsEbeJfqYKB3RFR7Nvpi+ApEoUfgdKHVg2ZybrbOkRW4RTblyONLL3mEr8Vrxpo7wBbObVLbWodGg4YXIQ7g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1073,10 +1073,10 @@
   resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.11.1.tgz#fa840af64840c930f24a9c82c08d4a092a068add"
   integrity sha512-H8BSBoKE8EubJa0ONqecA2TviT3TnHeC4NpgnAHSUiuhZoQBfPB4L2P9bs8R6AoTW10Endvh3vc+fomVMIDIYQ==
 
-"@solidity-parser/parser@^0.12.0":
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.12.0.tgz#18a0fb2a9d2484b23176f63b16093c64794fc323"
-  integrity sha512-DT3f/Aa4tQysZwUsuqBwvr8YRJzKkvPUKV/9o2/o5EVw3xqlbzmtx4O60lTUcZdCawL+N8bBLNUyOGpHjGlJVQ==
+"@solidity-parser/parser@^0.12.0", "@solidity-parser/parser@^0.12.1":
+  version "0.12.2"
+  resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.12.2.tgz#1afad367cb29a2ed8cdd4a3a62701c2821fb578f"
+  integrity sha512-d7VS7PxgMosm5NyaiyDJRNID5pK4AWj1l64Dbz0147hJgy5k2C0/ZiKK/9u5c5K+HRUVHmp+RMvGEjGh84oA5Q==
 
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
@@ -3465,7 +3465,7 @@ emoji-regex@^8.0.0:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
-emoji-regex@^9.2.1:
+emoji-regex@^9.2.2:
   version "9.2.2"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
   integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
@@ -7800,18 +7800,18 @@ prettier-linter-helpers@^1.0.0:
     fast-diff "^1.1.2"
 
 "prettier-plugin-solidity@^1.0.0-beta.6 ":
-  version "1.0.0-beta.6"
-  resolved "https://registry.yarnpkg.com/prettier-plugin-solidity/-/prettier-plugin-solidity-1.0.0-beta.6.tgz#aa7b14a60cd6e22e46db75c84d836b569fb63f65"
-  integrity sha512-WymLqd22Hl93t5+HDNLk08TAWp4i4vZMhpihuVqkwOApjCT7mH1qwhLtvf3m+NdU//qj8vrPDmMoT+xc74skcg==
+  version "1.0.0-beta.10"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-solidity/-/prettier-plugin-solidity-1.0.0-beta.10.tgz#f2a249002733826b08d981b599335ddb7e93af8d"
+  integrity sha512-55UsEbeJfqYKB3RFR7Nvpi+ApEoUfgdKHVg2ZybrbOkRW4RTblyONLL3mEr8Vrxpo7wBbObVLbWodGg4YXIQ7g==
   dependencies:
-    "@solidity-parser/parser" "^0.12.0"
+    "@solidity-parser/parser" "^0.12.1"
     dir-to-object "^2.0.0"
-    emoji-regex "^9.2.1"
+    emoji-regex "^9.2.2"
     escape-string-regexp "^4.0.0"
     prettier "^2.2.1"
-    semver "^7.3.4"
-    solidity-comments-extractor "^0.0.4"
-    string-width "^4.2.0"
+    semver "^7.3.5"
+    solidity-comments-extractor "^0.0.7"
+    string-width "^4.2.2"
 
 prettier@^1.14.3:
   version "1.19.1"
@@ -8577,10 +8577,10 @@ semver@^7.2.1, semver@^7.3.2:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
   integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
 
-semver@^7.3.4:
-  version "7.3.4"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
-  integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
+semver@^7.3.4, semver@^7.3.5:
+  version "7.3.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
+  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
   dependencies:
     lru-cache "^6.0.0"
 
@@ -8862,10 +8862,10 @@ solidity-ast@^0.4.4:
   resolved "https://registry.yarnpkg.com/solidity-ast/-/solidity-ast-0.4.17.tgz#e857b4f64466f3eb94da78fe961c0d256c84b228"
   integrity sha512-5jkkabmjPdy9W9c2DMQBlKobVBz7KDnipxn+0zW191uD6BML3w7dQ+ihUvwA9XOm9ILDECrb5Y8z2vu47STqCg==
 
-solidity-comments-extractor@^0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/solidity-comments-extractor/-/solidity-comments-extractor-0.0.4.tgz#ce420aef23641ffd0131c7d80ba85b6e1e42147e"
-  integrity sha512-58glBODwXIKMaQ7rfcJOrWtFQMMOK28tJ0/LcB5Xhu7WtAxk4UX2fpgKPuaL41XjMp/y0gAa1MTLqk018wuSzA==
+solidity-comments-extractor@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/solidity-comments-extractor/-/solidity-comments-extractor-0.0.7.tgz#99d8f1361438f84019795d928b931f4e5c39ca19"
+  integrity sha512-wciNMLg/Irp8OKGrh3S2tfvZiZ0NEyILfcRCXCD4mp7SgK/i9gzLfhY2hY7VMCQJ3kH9UB9BzNdibIVMchzyYw==
 
 solidity-coverage@^0.7.14:
   version "0.7.14"
@@ -9065,10 +9065,19 @@ string-width@^3.0.0, string-width@^3.1.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
 
-string-width@^4.1.0, string-width@^4.2.0:
+string-width@^4.1.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.0.tgz#952182c46cc7b2c313d1596e623992bd163b72b5"
   integrity sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.0"
+
+string-width@^4.2.0, string-width@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.2.tgz#dafd4f9559a7585cfba529c6a0a4f73488ebd4c5"
+  integrity sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==
   dependencies:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7799,8 +7799,8 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-"prettier-plugin-solidity@^1.0.0-beta.6 ":
-  version "1.0.0-beta.10"
+prettier-plugin-solidity@^1.0.0-beta.6:
+  version "1.0.0-beta.6"
   resolved "https://registry.yarnpkg.com/prettier-plugin-solidity/-/prettier-plugin-solidity-1.0.0-beta.10.tgz#f2a249002733826b08d981b599335ddb7e93af8d"
   integrity sha512-55UsEbeJfqYKB3RFR7Nvpi+ApEoUfgdKHVg2ZybrbOkRW4RTblyONLL3mEr8Vrxpo7wBbObVLbWodGg4YXIQ7g==
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -7799,7 +7799,7 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-"prettier-plugin-solidity@^1.0.0-beta.10 ":
+"prettier-plugin-solidity@^1.0.0-beta.6 ":
   version "1.0.0-beta.10"
   resolved "https://registry.yarnpkg.com/prettier-plugin-solidity/-/prettier-plugin-solidity-1.0.0-beta.10.tgz#f2a249002733826b08d981b599335ddb7e93af8d"
   integrity sha512-55UsEbeJfqYKB3RFR7Nvpi+ApEoUfgdKHVg2ZybrbOkRW4RTblyONLL3mEr8Vrxpo7wBbObVLbWodGg4YXIQ7g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -962,6 +962,11 @@
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.0.0.tgz#54d1de30911635020c383cb73b160b698e7ae179"
   integrity sha512-UcIJl/vUVjTr3H1yYXZi7Sr2PlXzBEHVUJKOUlVyzyy0FI8oQCCy0Wx+BuK/fojdnmLeMvUk4KUvhKUybP+C7Q==
 
+"@openzeppelin/contracts-upgradeable@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.0.0.tgz#11edb64933c43ab3eab2a84abe5e3ccf2981c4c7"
+  integrity sha512-T5tO/KD++m+Ph74ppPPmNuhyrvNcsMDgQWt+pGshNJMsTf9UvmhBNyyOqVAL91UeuqDI0FHAbBV1+NnMg7ffFA==
+
 "@openzeppelin/contracts@^3.2.1-solc-0.7":
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.4.1.tgz#03c891fec7f93be0ae44ed74e57a122a38732ce7"


### PR DESCRIPTION
# Description
This cleans up old metaTx stuff, where we used to support multiple types of metaTx.
The industry seems to be standardizing around ERC-2771, so it is now the only type we support in the Asset contract moving forward.

<!--
Provide a summary of the changes made, and include some context, such as why the changes are needed. This is helpful to both reviewers, and for future reference.
-->

# Checklist:

- [ ] Pull Request references Jira issue
- [x] Pull Request applies to a single purpose
- [ ] I've added comments to my code where needed
- [ ] I've updated any relevant docs
- [x] I've added tests to show that my changes achieve the desired results
- [x] I've reviewed my code
- [x] I've followed established naming conventions and formatting
- [ ] I've generated a coverage report and included a screenshot
- [x] All tests are passing locally
