### PR TITLE
generate random salt for 2 claims with same params

### DIFF
--- a/lib/merkleTreeHelper.ts
+++ b/lib/merkleTreeHelper.ts
@@ -260,7 +260,7 @@ function saltMultiClaim(
             .update(
               calculateMultiClaimHash(
                 claim,
-                '0x0000000000000000000000000000000000000000000000000000000000000000'
+                '0x' + crypto.randomBytes(32).toString('hex')
               )
             )
             .digest('hex'),


### PR DESCRIPTION
# Description

2 claims with the same parameters will use the same salt. To fix that, we generate a random hex in the mix to generate the salt

# Checklist:

- [ ] Pull Request references Jira issue
- [ ] Pull Request applies to a single purpose
- [ ] I've added comments to my code where needed
- [ ] I've updated any relevant docs
- [ ] I've added tests to show that my changes achieve the desired results
- [ ] I've reviewed my code
- [ ] I've followed established naming conventions and formatting
- [ ] I've generated a coverage report and included a screenshot
- [ ] All tests are passing locally
