### PR TITLE
claiming asset script fails

### DIFF
--- a/scripts/transact/connected_mintGenesisAsset.ts
+++ b/scripts/transact/connected_mintGenesisAsset.ts
@@ -10,7 +10,7 @@ const args = process.argv.slice(2);
   }
   const {genesisMinter, deployer} = await getNamedAccounts();
 
-  let to = deployer;
+  let to = genesisMinter;
   if (args.length > 0) {
     to = args[0];
   }
@@ -25,17 +25,19 @@ const args = process.argv.slice(2);
     }
   }
 
-  const genesisBouncer = await ethers.getContract(
-    'GenesisBouncer',
+  const defaultMinter = await ethers.getContract(
+    'DefaultMinter',
     genesisMinter
   );
-  const tx = await genesisBouncer.mintFor(
-    deployer,
+
+  const tx = await defaultMinter.mintFor(
+    genesisMinter,
     packId,
     '0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF',
     20000,
+    to,
     0,
-    to
+    0
   );
 
   console.log({txHash: tx.hash});


### PR DESCRIPTION
# Description

https://sandboxgame.atlassian.net/browse/TSBBLOC-252

When rewriting the doc of the claiming asset process, i had to use the script connected_mintGenesisAsset.ts which fails to estimate gas. 
I had to migrate the script to use the new minter

# Checklist:

- [x] Pull Request references Jira issue
- [x] Pull Request applies to a single purpose
- [ ] I've added comments to my code where needed
- [ ] I've updated any relevant docs
- [ ] I've added tests to show that my changes achieve the desired results
- [x] I've reviewed my code
- [ ] I've followed established naming conventions and formatting
- [ ] I've generated a coverage report and included a screenshot
- [x] All tests are passing locally
