### PR TITLE
TSBBLOC-305: Fix - polygon asset tests failing

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "lint:fix": "eslint --fix \"**/*.{js,ts}\" && solhint --fix \"src/**/*.sol\"",
     "format": "prettier --check \"**/*.{ts,js,sol}\"",
     "format:fix": "prettier --write \"**/*.{ts,js,sol}\"",
-    "test": "dotenv -- cross-env NODE_OPTIONS=--max-old-space-size=4096 HARDHAT_COMPILE=true mocha --bail --recursive test",
+    "test": "dotenv -- cross-env NODE_OPTIONS=--max-old-space-size=4096 HARDHAT_COMPILE=true hardhat test",
     "test:single": "dotenv -- cross-env HARDHAT_COMPILE=true mocha --bail --recursive test",
     "gas": "dotenv -- cross-env REPORT_GAS=true NODE_OPTIONS=--max-old-space-size=4096 hardhat test",
     "sizer": "hardhat size-contracts",

--- a/test/asset/asset.test.ts
+++ b/test/asset/asset.test.ts
@@ -2,8 +2,13 @@ import {setupAsset} from './fixtures';
 import {waitFor, getAssetChainIndex} from '../utils';
 import {expect} from '../chai-setup';
 import {sendMetaTx} from '../sendMetaTx';
+import {deployments} from 'hardhat';
 
 describe('Asset.sol', function () {
+  beforeEach(async function () {
+    await deployments.fixture(['Asset']);
+  });
+
   it('user sending asset to itself keep the same balance', async function () {
     const {Asset, users, mintAsset} = await setupAsset();
     const tokenId = await mintAsset(users[0].address, 20);

--- a/test/asset/fixtures.ts
+++ b/test/asset/fixtures.ts
@@ -10,12 +10,6 @@ import {waitFor, setupUsers} from '../utils';
 // import asset_regenerate_and_distribute from '../../setup/asset_regenerate_and_distribute';
 
 export const setupAsset = deployments.createFixture(async function () {
-  await deployments.fixture([
-    'Asset',
-    'PolygonAsset',
-    'ERC1155_PREDICATE',
-    'TRUSTED_FORWARDER',
-  ]);
   // await asset_regenerate_and_distribute(hre);
   const unnamedAccounts = await getUnnamedAccounts();
   const otherAccounts = [...unnamedAccounts];

--- a/test/asset/fixtures.ts
+++ b/test/asset/fixtures.ts
@@ -12,6 +12,7 @@ import {waitFor, setupUsers} from '../utils';
 export const setupAsset = deployments.createFixture(async function () {
   await deployments.fixture([
     'Asset',
+    'PolygonAsset',
     'ERC1155_PREDICATE',
     'TRUSTED_FORWARDER',
   ]);

--- a/test/polygon/asset/asset.test.ts
+++ b/test/polygon/asset/asset.test.ts
@@ -5,10 +5,14 @@ import {expect} from '../../chai-setup';
 import {sendMetaTx} from '../../sendMetaTx';
 import {AbiCoder} from 'ethers/lib/utils';
 import {Event} from '@ethersproject/contracts';
+import {deployments} from 'hardhat';
 
 const abiCoder = new AbiCoder();
 
 describe('PolygonAsset.sol', function () {
+  beforeEach(async function() {
+    await deployments.fixture(['PolygonAsset']);
+  });
   it('user sending asset to itself keep the same balance', async function () {
     const {Asset, users, mintAsset} = await setupPolygonAsset();
     const tokenId = await mintAsset(users[0].address, 20);

--- a/test/polygon/asset/asset.test.ts
+++ b/test/polygon/asset/asset.test.ts
@@ -10,7 +10,7 @@ import {deployments} from 'hardhat';
 const abiCoder = new AbiCoder();
 
 describe('PolygonAsset.sol', function () {
-  beforeEach(async function() {
+  beforeEach(async function () {
     await deployments.fixture(['PolygonAsset']);
   });
   it('user sending asset to itself keep the same balance', async function () {

--- a/test/polygon/asset/asset.test.ts
+++ b/test/polygon/asset/asset.test.ts
@@ -11,7 +11,7 @@ const abiCoder = new AbiCoder();
 
 describe('PolygonAsset.sol', function () {
   beforeEach(async function () {
-    await deployments.fixture(['PolygonAsset']);
+    await deployments.fixture(['PolygonAsset', 'Asset']);
   });
   it('user sending asset to itself keep the same balance', async function () {
     const {Asset, users, mintAsset} = await setupPolygonAsset();

--- a/test/polygon/asset/fixtures.ts
+++ b/test/polygon/asset/fixtures.ts
@@ -10,7 +10,6 @@ import {waitFor, setupUsers} from '../../utils';
 // import asset_regenerate_and_distribute from '../../setup/asset_regenerate_and_distribute';
 
 export const setupAsset = deployments.createFixture(async function () {
-  await deployments.fixture(['PolygonAsset']);
   // await asset_regenerate_and_distribute(hre);
   const unnamedAccounts = await getUnnamedAccounts();
   const otherAccounts = [...unnamedAccounts];


### PR DESCRIPTION
# Description

**Concern:** Polygon Asset tests were failing in the Mocha Explorer
**Cause:** Some issue with `deployments.fixture()`.
**Correction:** Moved `await deployments.fixture(['PolygonAsset']);` from polygon asset fixtures to the test file to run `beforeEach` test. Also added `PolygonAsset` into the L1 asset `deployments.fixture()`.

**JIRA:** [TSBBLOC-305](https://sandboxgame.atlassian.net/browse/TSBBLOC-305?atlOrigin=eyJpIjoiYzhjM2IwZTA5ODhmNDg0Y2EzMmE5MjVlOGQyODJkMGEiLCJwIjoiaiJ9)

# Checklist:

- [x] Pull Request references Jira issue
- [x] Pull Request applies to a single purpose
- [ ] I've added comments to my code where needed
- [ ] I've updated any relevant docs
- [x] I've added tests to show that my changes achieve the desired results
- [x] I've reviewed my code
- [x] I've followed established naming conventions and formatting
- [ ] I've generated a coverage report and included a screenshot
- [x] All tests are passing locally
