### PR TITLE
[Rinkeby -> GOerli migration] Add tools to migrate Lands

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@types/chai": "^4.2.11",
     "@types/fs-extra": "^9.0.6",
     "@types/inquirer": "^7.3.1",
+    "@types/minimist": "^1.2.2",
     "@types/mocha": "^8.0.2",
     "@types/node": "^14.10.2",
     "@typescript-eslint/eslint-plugin": "^4.6.0",

--- a/scripts/analysis/verifyLandOwnership.ts
+++ b/scripts/analysis/verifyLandOwnership.ts
@@ -1,61 +1,59 @@
 import BN from 'bn.js';
 import fs from 'fs-extra';
-import { ethers } from 'hardhat';
+import {ethers} from 'hardhat';
 
 const networkName = 'rinkeby';
 const landOwnersFilePath = `tmp/${networkName}-landOwners.json`;
 const errorFilePath = 'tmp/verificationLandErrors.json';
 
 (async () => {
-    const errors = [];
-    let succesfulChecks = 0;
-    type Land = {
-        coordinateX: BN;
-        coordinateY: BN;
-        size: BN;
-        tokenId: string;
-    };
-    type landOwnersMap = { [owner: string]: Land[] };
+  const errors = [];
+  let succesfulChecks = 0;
+  type Land = {
+    coordinateX: BN;
+    coordinateY: BN;
+    size: BN;
+    tokenId: string;
+  };
+  type landOwnersMap = {[owner: string]: Land[]};
 
-    // read original land owners file
-    if (!(fs.existsSync(landOwnersFilePath))) throw new Error(`file ${landOwnersFilePath} does not exist'`);
-    const landOwners: landOwnersMap = JSON.parse(
-        fs.readFileSync(landOwnersFilePath).toString()
-    );
+  // read original land owners file
+  if (!fs.existsSync(landOwnersFilePath))
+    throw new Error(`file ${landOwnersFilePath} does not exist'`);
+  const landOwners: landOwnersMap = JSON.parse(
+    fs.readFileSync(landOwnersFilePath).toString()
+  );
 
-    const LandContract = await ethers.getContract('Land');
+  const LandContract = await ethers.getContract('Land');
 
-    for (const landOwner in landOwners) {
-        const lands: Land[] = landOwners[landOwner];
-        for (const land of lands) {
-            try {
-                const ownerResult = await LandContract.callStatic.ownerOf(land.tokenId);
-                if (ownerResult !== landOwner) {
-                    errors.push({
-                        ...land,
-                        ownerResult: ownerResult
-                    });
-                } else {
-                    succesfulChecks++;
-                }
-            } catch (error) {
-                if (error instanceof Error) {
-                    errors.push({
-                        ...land,
-                        ownerResult: error.message
-                    });
-                }
-            }
+  for (const landOwner in landOwners) {
+    const lands: Land[] = landOwners[landOwner];
+    for (const land of lands) {
+      try {
+        const ownerResult = await LandContract.callStatic.ownerOf(land.tokenId);
+        if (ownerResult !== landOwner) {
+          errors.push({
+            ...land,
+            ownerResult: ownerResult,
+          });
+        } else {
+          succesfulChecks++;
         }
+      } catch (error) {
+        if (error instanceof Error) {
+          errors.push({
+            ...land,
+            ownerResult: error.message,
+          });
+        }
+      }
     }
+  }
 
-    console.log(`${succesfulChecks} checks were successful`);
-    console.log(`Error count is ${errors.length}`);
-    if (errors.length > 0) {
-        fs.ensureDirSync('tmp');
-        fs.writeFileSync(
-            errorFilePath,
-            JSON.stringify(errors)
-        );
-    }
-})()
+  console.log(`${succesfulChecks} checks were successful`);
+  console.log(`Error count is ${errors.length}`);
+  if (errors.length > 0) {
+    fs.ensureDirSync('tmp');
+    fs.writeFileSync(errorFilePath, JSON.stringify(errors));
+  }
+})();

