### PR TITLE
Remove predicate from Polygon Asset

### DIFF
--- a/src/solc_0.8/polygon/child/asset/PolygonAssetV2.sol
+++ b/src/solc_0.8/polygon/child/asset/PolygonAssetV2.sol
@@ -18,14 +18,12 @@ contract PolygonAssetV2 is ERC1155ERC721 {
         address trustedForwarder,
         address admin,
         address bouncerAdmin,
-        address predicate,
         address childChainManager,
         uint8 chainIndex
     ) external {
         require(trustedForwarder.isContract(), "TRUSTERFORWARDER_NOT_CONTRACT");
-        require(predicate.isContract(), "PREDICATE_NOT_CONTRACT");
         require(childChainManager.isContract(), "CHILDCHAINMANAGER_NOT_CONTRACT");
-        initV2(trustedForwarder, admin, bouncerAdmin, predicate, chainIndex);
+        initV2(trustedForwarder, admin, bouncerAdmin, address(0), chainIndex);
         _childChainManager = childChainManager;
     }
 


### PR DESCRIPTION
# Description

Polygon Asset contract itself would be considered the predicate contract. There is no need to store a `predicate` address in the Polygon Asset contract.

# Checklist:

- [ ] Pull Request references Jira issue
- [x] Pull Request applies to a single purpose
- [ ] I've added comments to my code where needed
- [ ] I've updated any relevant docs
- [ ] I've added tests to show that my changes achieve the desired results
- [ ] I've reviewed my code
- [x] I've followed established naming conventions and formatting
- [ ] I've generated a coverage report and included a screenshot
- [x] All tests are passing locally
