### PR TITLE
Making the Asset small again.

### DIFF
--- a/src/solc_0.8/asset/ERC1155ERC721.sol
+++ b/src/solc_0.8/asset/ERC1155ERC721.sol
@@ -276,25 +276,6 @@ contract ERC1155ERC721 is WithSuperOperators, IERC1155, IERC721, ERC2771Handler 
         _setApprovalForAll(_msgSender(), operator, approved);
     }
 
-    /// @notice Change or reaffirm the approved address for an NFT for `sender`.
-    /// @dev used for Meta Transaction (from metaTransactionContract).
-    /// @param sender the sender granting control.
-    /// @param operator the address to approve as NFT controller.
-    /// @param id the NFT to approve.
-    function approveFor(
-        address sender,
-        address operator,
-        uint256 id
-    ) external {
-        address owner = _ownerOf(id);
-        address msgSender = _msgSender();
-        require(sender != address(0), "SENDER==0");
-        require(sender == msgSender || isApprovedForAll(sender, msgSender), "!AUTHORIZED");
-        require(owner == sender, "OWNER!=SENDER");
-        _erc721operators[id] = operator;
-        emit Approval(owner, operator, id);
-    }
-
     /// @notice Change or reaffirm the approved address for an NFT.
     /// @param operator the address to approve as NFT controller.
     /// @param id the id of the NFT to approve.

--- a/src/solc_0.8/asset/ERC1155ERC721.sol
+++ b/src/solc_0.8/asset/ERC1155ERC721.sol
@@ -587,14 +587,6 @@ contract ERC1155ERC721 is WithSuperOperators, IERC1155, IERC721, ERC2771Handler 
         return _operatorsForAll[owner][operator] || _superOperators[operator];
     }
 
-    /// @dev get the layer a token was minted on from its id.
-    /// @param id The id of the token to query.
-    /// @return chainIndex The index of the original layer of minting.
-    /// 0 = eth mainnet, 1 == matic mainnet, etc...
-    function getChainIndex(uint256 id) public pure returns (uint256 chainIndex) {
-        return uint256((id & CHAIN_INDEX_MASK) >> 63);
-    }
-
     function _setApprovalForAll(
         address sender,
         address operator,

--- a/test/asset/asset.test.ts
+++ b/test/asset/asset.test.ts
@@ -1,5 +1,5 @@
 import {setupAsset} from './fixtures';
-import {waitFor, getChainIndex} from '../utils';
+import {waitFor, getAssetChainIndex} from '../utils';
 import {expect} from '../chai-setup';
 import {sendMetaTx} from '../sendMetaTx';
 
@@ -78,7 +78,7 @@ describe('Asset.sol', function () {
   it('can get the chainIndex from the tokenId', async function () {
     const {users, mintAsset} = await setupAsset();
     const tokenId = await mintAsset(users[1].address, 11);
-    const chainIndex = getChainIndex(tokenId);
+    const chainIndex = getAssetChainIndex(tokenId);
     expect(chainIndex).to.be.equal(0);
   });
 

--- a/test/asset/asset.test.ts
+++ b/test/asset/asset.test.ts
@@ -2,6 +2,12 @@ import {setupAsset} from './fixtures';
 import {waitFor} from '../utils';
 import {expect} from '../chai-setup';
 import {sendMetaTx} from '../sendMetaTx';
+import {BigNumber} from 'ethers';
+
+function getChainIndex(id: BigNumber): number {
+  const CHAIN_INDEX_MASK = 0x0000000000000000000000000000000000000000000007f8000000000000000;
+  return (Number(id) & CHAIN_INDEX_MASK) >> 63;
+}
 
 describe('Asset.sol', function () {
   it('user sending asset to itself keep the same balance', async function () {
@@ -76,9 +82,9 @@ describe('Asset.sol', function () {
   });
 
   it('can get the chainIndex from the tokenId', async function () {
-    const {Asset, users, mintAsset} = await setupAsset();
+    const {users, mintAsset} = await setupAsset();
     const tokenId = await mintAsset(users[1].address, 11);
-    const chainIndex = await Asset.callStatic.getChainIndex(tokenId);
+    const chainIndex = getChainIndex(tokenId);
     expect(chainIndex).to.be.equal(0);
   });
 

--- a/test/asset/asset.test.ts
+++ b/test/asset/asset.test.ts
@@ -1,13 +1,7 @@
 import {setupAsset} from './fixtures';
-import {waitFor} from '../utils';
+import {waitFor, getChainIndex} from '../utils';
 import {expect} from '../chai-setup';
 import {sendMetaTx} from '../sendMetaTx';
-import {BigNumber} from 'ethers';
-
-function getChainIndex(id: BigNumber): number {
-  const CHAIN_INDEX_MASK = 0x0000000000000000000000000000000000000000000007f8000000000000000;
-  return (Number(id) & CHAIN_INDEX_MASK) >> 63;
-}
 
 describe('Asset.sol', function () {
   it('user sending asset to itself keep the same balance', async function () {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -137,3 +137,8 @@ export async function setupUsers<T extends {[contractName: string]: Contract}>(
   }
   return users;
 }
+
+export function getChainIndex(id: BigNumber): number {
+  const CHAIN_INDEX_MASK = 0x0000000000000000000000000000000000000000000007f8000000000000000;
+  return (Number(id) & CHAIN_INDEX_MASK) >> 63;
+}

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,6 +1,12 @@
 /* eslint-disable mocha/no-exports */
 import {BigNumber} from '@ethersproject/bignumber';
-import {ContractReceipt, Event, Contract, ContractTransaction} from 'ethers';
+import {
+  ContractReceipt,
+  Event,
+  Contract,
+  ContractTransaction,
+  utils,
+} from 'ethers';
 import {Receipt} from 'hardhat-deploy/types';
 import {Result} from 'ethers/lib/utils';
 import {ethers} from 'hardhat';
@@ -138,7 +144,10 @@ export async function setupUsers<T extends {[contractName: string]: Contract}>(
   return users;
 }
 
-export function getChainIndex(id: BigNumber): number {
-  const CHAIN_INDEX_MASK = 0x0000000000000000000000000000000000000000000007f8000000000000000;
-  return (Number(id) & CHAIN_INDEX_MASK) >> 63;
+export function getAssetChainIndex(id: BigNumber): number {
+  // js bitwise & operands are converted to 32-bit integers
+  const idAsHexString = utils.hexValue(id);
+  const slicedId = Number('0x' + idAsHexString.slice(48, 56));
+  const SLICED_CHAIN_INDEX_MASK = Number('0x7F800000');
+  return (slicedId & SLICED_CHAIN_INDEX_MASK) >>> 23;
 }


### PR DESCRIPTION
# Description
- removes the `approveFor()` function; It is not part of the erc721/1155 spec and `approve()` + metaTx can handle it.
- removes `getChainIndex()` function; index can easily be calculated off-chain and is now done in a test.

Note: I looked into removing `setApprovalForAllFor()`, but it causes a test to fail ("operator can approve...") so I didn't remove it. 
<!--
Provide a summary of the changes made, and include some context, such as why the changes are needed. This is helpful to both reviewers, and for future reference.
-->

# Checklist:

- [ ] Pull Request references Jira issue
- [x] Pull Request applies to a single purpose
- [ ] I've added comments to my code where needed
- [ ] I've updated any relevant docs
- [ ] I've added tests to show that my changes achieve the desired results
- [x] I've reviewed my code
- [x] I've followed established naming conventions and formatting
- [ ] I've generated a coverage report and included a screenshot
- [x] All tests are passing locally