--- a/scripts/analysis/verifyLandOwnership.ts
+++ b/scripts/analysis/verifyLandOwnership.ts
@@ -1,0 +1,61 @@
+import BN from 'bn.js';
+import fs from 'fs-extra';
+import { ethers } from 'hardhat';
+
+const networkName = 'rinkeby';
+const landOwnersFilePath = `tmp/${networkName}-landOwners.json`;
+const errorFilePath = 'tmp/verificationLandErrors.json';
+
+(async () => {
+    const errors = [];
+    let succesfulChecks = 0;
+    type Land = {
+        coordinateX: BN;
+        coordinateY: BN;
+        size: BN;
+        tokenId: string;
+    };
+    type landOwnersMap = { [owner: string]: Land[] };
+
+    // read original land owners file
+    if (!(fs.existsSync(landOwnersFilePath))) throw new Error(`file ${landOwnersFilePath} does not exist'`);
+    const landOwners: landOwnersMap = JSON.parse(
+        fs.readFileSync(landOwnersFilePath).toString()
+    );
+
+    const LandContract = await ethers.getContract('Land');
+
+    for (const landOwner in landOwners) {
+        const lands: Land[] = landOwners[landOwner];
+        for (const land of lands) {
+            try {
+                const ownerResult = await LandContract.callStatic.ownerOf(land.tokenId);
+                if (ownerResult !== landOwner) {
+                    errors.push({
+                        ...land,
+                        ownerResult: ownerResult
+                    });
+                } else {
+                    succesfulChecks++;
+                }
+            } catch (error) {
+                if (error instanceof Error) {
+                    errors.push({
+                        ...land,
+                        ownerResult: error.message
+                    });
+                }
+            }
+        }
+    }
+
+    console.log(`${succesfulChecks} checks were successful`);
+    console.log(`Error count is ${errors.length}`);
+    if (errors.length > 0) {
+        fs.ensureDirSync('tmp');
+        fs.writeFileSync(
+            errorFilePath,
+            JSON.stringify(errors)
+        );
+    }
+})()

