### PR TITLE
QSP-5 ReferralValidator.handleReferralWithETH() Does Not Verify msg.value

### DIFF
--- a/src/solc_0.6/EstateSale/AuthValidator.sol
+++ b/src/solc_0.6/EstateSale/AuthValidator.sol
@@ -11,6 +11,9 @@ contract AuthValidator is Admin {
     event SigningWallet(address indexed signingWallet);
 
     constructor(address adminWallet, address initialSigningWallet) public {
+        require(adminWallet != address(0), "AuthValidator: zero address");
+        require(initialSigningWallet != address(0), "AuthValidator: zero address");
+
         _admin = adminWallet;
         _updateSigningAuthWallet(initialSigningWallet);
     }
@@ -20,7 +23,7 @@ contract AuthValidator is Admin {
     }
 
     function _updateSigningAuthWallet(address newSigningWallet) internal {
-        require(newSigningWallet != address(0), "INVALID_SIGNING_WALLET");
+        require(newSigningWallet != address(0), "AuthValidator: INVALID_SIGNING_WALLET");
         _signingAuthWallet = newSigningWallet;
         emit SigningWallet(newSigningWallet);
     }

--- a/src/solc_0.6/EstateSale/EstateSaleWithAuth.sol
+++ b/src/solc_0.6/EstateSale/EstateSaleWithAuth.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.6.5;
 
 import "@openzeppelin/contracts-0.6/utils/ReentrancyGuard.sol";
+import "@openzeppelin/contracts-0.6/utils/Address.sol";
 import "../common/Libraries/SafeMathWithRequire.sol";
 import "./LandToken.sol";
 import "../common/Interfaces/ERC1155.sol";
@@ -14,6 +15,7 @@ import "./AuthValidator.sol";
 /// @notice This contract manages the sale of our lands as Estates
 contract EstateSaleWithAuth is ReentrancyGuard, MetaTransactionReceiver, ReferralValidator {
     using SafeMathWithRequire for uint256;
+    using Address for address;
 
     event LandQuadPurchased(
         address indexed buyer,
@@ -258,6 +260,18 @@ contract EstateSaleWithAuth is ReentrancyGuard, MetaTransactionReceiver, Referra
         address feeDistributor,
         address authValidator
     ) public ReferralValidator(initialSigningWallet, initialMaxCommissionRate) {
+        require(landAddress.isContract(), "EstateSaleWithAuth: is not a contract");
+        require(sandContractAddress.isContract(), "EstateSaleWithAuth: is not a contract");
+        require(initialMetaTx != address(0), "EstateSaleWithAuth: zero address");
+        require(admin != address(0), "EstateSaleWithAuth: zero address");
+        require(initialWalletAddress != address(0), "EstateSaleWithAuth: zero address");
+        require(estate.isContract(), "EstateSaleWithAuth: is not a contract");
+        require(asset.isContract(), "EstateSaleWithAuth: is not a contract");
+        require(feeDistributor != address(0), "EstateSaleWithAuth: zero address");
+        require(authValidator.isContract(), "EstateSaleWithAuth: is not a contract");
+
+        require(block.timestamp < expiryTime, "EstateSaleWithAuth: invalid expiryTime");
+
         _land = LandToken(landAddress);
         _sand = ERC20(sandContractAddress);
         _setMetaTransactionProcessor(initialMetaTx, true);

--- a/src/solc_0.6/EstateSale/EstateSaleWithAuth.sol
+++ b/src/solc_0.6/EstateSale/EstateSaleWithAuth.sol
@@ -265,12 +265,10 @@ contract EstateSaleWithAuth is ReentrancyGuard, MetaTransactionReceiver, Referra
         require(initialMetaTx != address(0), "EstateSaleWithAuth: zero address");
         require(admin != address(0), "EstateSaleWithAuth: zero address");
         require(initialWalletAddress != address(0), "EstateSaleWithAuth: zero address");
-        require(estate.isContract(), "EstateSaleWithAuth: is not a contract");
         require(asset.isContract(), "EstateSaleWithAuth: is not a contract");
         require(feeDistributor != address(0), "EstateSaleWithAuth: zero address");
         require(authValidator.isContract(), "EstateSaleWithAuth: is not a contract");
 
-        require(block.timestamp < expiryTime, "EstateSaleWithAuth: invalid expiryTime");
 
         _land = LandToken(landAddress);
         _sand = ERC20(sandContractAddress);

--- a/src/solc_0.6/EstateSale/EstateSaleWithAuth.sol
+++ b/src/solc_0.6/EstateSale/EstateSaleWithAuth.sol
@@ -1,6 +1,7 @@
 /* solhint-disable not-rely-on-time, func-order */
 pragma solidity 0.6.5;
 
+import "@openzeppelin/contracts-0.6/utils/ReentrancyGuard.sol";
 import "../common/Libraries/SafeMathWithRequire.sol";
 import "./LandToken.sol";
 import "../common/Interfaces/ERC1155.sol";
@@ -11,7 +12,7 @@ import "./AuthValidator.sol";
 
 /// @title Estate Sale contract with referral
 /// @notice This contract manages the sale of our lands as Estates
-contract EstateSaleWithAuth is MetaTransactionReceiver, ReferralValidator {
+contract EstateSaleWithAuth is ReentrancyGuard, MetaTransactionReceiver, ReferralValidator {
     using SafeMathWithRequire for uint256;
 
     event LandQuadPurchased(
@@ -48,7 +49,7 @@ contract EstateSaleWithAuth is MetaTransactionReceiver, ReferralValidator {
         bytes32[] calldata proof,
         bytes calldata referral,
         bytes calldata signature
-    ) external {
+    ) external nonReentrant {
         _checkAddressesAndExpiryTime(buyer, reserved);
         _checkAuthAndProofValidity(to, reserved, info, salt, assetIds, proof, signature);
         _handleFeeAndReferral(buyer, info[PRICE_INDEX], referral);

--- a/src/solc_0.6/ReferralValidator/ReferralValidator.sol
+++ b/src/solc_0.6/ReferralValidator/ReferralValidator.sol
@@ -77,6 +77,8 @@ contract ReferralValidator is Admin {
     ) internal {
         uint256 amountForDestination = amount;
 
+        require(msg.value >= amount, "ReferralValidator: insufficient funds");
+
         if (referral.length > 0) {
             (bytes memory signature, address referrer, address referee, uint256 expiryTime, uint256 commissionRate) = decodeReferral(referral);
 

--- a/src/solc_0.6/common/BaseWithStorage/MetaTransactionReceiver.sol
+++ b/src/solc_0.6/common/BaseWithStorage/MetaTransactionReceiver.sol
@@ -2,7 +2,6 @@ pragma solidity 0.6.5;
 
 import "./Admin.sol";
 
-
 contract MetaTransactionReceiver is Admin {
     mapping(address => bool) internal _metaTransactionContracts;
 
@@ -16,6 +15,7 @@ contract MetaTransactionReceiver is Admin {
     /// @param enabled set whether the metaTransactionProcessor is enabled or disabled.
     function setMetaTransactionProcessor(address metaTransactionProcessor, bool enabled) public {
         require(msg.sender == _admin, "only admin can setup metaTransactionProcessors");
+        require(metaTransactionProcessor != address(0), "MetaTransactionReceiver: zero address");
         _setMetaTransactionProcessor(metaTransactionProcessor, enabled);
     }
 


### PR DESCRIPTION
# Description
QSP-5 ReferralValidator.handleReferralWithETH() Does Not Verify msg.value
<!--
Provide a summary of the changes made, and include some context, such as why the changes are needed. This is helpful to both reviewers, and for future reference.
-->

# Checklist:

- [ ] Pull Request references Jira issue
- [ ] Pull Request applies to a single purpose
- [ ] I've added comments to my code where needed
- [ ] I've updated any relevant docs
- [ ] I've added tests to show that my changes achieve the desired results
- [ ] I've reviewed my code
- [ ] I've followed established naming conventions and formatting
- [ ] I've generated a coverage report and included a screenshot
- [ ] All tests are passing locally
