### PR TITLE
void deployment on ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: CI
 on: push
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -28,30 +28,95 @@ jobs:
       - name: Installing dependencies
         run: yarn install --frozen-lockfile
 
-  lint:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
       - name: Linting
         run: yarn lint
 
   format:
-    needs: build
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.22.1
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Installing dependencies
+        run: yarn install --frozen-lockfile
+
       - name: Formatting
         run: yarn format
 
   test:
-    needs: build
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.22.1
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Installing dependencies
+        run: yarn install --frozen-lockfile
+
       - name: Running tests
         run: yarn test
 
   deploy:
-    needs: build
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.22.1
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Installing dependencies
+        run: yarn install --frozen-lockfile
+
       - name: Deploy contracts
         run: yarn void:deploy

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: CI
 on: push
 jobs:
-  test:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -28,14 +28,30 @@ jobs:
       - name: Installing dependencies
         run: yarn install --frozen-lockfile
 
+  lint:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
       - name: Linting
         run: yarn lint
 
+  format:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
       - name: Formatting
         run: yarn format
 
+  test:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
       - name: Running tests
         run: yarn test
 
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
       - name: Deploy contracts
         run: yarn void:deploy

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,8 +37,5 @@ jobs:
       - name: Running tests
         run: yarn test
 
-      # - name: Codechecks
-      #   env:
-      #     CC_SECRET: ${{ secrets.CC_SECRET }}
-      #     COINMARKETCAP_API_KEY: ${{ secrets.COINMARKETCAP_API_KEY }}
-      #   run: npx codechecks
+      - name: Deploy contracts
+        run: yarn void:deploy


### PR DESCRIPTION
# Description

Add a call to yarn void:deploy as part of the CI/CD process. It will deploy the content inside the deploy folder to memory, nothing will be stored in storage or in real chains, but it will find issues within deployment scripts.

I took the oppourtunity to split the ci into 4 jobs: lint, format, test and deploy that decreases the ci time by running jobs in parallel

https://sandboxgame.atlassian.net/browse/TSBBLOC-313

# Checklist:

- [x] Pull Request references Jira issue
- [x] Pull Request applies to a single purpose
- [x] I've added comments to my code where needed
- [x] I've updated any relevant docs
- [x] I've added tests to show that my changes achieve the desired results
- [x] I've reviewed my code
- [x] I've followed established naming conventions and formatting
- [x] I've generated a coverage report and included a screenshot
- [x] All tests are passing locally