--- a/scripts/gathering/getLandForMigration.ts
+++ b/scripts/gathering/getLandForMigration.ts
@@ -1,0 +1,147 @@
+import { Event } from 'ethers';
+import BN from 'bn.js';
+import fs from 'fs-extra';
+import { ethers } from 'hardhat';
+
+const startBlock = 5530851; // This is the block number where the Land contract was deployed in rinkeby network
+const networkName = 'rinkeby';
+const exportFilePath = `tmp/${networkName}-landOwners.json`;
+
+
+async function queryEvents(
+	filterFunc: (startBlock: number, endBlock: number) => Promise<Event[]>,
+	startBlock: number,
+	endBlock?: number
+) {
+	if (!endBlock) {
+		endBlock = await ethers.provider.getBlockNumber();
+	}
+	let consecutiveSuccess = 0;
+	const successes: Record<number, boolean> = {};
+	const failures: Record<number, boolean> = {};
+	const events = [];
+	let blockRange = 100000;
+	let fromBlock = startBlock;
+	let toBlock = Math.min(fromBlock + blockRange, endBlock);
+	while (fromBlock <= endBlock) {
+		try {
+			const moreEvents = await filterFunc(fromBlock, toBlock);
+			console.log({ fromBlock, toBlock, numEvents: moreEvents.length });
+			successes[blockRange] = true;
+			consecutiveSuccess++;
+			if (consecutiveSuccess > 6) {
+				const newBlockRange = blockRange * 2;
+				if (!failures[newBlockRange] || successes[newBlockRange]) {
+					blockRange = newBlockRange;
+					console.log({ blockRange });
+				}
+			}
+
+			fromBlock = toBlock + 1;
+			toBlock = Math.min(fromBlock + blockRange, endBlock);
+			events.push(...moreEvents);
+		} catch (e) {
+			failures[blockRange] = true;
+			consecutiveSuccess = 0;
+			blockRange /= 2;
+			toBlock = Math.min(fromBlock + blockRange, endBlock);
+
+			console.log({ fromBlock, toBlock, numEvents: 'ERROR' });
+			console.log({ blockRange });
+			console.error(e);
+		}
+	}
+	return events;
+}
+
+
+const gridSize = new BN(408);
+
+function tokenIdToMapCoords(topCornerId: BN): { coordinateX: string, coordinateY: string } {
+	const id = new BN(topCornerId.toString());
+	const coordinateX = id
+		.mod(gridSize) // x = id % 408
+		.toString(10);
+	const coordinateY = id
+		.div(gridSize) // y = id / 408
+		.toString(10);
+	return { coordinateX, coordinateY };
+}
+
+(async () => {
+	const presaleContractNames = [
+		'LandPreSale_1',
+		'LandPreSale_10_27',
+		'LandPreSale_10_28',
+		'LandPreSale_10_29',
+		'LandPreSale_10_30',
+		'LandPreSale_11_31',
+		'LandPreSale_12_32',
+		'LandPreSale_2',
+		'LandPreSale_3',
+		'LandPreSale_3_4',
+		'LandPreSale_3_5',
+		'LandPreSale_3_6',
+		'LandPreSale_3_7',
+		'LandPreSale_3_8',
+		'LandPreSale_3_9',
+		'LandPreSale_4_1',
+		'LandPreSale_4_2_11',
+		'LandPreSale_4_2_12',
+		'LandPreSale_4_2_13',
+		'LandPreSale_4_2_14',
+		'LandPreSale_5_16',
+		'LandPreSale_5_17',
+		'LandPreSale_5_18',
+		'LandPreSale_5_19',
+		'LandPreSale_6_18',
+		'LandPreSale_6_bis_18',
+		'LandPreSale_7_19',
+		'LandPreSale_8_20',
+		'LandPreSale_8_21',
+		'LandPreSale_8_22',
+		'LandPreSale_8_23',
+		'LandPreSale_8_24',
+		'LandPreSale_9_25',
+		'LandPreSale_9_26'
+	];
+
+	type Land = {
+		coordinateX: string;
+		coordinateY: string;
+		size: BN;
+		tokenId: string;
+	};
+	const landOwnersMap: { [owner: string]: Land[] } = {};
+
+	const LandContract = await ethers.getContract('Land');
+
+	for (const presaleContractName of presaleContractNames) {
+		const presaleContract = await ethers.getContract(presaleContractName);
+		if (!presaleContract) console.log(`No contract found for presale: ${presaleContractName}`);
+		const landQuadPurchasedEvents = await queryEvents(
+			presaleContract.queryFilter.bind(presaleContract, presaleContract.filters.LandQuadPurchased()),
+			startBlock
+		);
+
+		for (const event of landQuadPurchasedEvents) {
+			const topCornerId: BN = event.args && event.args.topCornerId;
+			const { coordinateX, coordinateY } = tokenIdToMapCoords(topCornerId);
+			const size = new BN(event.args && event.args.size.toString());
+			const currentLandOwner = await LandContract.callStatic.ownerOf(topCornerId);
+			const land: Land = { coordinateX, coordinateY, size, tokenId: topCornerId.toString() };
+			if (currentLandOwner) {
+				landOwnersMap[currentLandOwner] = landOwnersMap[currentLandOwner] || [];
+				landOwnersMap[currentLandOwner].push(land);
+			}
+		}
+	}
+
+	// write output file
+	console.log(`writing output to file ${exportFilePath}`);
+	fs.ensureDirSync('tmp');
+	fs.writeFileSync(
+		exportFilePath,
+		JSON.stringify(landOwnersMap)
+	);
+})()

--- a/scripts/gathering/getLandForMigration.ts
+++ b/scripts/gathering/getLandForMigration.ts
@@ -1,115 +1,125 @@
-import { Event } from 'ethers';
+import {Event} from 'ethers';
 import BN from 'bn.js';
 import fs from 'fs-extra';
-import { ethers } from 'hardhat';
+import {ethers} from 'hardhat';
 import hre from 'hardhat';
 
 const startBlock = 5530851; // This is the block number where the Land contract was deployed in rinkeby network
 const networkName = 'rinkeby';
 const exportFilePath = `tmp/${networkName}-landOwners.json`;
 
