### PR TITLE
fix: asset giveaway skip and deprecated deployment

### DIFF
--- a/deploy/07_giveaway/00_deploy_asset_giveaway_1.ts
+++ b/deploy/07_giveaway/00_deploy_asset_giveaway_1.ts
@@ -3,7 +3,7 @@ import {HardhatRuntimeEnvironment} from 'hardhat/types';
 import {DeployFunction} from 'hardhat-deploy/types';
 import {createAssetClaimMerkleTree} from '../../data/giveaways/asset_giveaway_1/getAssets';
 import {AddressZero} from '@ethersproject/constants';
-import {skipUnlessTest} from '../../utils/network';
+import {skipUnlessL1} from '../../utils/network';
 
 import helpers, {AssetClaim} from '../../lib/merkleTreeHelper';
 const {calculateClaimableAssetHash} = helpers;
@@ -68,4 +68,4 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 export default func;
 func.tags = ['Asset_Giveaway_1', 'Asset_Giveaway_1_deploy'];
 func.dependencies = ['Asset_deploy'];
-func.skip = skipUnlessTest;
+func.skip = skipUnlessL1;

--- a/deploy/07_giveaway/01_deploy_asset_giveaway_2.ts
+++ b/deploy/07_giveaway/01_deploy_asset_giveaway_2.ts
@@ -3,7 +3,7 @@ import {HardhatRuntimeEnvironment} from 'hardhat/types';
 import {DeployFunction} from 'hardhat-deploy/types';
 import {createAssetClaimMerkleTree} from '../../data/giveaways/asset_giveaway_2/getAssets';
 import {AddressZero} from '@ethersproject/constants';
-import {skipUnlessTest} from '../../utils/network';
+import {skipUnlessL1} from '../../utils/network';
 
 import helpers, {AssetClaim} from '../../lib/merkleTreeHelper';
 const {calculateClaimableAssetHash} = helpers;
@@ -73,4 +73,4 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 export default func;
 func.tags = ['Asset_Giveaway_2', 'Asset_Giveaway_2_deploy'];
 func.dependencies = ['Asset_deploy'];
-func.skip = skipUnlessTest;
+func.skip = skipUnlessL1;

--- a/deploy/07_giveaway/02_deploy_asset_giveaway_3.ts
+++ b/deploy/07_giveaway/02_deploy_asset_giveaway_3.ts
@@ -4,7 +4,7 @@ import {DeployFunction} from 'hardhat-deploy/types';
 import {createAssetClaimMerkleTree} from '../../data/giveaways/asset_giveaway_3/getAssets';
 import {AddressZero} from '@ethersproject/constants';
 import helpers, {AssetClaim} from '../../lib/merkleTreeHelper';
-import {skipUnlessTest} from '../../utils/network';
+import {skipUnlessL1} from '../../utils/network';
 const {calculateClaimableAssetHash} = helpers;
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
@@ -72,4 +72,4 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 export default func;
 func.tags = ['Asset_Giveaway_3', 'Asset_Giveaway_3_deploy'];
 func.dependencies = ['Asset_deploy'];
-func.skip = skipUnlessTest;
+func.skip = skipUnlessL1;

--- a/deploy/07_giveaway/03_deploy_asset_giveaway_4.ts
+++ b/deploy/07_giveaway/03_deploy_asset_giveaway_4.ts
@@ -4,7 +4,7 @@ import {DeployFunction} from 'hardhat-deploy/types';
 import {createAssetClaimMerkleTree} from '../../data/giveaways/asset_giveaway_4/getAssets';
 import {AddressZero} from '@ethersproject/constants';
 import helpers, {AssetClaim} from '../../lib/merkleTreeHelper';
-import {skipUnlessTest} from '../../utils/network';
+import {skipUnlessL1} from '../../utils/network';
 const {calculateClaimableAssetHash} = helpers;
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
@@ -72,4 +72,4 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 export default func;
 func.tags = ['Asset_Giveaway_4', 'Asset_Giveaway_4_deploy'];
 func.dependencies = ['Asset_deploy'];
-func.skip = skipUnlessTest;
+func.skip = skipUnlessL1;

--- a/deploy/07_giveaway/04_deploy_asset_giveaway_5.ts
+++ b/deploy/07_giveaway/04_deploy_asset_giveaway_5.ts
@@ -4,6 +4,7 @@ import {DeployFunction} from 'hardhat-deploy/types';
 import {createAssetClaimMerkleTree} from '../../data/giveaways/asset_giveaway_5/getAssets';
 import {AddressZero} from '@ethersproject/constants';
 import helpers, {AssetClaim} from '../../lib/merkleTreeHelper';
+import {skipUnlessL1} from '../../utils/network';
 const {calculateClaimableAssetHash} = helpers;
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
@@ -71,3 +72,4 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 export default func;
 func.tags = ['Asset_Giveaway_5', 'Asset_Giveaway_5_deploy'];
 func.dependencies = ['Asset_deploy'];
+func.skip = skipUnlessL1;

--- a/deploy/11_obsolete/0065_deploy_catalyst_minter_without_limits.ts
+++ b/deploy/11_obsolete/0065_deploy_catalyst_minter_without_limits.ts
@@ -125,4 +125,4 @@ func.dependencies = [
   'OldCatalysts_deploy', // old Catalyst is assumed to be deployed
   'OldCatalystRegistry_deploy', // old CatalystRegistry is assumed to be deployed
 ];
-func.skip = async (hre) => hre.network.name === 'hardhat'; // skip running as this is not to be used, require putting the whole Gem/Catalyst deployment back
+func.skip = async () => true; // skip running as this is not to be used, require putting the whole Gem/Catalyst deployment back


### PR DESCRIPTION
# Description

- Asset giveaway skip function was wrongly configured, it should be skiped if not L1
- Deprecated deploy should always be skipped, somehow I missed that while deploying to goerli

# Checklist:

- [ ] Pull Request references Jira issue
- [ ] Pull Request applies to a single purpose
- [ ] I've added comments to my code where needed
- [ ] I've updated any relevant docs
- [ ] I've added tests to show that my changes achieve the desired results
- [x] I've reviewed my code
- [ ] I've followed established naming conventions and formatting
- [ ] I've generated a coverage report and included a screenshot
- [ ] All tests are passing locally
