### PR TITLE
QSP-9 & QSP-11 & mark contract as abstract

### DIFF
--- a/src/solc_0.8/common/BaseWithStorage/ERC2771HandlerV2.sol
+++ b/src/solc_0.8/common/BaseWithStorage/ERC2771HandlerV2.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+// solhint-disable-next-line compiler-version
+pragma solidity 0.8.2;
+
+import "hardhat/console.sol";
+
+/// @dev minimal ERC2771 handler to keep bytecode-size down.
+/// based on: https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/metatx/ERC2771Context.sol
+
+abstract contract ERC2771HandlerV2 {
+    address internal _trustedForwarder;
+
+    function __ERC2771HandlerV2_initialize(address forwarder) internal {
+        _trustedForwarder = forwarder;
+    }
+
+    function isTrustedForwarder(address forwarder) public view returns (bool) {
+        return forwarder == _trustedForwarder;
+    }
+
+    function getTrustedForwarder() external view returns (address trustedForwarder) {
+        return _trustedForwarder;
+    }
+
+    function _msgSender() internal view virtual returns (address sender) {
+        if (isTrustedForwarder(msg.sender)) {
+            require(msg.data.length >= 24, "ERC2771HandlerV2: Invalid msg.data");
+            // The assembly code is more direct than the Solidity version using `abi.decode`.
+            // solhint-disable-next-line no-inline-assembly
+            assembly {
+                sender := shr(96, calldataload(sub(calldatasize(), 20)))
+            }
+        } else {
+            return msg.sender;
+        }
+    }
+
+    function _msgData() internal view virtual returns (bytes calldata) {
+        if (isTrustedForwarder(msg.sender)) {
+            require(msg.data.length >= 24, "ERC2771HandlerV2: Invalid msg.data");
+            return msg.data[:msg.data.length - 20];
+        } else {
+            return msg.data;
+        }
+    }
+}

--- a/src/solc_0.8/common/BaseWithStorage/ERC2771HandlerV2.sol
+++ b/src/solc_0.8/common/BaseWithStorage/ERC2771HandlerV2.sol
@@ -2,8 +2,6 @@
 // solhint-disable-next-line compiler-version
 pragma solidity 0.8.2;
 
-import "hardhat/console.sol";
-
 /// @dev minimal ERC2771 handler to keep bytecode-size down.
 /// based on: https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/metatx/ERC2771Context.sol
 

--- a/src/solc_0.8/defi/ERC20RewardPool.sol
+++ b/src/solc_0.8/defi/ERC20RewardPool.sol
@@ -9,7 +9,7 @@ import {ReentrancyGuard} from "@openzeppelin/contracts-0.8/security/ReentrancyGu
 import {Address} from "@openzeppelin/contracts-0.8/utils/Address.sol";
 import {AccessControl} from "@openzeppelin/contracts-0.8/access/AccessControl.sol";
 import {Pausable} from "@openzeppelin/contracts-0.8/security/Pausable.sol";
-import {ERC2771Handler} from "../common/BaseWithStorage/ERC2771Handler.sol";
+import {ERC2771HandlerV2} from "../common/BaseWithStorage/ERC2771HandlerV2.sol";
 import {StakeTokenWrapper} from "./StakeTokenWrapper.sol";
 import {IContributionRules} from "./interfaces/IContributionRules.sol";
 import {IRewardCalculator} from "./interfaces/IRewardCalculator.sol";
@@ -32,7 +32,7 @@ contract ERC20RewardPool is
     RequirementsRules,
     AccessControl,
     ReentrancyGuard,
-    ERC2771Handler,
+    ERC2771HandlerV2,
     Pausable
 {
     using SafeERC20 for IERC20;
@@ -71,7 +71,7 @@ contract ERC20RewardPool is
     ) StakeTokenWrapper(stakeToken_) {
         rewardToken = rewardToken_;
         _setupRole(DEFAULT_ADMIN_ROLE, _msgSender());
-        __ERC2771Handler_initialize(trustedForwarder);
+        __ERC2771HandlerV2_initialize(trustedForwarder);
     }
 
     modifier isContractAndAdmin(address contractAddress) {
@@ -384,11 +384,11 @@ contract ERC20RewardPool is
         return (rewardCalculator.getRewards() * 1e24) / _totalContributions;
     }
 
-    function _msgSender() internal view override(Context, ERC2771Handler) returns (address sender) {
-        return ERC2771Handler._msgSender();
+    function _msgSender() internal view override(Context, ERC2771HandlerV2) returns (address sender) {
+        return ERC2771HandlerV2._msgSender();
     }
 
-    function _msgData() internal view override(Context, ERC2771Handler) returns (bytes calldata) {
-        return ERC2771Handler._msgData();
+    function _msgData() internal view override(Context, ERC2771HandlerV2) returns (bytes calldata) {
+        return ERC2771HandlerV2._msgData();
     }
 }


### PR DESCRIPTION
# Description
QSP-9 ERC2771Handler not checking msg.data length
QSP-11 Unlocked Pragma
Adherence to Best Practices -> The ERC2771Handler.sol is not meant to be used on its own. Therefore, mark it as abstract.
<!--
Provide a summary of the changes made, and include some context, such as why the changes are needed. This is helpful to both reviewers, and for future reference.
-->

# Checklist:

- [x] Pull Request references Jira issue
- [x] Pull Request applies to a single purpose
- [x] I've added comments to my code where needed
- [x] I've updated any relevant docs
- [x] I've added tests to show that my changes achieve the desired results
- [x] I've reviewed my code
- [x] I've followed established naming conventions and formatting
- [x] I've generated a coverage report and included a screenshot
- [x] All tests are passing locally
