### PR TITLE
fix: fix TwoPeriodsRewardCalculator getRewards

### DIFF
--- a/src/solc_0.8/defi/rewardCalculation/TwoPeriodsRewardCalculator.sol
+++ b/src/solc_0.8/defi/rewardCalculation/TwoPeriodsRewardCalculator.sol
@@ -41,13 +41,18 @@ contract TwoPeriodsRewardCalculator is IRewardCalculator, AccessControl {
     // We need to save the rewards accumulated between the last call to restartRewards and the call to notifyRewardAmount
     uint256 public savedRewards;
     // The reward distribution is divided in two periods with two different rated
-    //             |    **
-    //             |  **
-    //             |**
-    //         ****|
-    //     ****    |
-    // ****        |
-    // <-perido1-> |<-period2->
+    //                   |            |            |************|*
+    //                   |            |          **|            |*
+    //                   |            |        **  |            |*
+    //                   |            |      **    |            |*
+    //                   |            |    **      |            |*
+    //                   |            |  **        |            |*
+    //                   |            |**          |            |*
+    //                   |        ****|            |            |*
+    //                   |    ****    |            |            |*
+    //                   |****        |            |            |*
+    // zero -> **********|            |            |            |********************
+    //                   |<-perido1-> |<-period2-> |<-restart-> |
     uint256 public finish1;
     uint256 public rate1;
     uint256 public finish2;
@@ -178,7 +183,7 @@ contract TwoPeriodsRewardCalculator is IRewardCalculator, AccessControl {
             return (block.timestamp - lastUpdateTime) * rate1;
         }
         // block.timestamp > finish1
-        uint256 rewards2 = (Math.min(block.timestamp, finish2) - finish1) * rate2;
+        uint256 rewards2 = (Math.min(block.timestamp, finish2) - Math.max(lastUpdateTime, finish1)) * rate2;
         if (lastUpdateTime < finish1) {
             // add reward1 + reward2
             return (finish1 - lastUpdateTime) * rate1 + rewards2;


### PR DESCRIPTION
Now it take into account lastUpdateTime for the second period.
Add some tests.

# Description

<!--
Provide a summary of the changes made, and include some context, such as why the changes are needed. This is helpful to both reviewers, and for future reference.
-->

# Checklist:

- [ ] Pull Request references Jira issue
- [ ] Pull Request applies to a single purpose
- [ ] I've added comments to my code where needed
- [ ] I've updated any relevant docs
- [ ] I've added tests to show that my changes achieve the desired results
- [ ] I've reviewed my code
- [ ] I've followed established naming conventions and formatting
- [ ] I've generated a coverage report and included a screenshot
- [ ] All tests are passing locally
