### PR TITLE
StarterPack-AUDIT-QSP-1-typehash-fix

### DIFF
--- a/src/solc_0.8/StarterPack/PurchaseValidator.sol
+++ b/src/solc_0.8/StarterPack/PurchaseValidator.sol
@@ -16,7 +16,7 @@ contract PurchaseValidator is AccessControl, EIP712 {
 
     bytes32 public constant PURCHASE_TYPEHASH =
         keccak256(
-            "Purchase(address buyer,uint256[] catalystIds,uint256[] catalystQuantities,uint256[] gemIds,uint256[] gemQuantities,uint256 nonce)"
+            "Purchase(address buyer,uint16[] catalystIds,uint256[] catalystQuantities,uint16[] gemIds,uint256[] gemQuantities,uint256 nonce)"
         );
 
     event SigningWallet(address indexed newSigningWallet);

--- a/test/polygon/starterPack/signature.ts
+++ b/test/polygon/starterPack/signature.ts
@@ -49,9 +49,9 @@ export const starterPack712Signature = async function (
       ],
       Purchase: [
         {name: 'buyer', type: 'address'},
-        {name: 'catalystIds', type: 'uint256[]'},
+        {name: 'catalystIds', type: 'uint16[]'},
         {name: 'catalystQuantities', type: 'uint256[]'},
-        {name: 'gemIds', type: 'uint256[]'},
+        {name: 'gemIds', type: 'uint16[]'},
         {name: 'gemQuantities', type: 'uint256[]'},
         {name: 'nonce', type: 'uint256'},
       ],


### PR DESCRIPTION
# Description

Converted Purchase typehash to use uint16[] for catalystIds and gemIds after merge
Required same change in test signature

# Checklist:

- [ ] Pull Request references Jira issue
- [x] Pull Request applies to a single purpose
- [ ] I've added comments to my code where needed
- [ ] I've updated any relevant docs
- [ ] I've added tests to show that my changes achieve the desired results
- [ ] I've reviewed my code
- [ ] I've followed established naming conventions and formatting
- [ ] I've generated a coverage report and included a screenshot
- [x] All tests are passing locally