-
 async function queryEvents(
-	filterFunc: (startBlock: number, endBlock: number) => Promise<Event[]>,
-	startBlock: number,
-	endBlock?: number
+  filterFunc: (startBlock: number, endBlock: number) => Promise<Event[]>,
+  startBlock: number,
+  endBlock?: number
 ) {
-	if (!endBlock) {
-		endBlock = await ethers.provider.getBlockNumber();
-	}
-	let consecutiveSuccess = 0;
-	const successes: Record<number, boolean> = {};
-	const failures: Record<number, boolean> = {};
-	const events = [];
-	let blockRange = 100000;
-	let fromBlock = startBlock;
-	let toBlock = Math.min(fromBlock + blockRange, endBlock);
-	while (fromBlock <= endBlock) {
-		try {
-			const moreEvents = await filterFunc(fromBlock, toBlock);
-			console.log({ fromBlock, toBlock, numEvents: moreEvents.length });
-			successes[blockRange] = true;
-			consecutiveSuccess++;
-			if (consecutiveSuccess > 6) {
-				const newBlockRange = blockRange * 2;
-				if (!failures[newBlockRange] || successes[newBlockRange]) {
-					blockRange = newBlockRange;
-					console.log({ blockRange });
-				}
-			}
+  if (!endBlock) {
+    endBlock = await ethers.provider.getBlockNumber();
+  }
+  let consecutiveSuccess = 0;
+  const successes: Record<number, boolean> = {};
+  const failures: Record<number, boolean> = {};
+  const events = [];
+  let blockRange = 100000;
+  let fromBlock = startBlock;
+  let toBlock = Math.min(fromBlock + blockRange, endBlock);
+  while (fromBlock <= endBlock) {
+    try {
+      const moreEvents = await filterFunc(fromBlock, toBlock);
+      console.log({fromBlock, toBlock, numEvents: moreEvents.length});
+      successes[blockRange] = true;
+      consecutiveSuccess++;
+      if (consecutiveSuccess > 6) {
+        const newBlockRange = blockRange * 2;
+        if (!failures[newBlockRange] || successes[newBlockRange]) {
+          blockRange = newBlockRange;
+          console.log({blockRange});
+        }
+      }
 
-			fromBlock = toBlock + 1;
-			toBlock = Math.min(fromBlock + blockRange, endBlock);
-			events.push(...moreEvents);
-		} catch (e) {
-			failures[blockRange] = true;
-			consecutiveSuccess = 0;
-			blockRange /= 2;
-			toBlock = Math.min(fromBlock + blockRange, endBlock);
+      fromBlock = toBlock + 1;
+      toBlock = Math.min(fromBlock + blockRange, endBlock);
+      events.push(...moreEvents);
+    } catch (e) {
+      failures[blockRange] = true;
+      consecutiveSuccess = 0;
+      blockRange /= 2;
+      toBlock = Math.min(fromBlock + blockRange, endBlock);
 
-			console.log({ fromBlock, toBlock, numEvents: 'ERROR' });
-			console.log({ blockRange });
-			console.error(e);
-		}
-	}
-	return events;
+      console.log({fromBlock, toBlock, numEvents: 'ERROR'});
+      console.log({blockRange});
+      console.error(e);
+    }
+  }
+  return events;
 }
-
 
 const gridSize = new BN(408);
 
