### PR TITLE
add script that generate the list of address of SAND LPs

### DIFF
--- a/scripts/gathering/generateLPRewards.ts
+++ b/scripts/gathering/generateLPRewards.ts
@@ -1,0 +1,38 @@
+import fs from 'fs';
+import {TheGraph} from '../utils/thegraph';
+import {getBlockArgs} from '../utils/utils';
+
+const blockNumber = getBlockArgs(0);
+
+interface Staker {
+  id: string;
+}
+
+const theGraph = new TheGraph(
+  'https://api.thegraph.com/subgraphs/name/nicovrg/liquidity-mining'
+);
+
+const queryString = `
+  query($blockNumber: Int! $first: Int! $lastId: ID!) {
+    stakers(first: $first where: {id_gt: $lastId} block: {number: $blockNumber}) {
+      id
+    }
+  }
+`;
+
+async function main() {
+  const addList: Array<string> = [];
+
+  const stakers: Array<Staker> = await theGraph.query(queryString, 'stakers', {
+    blockNumber,
+  });
+
+  stakers.map((staker) => {
+    addList.push(staker.id);
+  });
+
+  console.log({numStakers: stakers.length});
+  fs.writeFileSync('result.json', JSON.stringify(addList, null, '  '));
+}
+
+main();


### PR DESCRIPTION
# Description

To keep for the record, this was the script used to generate the list of addresses that provided liquidity for SAND on uniswap.
Main problem with this PR was that the graph node was not indexed anymore, I search for a reason but failed to find one tangible, so I assume it's a bug on The Graph side

# Checklist:

- [ ] Pull Request references Jira issue
- [ ] Pull Request applies to a single purpose
- [ ] I've added comments to my code where needed
- [ ] I've updated any relevant docs
- [ ] I've added tests to show that my changes achieve the desired results
- [ ] I've reviewed my code
- [ ] I've followed established naming conventions and formatting
- [ ] I've generated a coverage report and included a screenshot
- [ ] All tests are passing locally
