### PR TITLE
L12 SafeMath is unneeded after 0.8.0

### DIFF
--- a/src/solc_0.8/asset/AssetMinter.sol
+++ b/src/solc_0.8/asset/AssetMinter.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.2;
 pragma experimental ABIEncoderV2;
 
-import "@openzeppelin/contracts-0.8/utils/math/SafeMath.sol";
 import "@openzeppelin/contracts-0.8/access/Ownable.sol";
 import "../common/BaseWithStorage/ERC2771Handler.sol";
 import "../common/interfaces/IAssetMinter.sol";

--- a/src/solc_0.8/common/Libraries/SafeMathWithRequire.sol
+++ b/src/solc_0.8/common/Libraries/SafeMathWithRequire.sol
@@ -1,23 +1,19 @@
 //SPDX-License-Identifier: MIT
 pragma solidity 0.8.2;
 
-import "@openzeppelin/contracts-0.8/utils/math/SafeMath.sol";
-
 /**
  * @title SafeMath
  * @dev Math operations with safety checks that revert
  */
 library SafeMathWithRequire {
-    using SafeMath for uint256;
-
     uint256 private constant DECIMALS_18 = 1000000000000000000;
     uint256 private constant DECIMALS_12 = 1000000000000;
     uint256 private constant DECIMALS_9 = 1000000000;
     uint256 private constant DECIMALS_6 = 1000000;
 
     function sqrt6(uint256 a) internal pure returns (uint256 c) {
-        a = a.mul(DECIMALS_12);
-        uint256 tmp = a.add(1) / 2;
+        a = a * DECIMALS_12;
+        uint256 tmp = (a + 1) / 2;
         c = a;
         // tmp cannot be zero unless a = 0 which skip the loop
         while (tmp < c) {
@@ -27,8 +23,8 @@ library SafeMathWithRequire {
     }
 
     function sqrt3(uint256 a) internal pure returns (uint256 c) {
-        a = a.mul(DECIMALS_6);
-        uint256 tmp = a.add(1) / 2;
+        a = a * DECIMALS_6;
+        uint256 tmp = (a + 1) / 2;
         c = a;
         // tmp cannot be zero unless a = 0 which skip the loop
         while (tmp < c) {
@@ -38,8 +34,8 @@ library SafeMathWithRequire {
     }
 
     function cbrt6(uint256 a) internal pure returns (uint256 c) {
-        a = a.mul(DECIMALS_18);
-        uint256 tmp = a.add(2) / 3;
+        a = a * DECIMALS_18;
+        uint256 tmp = (a + 2) / 3;
         c = a;
         // tmp cannot be zero unless a = 0 which skip the loop
         while (tmp < c) {
@@ -52,8 +48,8 @@ library SafeMathWithRequire {
     }
 
     function cbrt3(uint256 a) internal pure returns (uint256 c) {
-        a = a.mul(DECIMALS_9);
-        uint256 tmp = a.add(2) / 3;
+        a = a * DECIMALS_9;
+        uint256 tmp = (a + 2) / 3;
         c = a;
         // tmp cannot be zero unless a = 0 which skip the loop
         while (tmp < c) {


### PR DESCRIPTION
# Description

<img width="1049" alt="Screenshot 2022-06-21 at 11 47 35 AM" src="https://user-images.githubusercontent.com/91669586/174729562-ec45e626-c9eb-4c48-824f-03eb9e8cbe04.png">


# Checklist:

- [ ] Pull Request references Jira issue
- [ ] Pull Request applies to a single purpose
- [ ] I've added comments to my code where needed
- [ ] I've updated any relevant docs
- [ ] I've added tests to show that my changes achieve the desired results
- [ ] I've reviewed my code
- [ ] I've followed established naming conventions and formatting
- [ ] I've generated a coverage report and included a screenshot
- [ ] All tests are passing locally