-function tokenIdToMapCoords(topCornerId: BN): { coordinateX: string, coordinateY: string } {
-	const id = new BN(topCornerId.toString());
-	const coordinateX = id
-		.mod(gridSize) // x = id % 408
-		.toString(10);
-	const coordinateY = id
-		.div(gridSize) // y = id / 408
-		.toString(10);
-	return { coordinateX, coordinateY };
+function tokenIdToMapCoords(
+  topCornerId: BN
+): {coordinateX: string; coordinateY: string} {
+  const id = new BN(topCornerId.toString());
+  const coordinateX = id
+    .mod(gridSize) // x = id % 408
+    .toString(10);
+  const coordinateY = id
+    .div(gridSize) // y = id / 408
+    .toString(10);
+  return {coordinateX, coordinateY};
 }
 
 (async () => {
-	const { deployments } = hre;
-	const allDeployedContracts = await deployments.all();
-	const presaleContractNames = Object.keys(allDeployedContracts).filter(contract => contract.includes('LandPreSale'));
+  const {deployments} = hre;
+  const allDeployedContracts = await deployments.all();
+  const presaleContractNames = Object.keys(
+    allDeployedContracts
+  ).filter((contract) => contract.includes('LandPreSale'));
 
-	type Land = {
-		coordinateX: string;
-		coordinateY: string;
-		size: BN;
-		tokenId: string;
-	};
-	const landOwnersMap: { [owner: string]: Land[] } = {};
+  type Land = {
+    coordinateX: string;
+    coordinateY: string;
+    size: BN;
+    tokenId: string;
+  };
+  const landOwnersMap: {[owner: string]: Land[]} = {};
 
-	const LandContract = await ethers.getContract('Land');
+  const LandContract = await ethers.getContract('Land');
 
-	for (const presaleContractName of presaleContractNames) {
-		const presaleContract = await ethers.getContract(presaleContractName);
-		if (!presaleContract) console.log(`No contract found for presale: ${presaleContractName}`);
-		const landQuadPurchasedEvents = await queryEvents(
-			presaleContract.queryFilter.bind(presaleContract, presaleContract.filters.LandQuadPurchased()),
-			startBlock
-		);
+  for (const presaleContractName of presaleContractNames) {
+    const presaleContract = await ethers.getContract(presaleContractName);
+    if (!presaleContract)
+      console.log(`No contract found for presale: ${presaleContractName}`);
+    const landQuadPurchasedEvents = await queryEvents(
+      presaleContract.queryFilter.bind(
+        presaleContract,
+        presaleContract.filters.LandQuadPurchased()
+      ),
+      startBlock
+    );
 
-		for (const event of landQuadPurchasedEvents) {
-			const topCornerId: BN = event.args && event.args.topCornerId;
-			const { coordinateX, coordinateY } = tokenIdToMapCoords(topCornerId);
-			const size = new BN(event.args && event.args.size.toString());
-			const currentLandOwner = await LandContract.callStatic.ownerOf(topCornerId);
-			const land: Land = { coordinateX, coordinateY, size, tokenId: topCornerId.toString() };
-			if (currentLandOwner) {
-				landOwnersMap[currentLandOwner] = landOwnersMap[currentLandOwner] || [];
-				landOwnersMap[currentLandOwner].push(land);
-			}
-		}
-	}
+    for (const event of landQuadPurchasedEvents) {
+      const topCornerId: BN = event.args && event.args.topCornerId;
+      const {coordinateX, coordinateY} = tokenIdToMapCoords(topCornerId);
+      const size = new BN(event.args && event.args.size.toString());
+      const currentLandOwner = await LandContract.callStatic.ownerOf(
+        topCornerId
+      );
+      const land: Land = {
+        coordinateX,
+        coordinateY,
+        size,
+        tokenId: topCornerId.toString(),
+      };
+      if (currentLandOwner) {
+        landOwnersMap[currentLandOwner] = landOwnersMap[currentLandOwner] || [];
+        landOwnersMap[currentLandOwner].push(land);
+      }
+    }
+  }
 
-	// write output file
-	console.log(`writing output to file ${exportFilePath}`);
-	fs.ensureDirSync('tmp');
-	fs.writeFileSync(
-		exportFilePath,
-		JSON.stringify(landOwnersMap)
-	);
-})()
+  // write output file
+  console.log(`writing output to file ${exportFilePath}`);
+  fs.ensureDirSync('tmp');
+  fs.writeFileSync(exportFilePath, JSON.stringify(landOwnersMap));
+})();

--- a/scripts/gathering/getLandForMigration.ts
+++ b/scripts/gathering/getLandForMigration.ts
@@ -2,6 +2,7 @@ import { Event } from 'ethers';
 import BN from 'bn.js';
 import fs from 'fs-extra';
 import { ethers } from 'hardhat';
+import hre from 'hardhat';
 
 const startBlock = 5530851; // This is the block number where the Land contract was deployed in rinkeby network
 const networkName = 'rinkeby';
