### PR TITLE
set trusted forwarder by owner, not admin

### DIFF
--- a/deploy_polygon/03_sand/05_setup_trusted_forwarder.ts
+++ b/deploy_polygon/03_sand/05_setup_trusted_forwarder.ts
@@ -15,11 +15,11 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   );
   if (!isTrustedForwarder) {
     console.log('Setting TRUSTED_FORWARDER_V2 as trusted forwarder');
-    const admin = await read('PolygonSand', 'getAdmin');
+    const owner = await read('PolygonSand', 'owner');
     await catchUnknownSigner(
       execute(
         'PolygonSand',
-        {from: admin, log: true},
+        {from: owner, log: true},
         'setTrustedForwarder',
         TRUSTED_FORWARDER_V2.address
       )


### PR DESCRIPTION
# Description

Lil fix on the deployment script of polygon sand when changing the trusted forwarder

# Checklist:

- [ ] Pull Request references Jira issue
- [ ] Pull Request applies to a single purpose
- [ ] I've added comments to my code where needed
- [ ] I've updated any relevant docs
- [ ] I've added tests to show that my changes achieve the desired results
- [ ] I've reviewed my code
- [ ] I've followed established naming conventions and formatting
- [ ] I've generated a coverage report and included a screenshot
- [ ] All tests are passing locally
