### PR TITLE
QSP-2 can't revoke admin role

### DIFF
--- a/src/solc_0.8/claims/MultiGiveaway/MultiGiveaway.sol
+++ b/src/solc_0.8/claims/MultiGiveaway/MultiGiveaway.sol
@@ -147,7 +147,7 @@ contract MultiGiveaway is AccessControl, ClaimERC1155ERC721ERC20, ERC2771Handler
     /// @param account the address being revoked
     function _revokeRole(bytes32 role, address account) internal virtual override {
         if (role == DEFAULT_ADMIN_ROLE) {
-            revert("MultiGiveaway: DEFAULT_ADMIN_ROLE role can't be revoked");
+            revert("MULTIGIVEAWAY_PREVENT_REVOKE");
         }
 
         super._revokeRole(role, account);

--- a/src/solc_0.8/claims/MultiGiveaway/MultiGiveaway.sol
+++ b/src/solc_0.8/claims/MultiGiveaway/MultiGiveaway.sol
@@ -141,4 +141,15 @@ contract MultiGiveaway is AccessControl, ClaimERC1155ERC721ERC20, ERC2771Handler
     function _msgData() internal view override(Context, ERC2771Handler) returns (bytes calldata) {
         return ERC2771Handler._msgData();
     }
+
+    /// @dev Prevent the renunciation of the DEFAULT_ADMIN_ROLE
+    /// @param role the role to revoke
+    /// @param account the address being revoked
+    function _revokeRole(bytes32 role, address account) internal virtual override {
+        if (role == DEFAULT_ADMIN_ROLE) {
+            revert("MultiGiveaway: DEFAULT_ADMIN_ROLE role can't be revoked");
+        }
+
+        super._revokeRole(role, account);
+    }
 }

--- a/test/multiGiveaway/multiGiveaway.test.ts
+++ b/test/multiGiveaway/multiGiveaway.test.ts
@@ -44,9 +44,7 @@ describe('Multi_Giveaway', function () {
 
       await expect(
         giveawayContractAsAdmin.revokeRole(defaultRole, multiGiveawayAdmin)
-      ).to.be.revertedWith(
-        "MultiGiveaway: DEFAULT_ADMIN_ROLE role can't be revoked"
-      );
+      ).to.be.revertedWith('MULTIGIVEAWAY_PREVENT_REVOKE');
     });
     it('Admin can add a new giveaway', async function () {
       const options = {};

--- a/test/multiGiveaway/multiGiveaway.test.ts
+++ b/test/multiGiveaway/multiGiveaway.test.ts
@@ -36,6 +36,18 @@ describe('Multi_Giveaway', function () {
       expect(await giveawayContract.hasRole(defaultRole, multiGiveawayAdmin)).to
         .be.true;
     });
+    it("Admin can't revoke admin role", async function () {
+      const options = {};
+      const setUp = await setupTestGiveaway(options);
+      const {giveawayContractAsAdmin, multiGiveawayAdmin} = setUp;
+      const defaultRole = emptyBytes32;
+
+      await expect(
+        giveawayContractAsAdmin.revokeRole(defaultRole, multiGiveawayAdmin)
+      ).to.be.revertedWith(
+        "MultiGiveaway: DEFAULT_ADMIN_ROLE role can't be revoked"
+      );
+    });
     it('Admin can add a new giveaway', async function () {
       const options = {};
       const setUp = await setupTestGiveaway(options);


### PR DESCRIPTION
# Description

Prevent the renunciation of the DEFAULT_ADMIN_ROLE.
![QSP-2](https://user-images.githubusercontent.com/4458590/177815579-e963e0a6-d1d5-4f39-8819-ace2a94be1f6.png)


# Checklist:

- [ ] Pull Request references Jira issue
- [ ] Pull Request applies to a single purpose
- [ ] I've added comments to my code where needed
- [ ] I've updated any relevant docs
- [ ] I've added tests to show that my changes achieve the desired results
- [ ] I've reviewed my code
- [ ] I've followed established naming conventions and formatting
- [ ] I've generated a coverage report and included a screenshot
- [ ] All tests are passing locally