@@ -69,42 +70,9 @@ function tokenIdToMapCoords(topCornerId: BN): { coordinateX: string, coordinateY
 }
 
 (async () => {
-	const presaleContractNames = [
-		'LandPreSale_1',
-		'LandPreSale_10_27',
-		'LandPreSale_10_28',
-		'LandPreSale_10_29',
-		'LandPreSale_10_30',
-		'LandPreSale_11_31',
-		'LandPreSale_12_32',
-		'LandPreSale_2',
-		'LandPreSale_3',
-		'LandPreSale_3_4',
-		'LandPreSale_3_5',
-		'LandPreSale_3_6',
-		'LandPreSale_3_7',
-		'LandPreSale_3_8',
-		'LandPreSale_3_9',
-		'LandPreSale_4_1',
-		'LandPreSale_4_2_11',
-		'LandPreSale_4_2_12',
-		'LandPreSale_4_2_13',
-		'LandPreSale_4_2_14',
-		'LandPreSale_5_16',
-		'LandPreSale_5_17',
-		'LandPreSale_5_18',
-		'LandPreSale_5_19',
-		'LandPreSale_6_18',
-		'LandPreSale_6_bis_18',
-		'LandPreSale_7_19',
-		'LandPreSale_8_20',
-		'LandPreSale_8_21',
-		'LandPreSale_8_22',
-		'LandPreSale_8_23',
-		'LandPreSale_8_24',
-		'LandPreSale_9_25',
-		'LandPreSale_9_26'
-	];
+	const { deployments } = hre;
+	const allDeployedContracts = await deployments.all();
+	const presaleContractNames = Object.keys(allDeployedContracts).filter(contract => contract.includes('LandPreSale'));
 
 	type Land = {
 		coordinateX: string;

--- a/scripts/transact/mintLandsFromFile.ts
+++ b/scripts/transact/mintLandsFromFile.ts
@@ -1,61 +1,68 @@
 import BN from 'bn.js';
 import fs from 'fs-extra';
-import { ethers, deployments } from 'hardhat';
+import {ethers, deployments} from 'hardhat';
 
 const networkName = 'rinkeby';
 const filePath = `tmp/${networkName}-landOwners.json`;
 const errorFilePath = 'tmp/mintLandErrors.json';
 
 (async () => {
-    const { execute } = deployments;
-    const errors = [];
-    type Land = {
-        coordinateX: BN;
-        coordinateY: BN;
-        size: BN;
-        tokenId: string;
-    };
-    type landOwnersMap = { [owner: string]: Land[] };
+  const {execute} = deployments;
+  const errors = [];
+  type Land = {
+    coordinateX: BN;
+    coordinateY: BN;
+    size: BN;
+    tokenId: string;
+  };
+  type landOwnersMap = {[owner: string]: Land[]};
 
-    if(!(fs.existsSync(filePath))) throw new Error(`file ${filePath} does not exist'`);
-    const landOwners: landOwnersMap = JSON.parse(
-        fs.readFileSync(filePath).toString()
-    );
+  if (!fs.existsSync(filePath))
+    throw new Error(`file ${filePath} does not exist'`);
+  const landOwners: landOwnersMap = JSON.parse(
+    fs.readFileSync(filePath).toString()
+  );
 
-    const LandContract = await ethers.getContract('Land');
-    if (!LandContract) throw new Error('Land contract not found');
-    const admin = await LandContract.callStatic.getAdmin();
-    console.log(`land admin is: ${admin}`);
-    
-    // set contract admin as minter and verify
-    await execute('Land', {from: admin}, 'setMinter', admin, true);
-    const isMinter = await LandContract.callStatic.isMinter(admin);
-    if (!isMinter) throw new Error('admin is not minter even after calling setMinter');
+  const LandContract = await ethers.getContract('Land');
+  if (!LandContract) throw new Error('Land contract not found');
+  const admin = await LandContract.callStatic.getAdmin();
+  console.log(`land admin is: ${admin}`);
 
-    for (const landOwner in landOwners) {
-        const lands: Land[] = landOwners[landOwner];
-        for (const land of lands) {
-            try {
-                await execute('Land', {from: admin}, 'mintQuad', landOwner, land.size, land.coordinateX, land.coordinateY, 0);
-            } catch (error ) {
-                if (error instanceof Error) {
-                    errors.push({
-                        ...land,
-                        mintResult: error.message
-                    });
-                }
-            }
-            
-        }
-    }
+  // set contract admin as minter and verify
+  await execute('Land', {from: admin}, 'setMinter', admin, true);
+  const isMinter = await LandContract.callStatic.isMinter(admin);
+  if (!isMinter)
+    throw new Error('admin is not minter even after calling setMinter');
 
-    console.log(`Error count is ${errors.length}`);
-    if (errors.length > 0) {
-        fs.ensureDirSync('tmp');
-        console.log(`writing errors to ${errorFilePath}`);
-        fs.writeFileSync(
-            errorFilePath,
-            JSON.stringify(errors)
+  for (const landOwner in landOwners) {
+    const lands: Land[] = landOwners[landOwner];
+    for (const land of lands) {
+      try {
+        await execute(
+          'Land',
+          {from: admin},
+          'mintQuad',
+          landOwner,
+          land.size,
+          land.coordinateX,
+          land.coordinateY,
+          0
         );
+      } catch (error) {
+        if (error instanceof Error) {
+          errors.push({
+            ...land,
+            mintResult: error.message,
+          });
+        }
+      }
     }
-})()
+  }
+
+  console.log(`Error count is ${errors.length}`);
+  if (errors.length > 0) {
+    fs.ensureDirSync('tmp');
+    console.log(`writing errors to ${errorFilePath}`);
+    fs.writeFileSync(errorFilePath, JSON.stringify(errors));
+  }
+})();

--- a/scripts/transact/mintLandsFromFile.ts
+++ b/scripts/transact/mintLandsFromFile.ts
@@ -1,0 +1,61 @@
+import BN from 'bn.js';
+import fs from 'fs-extra';
+import { ethers, deployments } from 'hardhat';
+
+const networkName = 'rinkeby';
+const filePath = `tmp/${networkName}-landOwners.json`;
+const errorFilePath = 'tmp/mintLandErrors.json';
+
+(async () => {
+    const { execute } = deployments;
+    const errors = [];
+    type Land = {
+        coordinateX: BN;
+        coordinateY: BN;
+        size: BN;
+        tokenId: string;
+    };
+    type landOwnersMap = { [owner: string]: Land[] };
+
+    if(!(fs.existsSync(filePath))) throw new Error(`file ${filePath} does not exist'`);
+    const landOwners: landOwnersMap = JSON.parse(
+        fs.readFileSync(filePath).toString()
+    );
+
+    const LandContract = await ethers.getContract('Land');
+    if (!LandContract) throw new Error('Land contract not found');
+    const admin = await LandContract.callStatic.getAdmin();
+    console.log(`land admin is: ${admin}`);
+    
+    // set contract admin as minter and verify
+    await execute('Land', {from: admin}, 'setMinter', admin, true);
+    const isMinter = await LandContract.callStatic.isMinter(admin);
+    if (!isMinter) throw new Error('admin is not minter even after calling setMinter');
+
+    for (const landOwner in landOwners) {
+        const lands: Land[] = landOwners[landOwner];
+        for (const land of lands) {
+            try {
+                await execute('Land', {from: admin}, 'mintQuad', landOwner, land.size, land.coordinateX, land.coordinateY, 0);
+            } catch (error ) {
+                if (error instanceof Error) {
+                    errors.push({
+                        ...land,
+                        mintResult: error.message
+                    });
+                }
+            }
+            
+        }
+    }
+
+    console.log(`Error count is ${errors.length}`);
+    if (errors.length > 0) {
+        fs.ensureDirSync('tmp');
+        console.log(`writing errors to ${errorFilePath}`);
+        fs.writeFileSync(
+            errorFilePath,
+            JSON.stringify(errors)
+        );
+    }
+})()

--- a/yarn.lock
+++ b/yarn.lock
@@ -1207,6 +1207,11 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
+"@types/minimist@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
+  integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
+
 "@types/mocha@^8.0.2":
   version "8.0.3"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-8.0.3.tgz#51b21b6acb6d1b923bbdc7725c38f9f455166402"


### PR DESCRIPTION
# Description

This PR adds 3 scripts that will allow us to:

1. Gather all the data about minted Lands in one network
2. Mint Lands into a different network directly to the owner
3. Verify the execution and the ownership in the destination network.

These are the steps to execute the scripts in the local hardhat environment:
`yarn execute rinkeby scripts/gathering/getLandForMigration.ts`
`yarn execute localhost scripts/transact/mintLandsFromFile.ts --sourceNetwork rinkeby`
`yarn execute localhost scripts/analysis/verifyLandOwnership.ts --sourceNetwork rinkeby`

