### PR TITLE
Asset IPFS hash - L1 to L2

### DIFF
--- a/src/solc_0.8/polygon/child/asset/PolygonAssetV2.sol
+++ b/src/solc_0.8/polygon/child/asset/PolygonAssetV2.sol
@@ -41,20 +41,17 @@ contract PolygonAssetV2 is ERC1155ERC721 {
         (uint256[] memory ids, uint256[] memory amounts, bytes memory data) =
             abi.decode(depositData, (uint256[], uint256[], bytes));
         address sender = _msgSender();
+        bytes32 hash = abi.decode(data, (bytes32));
         for (uint256 i = 0; i < ids.length; i++) {
             // ERC-721
             if ((amounts[i] == 1) && (ids[i] & IS_NFT > 0)) {
-                // temp: to be replaced by encoded IPFS hash
-                bytes32 dummyHash = bytes32("0x00");
                 uint8 rarity = 0;
-                _mint(dummyHash, amounts[i], rarity, sender, user, ids[0], data, false);
+                _mint(hash, amounts[i], rarity, sender, user, ids[0], data, false);
             }
             // ERC-1155
             else {
-                // temp: to be replaced by encoded IPFS hash
-                bytes32 dummyHash = bytes32("0x00");
                 uint8 rarity = 0;
-                _mint(dummyHash, amounts[i], rarity, sender, user, ids[0], data, false);
+                _mint(hash, amounts[i], rarity, sender, user, ids[0], data, false);
             }
         }
     }


### PR DESCRIPTION
# Description

Transfer of the Asset IPFS Hash between from L1 to L2.
Decoded the `data` to get the `hash`.

**JIRA:** [NB-38](https://sandboxgame.atlassian.net/browse/NB-38?atlOrigin=eyJpIjoiMzg5NTI3ZDNhMTQ3NDUwY2FkMmQ1MmMxYmE4OGM0YTQiLCJwIjoiaiJ9)

# Checklist:

- [x] Pull Request references Jira issue
- [x] Pull Request applies to a single purpose
- [x] I've added comments to my code where needed
- [ ] I've updated any relevant docs
- [ ] I've added tests to show that my changes achieve the desired results
- [ ] I've reviewed my code
- [x] I've followed established naming conventions and formatting
- [ ] I've generated a coverage report and included a screenshot
- [x] All tests are passing locally
