### PR TITLE
feat: add script to giveaways recovery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,3 +42,7 @@ ETHERSCAN_API_KEY_MUMBAI=xxxxxxxxxxxxxxxxxxxxxx
 NODE_OPTIONS=--max-old-space-size=8192
 
 INFURA_HTTP_BLOCK_QUERY_LIMIT=1000
+
+# THE GRAPH URL
+CLAIMS_GRAPH_URL_MUMBAI=xxxxxxxxxxxxxxxxxxxxxx
+CLAIMS_GRAPH_URL_POLYGON=xxxxxxxxxxxxxxxxxxxxxx

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ deployments/rinkeby_test
 deployments/goerli_test
 deployments/mumbai_test
 
+scripts/giveaway/*.csv
 scripts/giveaway/output
 scripts/giveaway/proofs/**/
 

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ deployments/rinkeby_test
 deployments/goerli_test
 deployments/mumbai_test
 
+scripts/giveaway/output
+scripts/giveaway/proofs/**/
+
 .google_credentials.json
 token.json
 .bitski*

--- a/scripts/giveaway/README.md
+++ b/scripts/giveaway/README.md
@@ -6,15 +6,20 @@ Both scripts require to copy of the final proof files containing the data for ea
 
 The search-duplicates.ts script reads the proof files for duplicate salts and writes the search result to the output folder.
 
-The regenerate.ts script reads the proof files, checks the claims made for each giveaway using TheGraph, and creates a new file with the unrealized claims.
+The regenerate.ts script reads the proof files, checks the claims made for each giveaway using The Graph, and creates a new file with unrealized claims, excluding banned wallets.
+
+# Checklist
+
+- [ ] Add script to detect duplicated giveaway salt signatures
+- [ ] Add script to regenerate unclaimed giveaways.
 
 # Check for duplicates
 
-Copy proofs files from Amazon S3 to the folowing directory:
+Copy proofs files from Amazon S3 to the following directory:
     
     sandbox-smart-contracts/scripts/giveaway/proofs/{network}/{giveaway}
     
-After copy the files we should have something like this:
+After copying the files, we should have something like this:
 
     sandbox-smart-contracts/scripts/giveaway/proofs/mumbai/45/proofs
     sandbox-smart-contracts/scripts/giveaway/proofs/mumbai/64/proofs
@@ -22,7 +27,7 @@ After copy the files we should have something like this:
     sandbox-smart-contracts/scripts/giveaway/proofs/mumbai/73/proofs
     ...
 
-or for polygon mainnet:
+Or for polygon mainnet:
 
     sandbox-smart-contracts/scripts/giveaway/proofs/polygon/45/proofs
     sandbox-smart-contracts/scripts/giveaway/proofs/polygon/64/proofs
@@ -50,7 +55,24 @@ This file lets us know how many duplicate salts we have and what giveaways are i
 
 # Regenerate Claims
 
-The script to regenerate takes all the claims existing in the proof file and checks if they were already claimed. The script creates a new file with the list of unclaimed giveaways.
+The script to regenerate will take all the claims existing in the proof file and check if they were already claimed. The script creates a new file with the list of unclaimed giveaways. This list does not include the claims for banned wallets. 
+
+To exclude the banned wallets, it's required to put in place the file `deny_list_wallets.csv` provided by the anti-cheating team at the following path:
+
+    sandbox-smart-contracts/scripts/giveaway
+
+This file looks like this:
+
+    user_wallet
+    0x00000006o796df0489b6f16120e9a72bbc945t78
+    0x000000a5694c92839fdbcef14245f7b8c4534098
+    0x000000a4fc9e28e0fd2fa5fb5435cb10d9a45u90
+
+The claims corresponding to banned wallets will be saved to a different file ending with _banned.json
+
+e.g.:
+
+    sandbox-smart-contracts/scripts/giveaway/output/mumbai/{giveaway}_banned.json
 
 With the files to process in place, run the following command:
 
@@ -61,7 +83,7 @@ The script generates two output files for each giveaway:
     sandbox-smart-contracts/scripts/giveaway/output/mumbai/{giveaway}.json
     sandbox-smart-contracts/scripts/giveaway/output/mumbai/{giveaway}.csv
 
-After run the script we should have something like this:
+After running the script, we should have something like this:
 
     sandbox-smart-contracts/scripts/giveaway/output/mumbai/45.json
     sandbox-smart-contracts/scripts/giveaway/output/mumbai/45.csv
@@ -69,7 +91,7 @@ After run the script we should have something like this:
     sandbox-smart-contracts/scripts/giveaway/output/mumbai/64.csv
     ...
 
-or for Polygon mainnet:
+Or for Polygon Mainnet:
 
     sandbox-smart-contracts/scripts/giveaway/output/polygon/45.json
     sandbox-smart-contracts/scripts/giveaway/output/polygon/45.csv

--- a/scripts/giveaway/README.md
+++ b/scripts/giveaway/README.md
@@ -1,6 +1,6 @@
 # Description
 
-To correct the duplicate signatures in the claiming data for multiple giveaways on Polygon, we have created a couple of scripts:
+To fix the duplicate signatures in the claiming data for multiple giveaways on Polygon, we have created a couple of scripts:
 
 Both scripts require to copy of the final proof files containing the data for each claim.
 
@@ -32,9 +32,9 @@ or for polygon mainnet:
 
 Once in place the files to process, run the following command:
 
-    npx ts-node scripts/giveaway/search-duplicates.ts
+    yarn execute <NETWORK> ./scripts/giveaway/search-duplicates.ts
 
-The script runs on the Mumbai testnet by default and generates a CSV file:
+The script generates a CSV file:
 
     sandbox-smart-contracts/scripts/giveaway/output/mumbai/duplicates.csv
 
@@ -48,19 +48,15 @@ The content file looks like this:
 
 This file lets us know how many duplicate salts we have and what giveaways are involved.
 
-To run the script using polygon mainnet network is required to add the flag --polygon
-
-    npx ts-node scripts/giveaway/search-duplicates.ts --polygon
-
 # Regenerate Claims
 
 The script to regenerate takes all the claims existing in the proof file and checks if they were already claimed. The script creates a new file with the list of unclaimed giveaways.
 
 With the files to process in place, run the following command:
 
-    npx ts-node scripts/giveaway/regenerate.ts
+    yarn execute <NETWORK> ./scripts/giveaway/regenerate.ts
 
-The script runs on the Mumbai testnet by default and generates two output files for each giveaway:
+The script generates two output files for each giveaway:
 
     sandbox-smart-contracts/scripts/giveaway/output/mumbai/{giveaway}.json
     sandbox-smart-contracts/scripts/giveaway/output/mumbai/{giveaway}.csv
@@ -82,7 +78,3 @@ or for Polygon mainnet:
     ...
 
 The JSON file has the format to be processed with the current procedure (by hand). The CSV file has the format to be processed by the new giveaway back-office.
-
-To run the script using Polygon mainnet network is required to add the flag --polygon
-
-    npx ts-node scripts/giveaway/regenerate.ts --polygon

--- a/scripts/giveaway/README.md
+++ b/scripts/giveaway/README.md
@@ -1,0 +1,88 @@
+# Description
+
+To correct the duplicate signatures in the claiming data for multiple giveaways on Polygon, we have created a couple of scripts:
+
+Both scripts require to copy of the final proof files containing the data for each claim.
+
+The search-duplicates.ts script reads the proof files for duplicate salts and writes the search result to the output folder.
+
+The regenerate.ts script reads the proof files, checks the claims made for each giveaway using TheGraph, and creates a new file with the unrealized claims.
+
+# Check for duplicates
+
+Copy proofs files from Amazon S3 to the folowing directory:
+    
+    sandbox-smart-contracts/scripts/giveaway/proofs/{network}/{giveaway}
+    
+After copy the files we should have something like this:
+
+    sandbox-smart-contracts/scripts/giveaway/proofs/mumbai/45/proofs
+    sandbox-smart-contracts/scripts/giveaway/proofs/mumbai/64/proofs
+    sandbox-smart-contracts/scripts/giveaway/proofs/mumbai/66/proofs
+    sandbox-smart-contracts/scripts/giveaway/proofs/mumbai/73/proofs
+    ...
+
+or for polygon mainnet:
+
+    sandbox-smart-contracts/scripts/giveaway/proofs/polygon/45/proofs
+    sandbox-smart-contracts/scripts/giveaway/proofs/polygon/64/proofs
+    sandbox-smart-contracts/scripts/giveaway/proofs/polygon/66/proofs
+    sandbox-smart-contracts/scripts/giveaway/proofs/polygon/73/proofs
+    ...
+
+Once in place the files to process, run the following command:
+
+    npx ts-node scripts/giveaway/search-duplicates.ts
+
+The script runs on the Mumbai testnet by default and generates a CSV file:
+
+    sandbox-smart-contracts/scripts/giveaway/output/mumbai/duplicates.csv
+
+The content file looks like this:
+
+    salt,giveaways
+    0x6939b0d018927ad7420456e206727c8862eb2ebbdd79851165aa6b38e6061ed8,"268,269"
+    0x114b2e829bd3ac68b46b9787b3f3d76c96cb325be9ac4d9108b8d8d1c8bf7e58,"268,269"
+    0x3014a81f15cbf6084454c06a95f984e39f68964e1b9c83b0fde9f81e10d97fd9,"268,269"
+    0xbf260a18800fd90ac0f898501f5eb4da09a1c7d1725b17ed682f4af2ef12a1e6,"268,269"
+
+This file lets us know how many duplicate salts we have and what giveaways are involved.
+
+To run the script using polygon mainnet network is required to add the flag --polygon
+
+    npx ts-node scripts/giveaway/search-duplicates.ts --polygon
+
+# Regenerate Claims
+
+The script to regenerate takes all the claims existing in the proof file and checks if they were already claimed. The script creates a new file with the list of unclaimed giveaways.
+
+With the files to process in place, run the following command:
+
+    npx ts-node scripts/giveaway/regenerate.ts
+
+The script runs on the Mumbai testnet by default and generates two output files for each giveaway:
+
+    sandbox-smart-contracts/scripts/giveaway/output/mumbai/{giveaway}.json
+    sandbox-smart-contracts/scripts/giveaway/output/mumbai/{giveaway}.csv
+
+After run the script we should have something like this:
+
+    sandbox-smart-contracts/scripts/giveaway/output/mumbai/45.json
+    sandbox-smart-contracts/scripts/giveaway/output/mumbai/45.csv
+    sandbox-smart-contracts/scripts/giveaway/output/mumbai/64.json
+    sandbox-smart-contracts/scripts/giveaway/output/mumbai/64.csv
+    ...
+
+or for Polygon mainnet:
+
+    sandbox-smart-contracts/scripts/giveaway/output/polygon/45.json
+    sandbox-smart-contracts/scripts/giveaway/output/polygon/45.csv
+    sandbox-smart-contracts/scripts/giveaway/output/polygon/64.json
+    sandbox-smart-contracts/scripts/giveaway/output/polygon/64.csv
+    ...
+
+The JSON file has the format to be processed with the current procedure (by hand). The CSV file has the format to be processed by the new giveaway back-office.
+
+To run the script using Polygon mainnet network is required to add the flag --polygon
+
+    npx ts-node scripts/giveaway/regenerate.ts --polygon

--- a/scripts/giveaway/regenerate.ts
+++ b/scripts/giveaway/regenerate.ts
@@ -3,7 +3,12 @@
  *  - yarn execute <NETWORK> ./scripts/giveaway/regenerate.ts
  */
 import fs from 'fs';
-import path from 'path';
+import csv from 'csv-parser';
+import {
+  ERC1155Claim,
+  ERC721Claim,
+  MultiClaim,
+} from '../../lib/merkleTreeHelper';
 import tsbApi from './tsb-api';
 import {
   getClaimTxs,
@@ -13,70 +18,84 @@ import {
   getOutputBasePath,
 } from './utils';
 
-const main = async () => {
+const createClaimFiles = async (
+  bannedWallets: Array<{user_wallet: string}>
+) => {
   createtMultigiveawayBasePath();
   const giveaways = getMultiGiveawayPaths();
+  const basePath = getOutputBasePath();
+
+  if (!fs.existsSync(basePath)) {
+    fs.mkdirSync(basePath, {recursive: true});
+  }
 
   for (const giveaway of giveaways) {
     const claim = await tsbApi.getClaim(giveaway);
     const proofsFileData = getProofsFileData(giveaway);
+    const isBanned = (walletAddress: string): boolean => {
+      return bannedWallets.some(
+        ({user_wallet}) =>
+          user_wallet.toLowerCase() === walletAddress.toLowerCase()
+      );
+    };
 
     if (proofsFileData) {
-      const basePath = getOutputBasePath();
-      if (!fs.existsSync(basePath)) {
-        fs.mkdirSync(basePath, {recursive: true});
-      }
-      const resultFileJSON = path.join(basePath, `${giveaway}.json`);
+      const resultFileJSON = `${basePath}/${giveaway}.json`;
+
       if (fs.existsSync(resultFileJSON)) {
         console.log(`${claim.name} already processed.`);
       } else {
         console.log(`getting claim transactions for ${claim.name}...`);
+
         const claimed = await getClaimTxs(claim.rootHash);
-        const result = [];
+        const result: Array<MultiClaim> = [];
+        const bannedResult: Array<MultiClaim> = [];
+        const bannedResultFileJSON = `${basePath}/${giveaway}_banned.json`;
+        const resultFileCSV = `${basePath}/${giveaway}.csv`;
 
         for (let i = 0; i < proofsFileData.length; i++) {
           const entry = proofsFileData[i];
           const wallet = entry.to.toLowerCase();
           const isClaimed = claimed.some((claim) => claim.wallet.id === wallet);
+          const banned = isBanned(entry.to);
 
           if (!isClaimed) {
             const {erc20, erc1155, erc721, to} = entry;
-            result.push({
+            const newEntry = {
               erc20,
               erc1155,
               erc721,
               to,
-            });
+            };
+            if (banned) {
+              bannedResult.push(newEntry);
+            } else {
+              result.push(newEntry);
+            }
           }
 
           console.log(`${claim.name} - ${i + 1}/${proofsFileData.length}`);
         }
 
         fs.writeFileSync(resultFileJSON, JSON.stringify(result));
+        if (bannedResult.length) {
+          fs.writeFileSync(bannedResultFileJSON, JSON.stringify(bannedResult));
+        }
 
-        const resultFileCSV = path.join(basePath, `${giveaway}.csv`);
         let resultFileCSVContent =
           'type,contractAddress,tokenId,amount,address\r\n';
         result.forEach((r) => {
-          r.erc1155.forEach(
-            (entry: {
-              ids: Array<string>;
-              values: Array<number>;
-              contractAddress: string;
-            }) => {
-              entry.ids.forEach((assetId, assetIndex) => {
-                resultFileCSVContent += `ERC1155,${entry.contractAddress},${assetId},${entry.values[assetIndex]},${r.to}\r\n`;
-              });
-            }
-          );
-          r.erc721.forEach(
-            (entry: {ids: Array<string>; contractAddress: string}) => {
-              entry.ids.forEach((assetId: string) => {
-                resultFileCSVContent += `ERC721,${entry.contractAddress},${assetId},1,${r.to}\r\n`;
-              });
-            }
-          );
-          r.erc20.amounts.forEach((amount: string, index: number) => {
+          r.erc1155.forEach((entry: ERC1155Claim) => {
+            entry.ids.forEach((assetId, assetIndex) => {
+              resultFileCSVContent += `ERC1155,${entry.contractAddress},${assetId},${entry.values[assetIndex]},${r.to}\r\n`;
+            });
+          });
+          r.erc721.forEach((entry: ERC721Claim) => {
+            entry.ids.forEach((assetId: number) => {
+              resultFileCSVContent += `ERC721,${entry.contractAddress},${assetId},1,${r.to}\r\n`;
+            });
+          });
+          r.erc20.amounts.forEach((amount: number, index: number) => {
             const contractAddress = r.erc20.contractAddresses[index];
             resultFileCSVContent += `ERC20,${contractAddress},,${amount},${r.to}\r\n`;
           });
@@ -87,8 +106,22 @@ const main = async () => {
       console.log(`${claim.name} proof file missing.`);
     }
   }
+};
 
-  console.log('done!');
+const main = async () => {
+  const bannedWallets: Array<{user_wallet: string}> = [];
+  const bannedWalletsFile = `${__dirname}/deny_list_wallets.csv`;
+  if (!fs.existsSync(bannedWalletsFile)) {
+    throw new Error(`The file does not exist: ${bannedWalletsFile}`);
+  }
+  fs.createReadStream(bannedWalletsFile)
+    .pipe(csv(['user_wallet']))
+    .on('data', (data) => bannedWallets.push(data))
+    .on('end', () => {
+      void createClaimFiles(bannedWallets).then(() => {
+        console.log('done!');
+      });
+    });
 };
 
 main().catch((err) => console.error(err));

--- a/scripts/giveaway/regenerate.ts
+++ b/scripts/giveaway/regenerate.ts
@@ -1,36 +1,32 @@
-import 'dotenv/config';
+/**
+ * How to use:
+ *  - yarn execute <NETWORK> ./scripts/giveaway/regenerate.ts
+ */
 import fs from 'fs';
 import path from 'path';
 import tsbApi from './tsb-api';
 import {
-  isPolygon,
   getClaimTxs,
-  getMultiGiveawayFiles,
   getProofsFileData,
-  multigiveawayPath,
+  getMultiGiveawayPaths,
+  createtMultigiveawayBasePath,
+  getOutputBasePath,
 } from './utils';
 
 const main = async () => {
-  if (!fs.existsSync(multigiveawayPath)) {
-    throw new Error(`Directory not exists: ${multigiveawayPath}`);
-  }
-
-  const giveaways = getMultiGiveawayFiles();
+  createtMultigiveawayBasePath();
+  const giveaways = getMultiGiveawayPaths();
 
   for (const giveaway of giveaways) {
     const claim = await tsbApi.getClaim(giveaway);
     const proofsFileData = getProofsFileData(giveaway);
 
     if (proofsFileData) {
-      const subPath = isPolygon ? 'polygon' : 'mumbai';
-      const basePath = `${__dirname}/output/${subPath}`;
-
+      const basePath = getOutputBasePath();
       if (!fs.existsSync(basePath)) {
         fs.mkdirSync(basePath, {recursive: true});
       }
-
       const resultFileJSON = path.join(basePath, `${giveaway}.json`);
-
       if (fs.existsSync(resultFileJSON)) {
         console.log(`${claim.name} already processed.`);
       } else {
@@ -59,24 +55,33 @@ const main = async () => {
         fs.writeFileSync(resultFileJSON, JSON.stringify(result));
 
         const resultFileCSV = path.join(basePath, `${giveaway}.csv`);
-
-        fs.writeFileSync(
-          resultFileCSV,
-          'type,contractAddress,tokenId,amount,address\r\n'
-        );
-
+        let resultFileCSVContent =
+          'type,contractAddress,tokenId,amount,address\r\n';
         result.forEach((r) => {
+          r.erc1155.forEach(
+            (entry: {
+              ids: Array<string>;
+              values: Array<number>;
+              contractAddress: string;
+            }) => {
+              entry.ids.forEach((assetId, assetIndex) => {
+                resultFileCSVContent += `ERC1155,${entry.contractAddress},${assetId},${entry.values[assetIndex]},${r.to}\r\n`;
+              });
+            }
+          );
+          r.erc721.forEach(
+            (entry: {ids: Array<string>; contractAddress: string}) => {
+              entry.ids.forEach((assetId: string) => {
+                resultFileCSVContent += `ERC721,${entry.contractAddress},${assetId},1,${r.to}\r\n`;
+              });
+            }
+          );
           r.erc20.amounts.forEach((amount: string, index: number) => {
             const contractAddress = r.erc20.contractAddresses[index];
-            fs.writeFileSync(
-              resultFileCSV,
-              `ERC20,${contractAddress},,${amount},${r.to}\r\n`,
-              {
-                flag: 'a+',
-              }
-            );
+            resultFileCSVContent += `ERC20,${contractAddress},,${amount},${r.to}\r\n`;
           });
         });
+        fs.writeFileSync(resultFileCSV, resultFileCSVContent);
       }
     } else {
       console.log(`${claim.name} proof file missing.`);

--- a/scripts/giveaway/regenerate.ts
+++ b/scripts/giveaway/regenerate.ts
@@ -1,0 +1,89 @@
+import 'dotenv/config';
+import fs from 'fs';
+import path from 'path';
+import tsbApi from './tsb-api';
+import {
+  isPolygon,
+  getClaimTxs,
+  getMultiGiveawayFiles,
+  getProofsFileData,
+  multigiveawayPath,
+} from './utils';
+
+const main = async () => {
+  if (!fs.existsSync(multigiveawayPath)) {
+    throw new Error(`Directory not exists: ${multigiveawayPath}`);
+  }
+
+  const giveaways = getMultiGiveawayFiles();
+
+  for (const giveaway of giveaways) {
+    const claim = await tsbApi.getClaim(giveaway);
+    const proofsFileData = getProofsFileData(giveaway);
+
+    if (proofsFileData) {
+      const subPath = isPolygon ? 'polygon' : 'mumbai';
+      const basePath = `${__dirname}/output/${subPath}`;
+
+      if (!fs.existsSync(basePath)) {
+        fs.mkdirSync(basePath, {recursive: true});
+      }
+
+      const resultFileJSON = path.join(basePath, `${giveaway}.json`);
+
+      if (fs.existsSync(resultFileJSON)) {
+        console.log(`${claim.name} already processed.`);
+      } else {
+        console.log(`getting claim transactions for ${claim.name}...`);
+        const claimed = await getClaimTxs(claim.rootHash);
+        const result = [];
+
+        for (let i = 0; i < proofsFileData.length; i++) {
+          const entry = proofsFileData[i];
+          const wallet = entry.to.toLowerCase();
+          const isClaimed = claimed.some((claim) => claim.wallet.id === wallet);
+
+          if (!isClaimed) {
+            const {erc20, erc1155, erc721, to} = entry;
+            result.push({
+              erc20,
+              erc1155,
+              erc721,
+              to,
+            });
+          }
+
+          console.log(`${claim.name} - ${i + 1}/${proofsFileData.length}`);
+        }
+
+        fs.writeFileSync(resultFileJSON, JSON.stringify(result));
+
+        const resultFileCSV = path.join(basePath, `${giveaway}.csv`);
+
+        fs.writeFileSync(
+          resultFileCSV,
+          'type,contractAddress,tokenId,amount,address\r\n'
+        );
+
+        result.forEach((r) => {
+          r.erc20.amounts.forEach((amount: string, index: number) => {
+            const contractAddress = r.erc20.contractAddresses[index];
+            fs.writeFileSync(
+              resultFileCSV,
+              `ERC20,${contractAddress},,${amount},${r.to}\r\n`,
+              {
+                flag: 'a+',
+              }
+            );
+          });
+        });
+      }
+    } else {
+      console.log(`${claim.name} proof file missing.`);
+    }
+  }
+
+  console.log('done!');
+};
+
+main().catch((err) => console.error(err));

--- a/scripts/giveaway/search-duplicates.ts
+++ b/scripts/giveaway/search-duplicates.ts
@@ -1,0 +1,64 @@
+import fs from 'fs';
+import {
+  isPolygon,
+  getMultiGiveawayFiles,
+  getProofsFileData,
+  multigiveawayPath,
+} from './utils';
+
+const main = () => {
+  const hashMap: {
+    [key: string]: {
+      files: Array<number>;
+    };
+  } = {};
+
+  if (!fs.existsSync(multigiveawayPath)) {
+    throw new Error(`Directory not exists: ${multigiveawayPath}`);
+  }
+
+  const giveaways = getMultiGiveawayFiles();
+
+  for (const giveaway of giveaways) {
+    const data = getProofsFileData(giveaway);
+    if (data) {
+      data.forEach((entry) => {
+        if (hashMap[entry.salt]) {
+          hashMap[entry.salt].files.push(giveaway);
+        } else {
+          hashMap[entry.salt] = {
+            files: [giveaway],
+          };
+        }
+      });
+    }
+  }
+
+  const duplicates = Object.entries(hashMap).filter(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    ([_key, value]) => value.files.length > 1
+  );
+
+  const subPath = isPolygon ? 'polygon' : 'mumbai';
+  const basePath = `${__dirname}/output/${subPath}`;
+
+  if (!fs.existsSync(basePath)) {
+    fs.mkdirSync(basePath, {recursive: true});
+  }
+  const fileName = `${basePath}/duplicates.csv`;
+
+  fs.writeFileSync(fileName, 'salt,giveaways\r\n');
+  duplicates.forEach((e) => {
+    const line = `${e[0]},"${e[1].files.join(',')}"`;
+    fs.writeFileSync(fileName, `${line}\r\n`, {flag: 'a+'});
+    console.log(line);
+  });
+
+  console.log('done!');
+};
+
+try {
+  main();
+} catch (err) {
+  console.error(err);
+}

--- a/scripts/giveaway/search-duplicates.ts
+++ b/scripts/giveaway/search-duplicates.ts
@@ -23,6 +23,11 @@ const main = () => {
   for (const giveaway of giveaways) {
     const data = getProofsFileData(giveaway);
     data.forEach((entry) => {
+      if (!entry.salt) {
+        throw new Error(
+          `missing salt for giveaway ${giveaway} and wallet address ${entry.to}`
+        );
+      }
       if (hashMap[entry.salt]) {
         hashMap[entry.salt].files.push(giveaway);
       } else {

--- a/scripts/giveaway/totals.ts
+++ b/scripts/giveaway/totals.ts
@@ -1,0 +1,48 @@
+/**
+ * How to use:
+ *  - yarn execute <NETWORK> ./scripts/giveaway/totals.ts
+ */
+import fs from 'fs';
+import {MultiClaim} from '../../lib/merkleTreeHelper';
+import tsbApi from './tsb-api';
+import {
+  getMultiGiveawayPaths,
+  createtMultigiveawayBasePath,
+  getOutputBasePath,
+} from './utils';
+
+const main = async () => {
+  createtMultigiveawayBasePath();
+  const giveaways = getMultiGiveawayPaths();
+  const outputBasePath = getOutputBasePath();
+  const result = [];
+  for (const giveaway of giveaways) {
+    const claim = await tsbApi.getClaim(giveaway);
+    const file = `${outputBasePath}/${giveaway}.json`;
+    const buffer = fs.readFileSync(file);
+    const fileContent = JSON.parse(buffer.toString());
+    result.push({
+      claim,
+      total: (fileContent as Array<MultiClaim>).length,
+    });
+  }
+
+  result
+    .sort((a, b) => a.claim.id - b.claim.id)
+    .forEach(
+      (e: {
+        claim: {id: number; name: string; rootHash: string};
+        total: number;
+      }) => {
+        console.log(
+          `${e.claim.id} - ${e.claim.name.trim()} (${e.claim.rootHash}) -> ${
+            e.total
+          }`
+        );
+      }
+    );
+
+  console.log('done!');
+};
+
+main().catch((err) => console.error(err));

--- a/scripts/giveaway/tsb-api.ts
+++ b/scripts/giveaway/tsb-api.ts
@@ -1,0 +1,17 @@
+import axios from 'axios';
+import {isPolygon} from './utils';
+
+const baseUrl = isPolygon
+  ? 'https://api.sandbox.game'
+  : 'https://api-demo.sandbox.game';
+
+const getClaim = async (
+  claimId: number | string
+): Promise<{id: number; name: string; rootHash: string}> => {
+  const {data} = await axios.get(`${baseUrl}/assetclaims/${claimId}`);
+  return data;
+};
+
+export default {
+  getClaim,
+};

--- a/scripts/giveaway/tsb-api.ts
+++ b/scripts/giveaway/tsb-api.ts
@@ -1,9 +1,10 @@
 import axios from 'axios';
-import {isPolygon} from './utils';
+import {network} from 'hardhat';
 
-const baseUrl = isPolygon
-  ? 'https://api.sandbox.game'
-  : 'https://api-demo.sandbox.game';
+const baseUrl =
+  network.name === 'polygon'
+    ? 'https://api.sandbox.game'
+    : 'https://api-demo.sandbox.game';
 
 const getClaim = async (
   claimId: number | string

--- a/scripts/giveaway/utils.ts
+++ b/scripts/giveaway/utils.ts
@@ -1,0 +1,81 @@
+import fs from 'fs';
+import {TheGraph} from '../utils/thegraph';
+
+export const isPolygon = process.argv.indexOf('--polygon') > -1;
+
+export const multigiveawayPath = isPolygon
+  ? `${__dirname}/proofs/polygon`
+  : `${__dirname}/proofs/mumbai`;
+
+export const getMultiGiveawayFiles = (): Array<number> => {
+  if (fs.existsSync(multigiveawayPath)) {
+    return fs
+      .readdirSync(multigiveawayPath)
+      .filter((giveaway) => Number(giveaway) > 0)
+      .map((giveaway) => parseInt(giveaway, 10))
+      .sort((a, b) => a - b);
+  } else {
+    return [];
+  }
+};
+
+export const getProofsFileData = (
+  giveaway: number
+): Array<{
+  to: string;
+  erc1155: Array<{
+    ids: Array<string>;
+    values: Array<number>;
+    contractAddress: string;
+  }>;
+  erc721: Array<{
+    ids: Array<string>;
+    contractAddress: string;
+  }>;
+  erc20: {
+    amounts: Array<string>;
+    contractAddresses: Array<string>;
+  };
+  salt: string;
+}> | null => {
+  const file = `${multigiveawayPath}/${giveaway}/proofs`;
+  if (!fs.existsSync(file)) {
+    return null;
+  }
+  const buffer = fs.readFileSync(file);
+  return JSON.parse(buffer.toString());
+};
+
+export const getClaimTxs = async (
+  rootHash: string
+): Promise<
+  Array<{id: string; txHash: string; wallet: {id: string}; claim: {id: string}}>
+> => {
+  const graphUrl = isPolygon
+    ? 'https://api.thegraph.com/subgraphs/name/sandboxthegraph/the-sandbox-claims-polygon'
+    : 'https://api.thegraph.com/subgraphs/name/sandboxthegraph/the-sandbox-claims-mumbai';
+
+  if (!graphUrl) throw new Error(`Giveaway claims graph url is missing`);
+
+  const query = `
+        query($rootHash: String! $first: Int! $lastId: ID!) {
+          claimTxes(first: $first where: { claim_: { id: $rootHash } id_gt: $lastId }) {
+            id
+            txHash
+            wallet {
+              id
+            }
+            claim {
+              id
+            }
+          }
+        }`;
+  const graph = new TheGraph(graphUrl);
+  const result = await graph.query<{
+    id: string;
+    txHash: string;
+    wallet: {id: string};
+    claim: {id: string};
+  }>(query, 'claimTxes', {rootHash});
+  return result;
+};

--- a/scripts/giveaway/utils.ts
+++ b/scripts/giveaway/utils.ts
@@ -1,6 +1,7 @@
 import 'dotenv/config';
 import fs from 'fs';
 import {network} from 'hardhat';
+import {MultiClaim} from '../../lib/merkleTreeHelper';
 import {TheGraph} from '../utils/thegraph';
 
 const multigiveawayBasePath = `${__dirname}/proofs/${network.name}`;
@@ -33,25 +34,7 @@ export const getMultiGiveawayPaths = (): Array<number> => {
   }
 };
 
-export const getProofsFileData = (
-  giveaway: number
-): Array<{
-  to: string;
-  erc1155: Array<{
-    ids: Array<string>;
-    values: Array<number>;
-    contractAddress: string;
-  }>;
-  erc721: Array<{
-    ids: Array<string>;
-    contractAddress: string;
-  }>;
-  erc20: {
-    amounts: Array<string>;
-    contractAddresses: Array<string>;
-  };
-  salt: string;
-}> => {
+export const getProofsFileData = (giveaway: number): Array<MultiClaim> => {
   const file = `${multigiveawayBasePath}/${giveaway}/proofs`;
   if (!fs.existsSync(file)) {
     throw new Error(`The file does not exist: ${file}`);


### PR DESCRIPTION
# Description

To fix the duplicate signatures in the claiming data for multiple giveaways on Polygon, we have created a couple of scripts:

Both scripts require to copy of the final proof files containing the data for each claim.

The search-duplicates.ts script reads the proof files for duplicate salts and writes the search result to the output folder.

The regenerate.ts script reads the proof files, checks the claims made for each giveaway using The Graph, and creates a new file with unrealized claims, excluding banned wallets.

[Clickup Task](https://app.clickup.com/t/860phbnd8)

# Checklist

- [ ] Add script to detect duplicated giveaway salt signatures
- [ ] Add script to regenerate unclaimed giveaways.

# Check for duplicates

Copy proofs files from Amazon S3 to the following directory:
    
    sandbox-smart-contracts/scripts/giveaway/proofs/{network}/{giveaway}
    
After copying the files, we should have something like this:

    sandbox-smart-contracts/scripts/giveaway/proofs/mumbai/45/proofs
    sandbox-smart-contracts/scripts/giveaway/proofs/mumbai/64/proofs
    sandbox-smart-contracts/scripts/giveaway/proofs/mumbai/66/proofs
    sandbox-smart-contracts/scripts/giveaway/proofs/mumbai/73/proofs
    ...

Or for polygon mainnet:

    sandbox-smart-contracts/scripts/giveaway/proofs/polygon/45/proofs
    sandbox-smart-contracts/scripts/giveaway/proofs/polygon/64/proofs
    sandbox-smart-contracts/scripts/giveaway/proofs/polygon/66/proofs
    sandbox-smart-contracts/scripts/giveaway/proofs/polygon/73/proofs
    ...

Once in place the files to process, run the following command:

    yarn execute <NETWORK> ./scripts/giveaway/search-duplicates.ts

The script generates a CSV file:

    sandbox-smart-contracts/scripts/giveaway/output/mumbai/duplicates.csv

The content file looks like this:

    salt,giveaways
    0x6939b0d018927ad7420456e206727c8862eb2ebbdd79851165aa6b38e6061ed8,"268,269"
    0x114b2e829bd3ac68b46b9787b3f3d76c96cb325be9ac4d9108b8d8d1c8bf7e58,"268,269"
    0x3014a81f15cbf6084454c06a95f984e39f68964e1b9c83b0fde9f81e10d97fd9,"268,269"
    0xbf260a18800fd90ac0f898501f5eb4da09a1c7d1725b17ed682f4af2ef12a1e6,"268,269"

This file lets us know how many duplicate salts we have and what giveaways are involved.

# Regenerate Claims

The script to regenerate will take all the claims existing in the proof file and check if they were already claimed. The script creates a new file with the list of unclaimed giveaways. This list does not include the claims for banned wallets. 

To exclude the banned wallets, it's required to put in place the file `deny_list_wallets.csv` provided by the anti-cheating team at the following path:

    sandbox-smart-contracts/scripts/giveaway

This file looks like this:

    user_wallet
    0x00000006o796df0489b6f16120e9a72bbc945t78
    0x000000a5694c92839fdbcef14245f7b8c4534098
    0x000000a4fc9e28e0fd2fa5fb5435cb10d9a45u90

The claims corresponding to banned wallets will be saved to a different file ending with _banned.json

e.g.:

    sandbox-smart-contracts/scripts/giveaway/output/mumbai/{giveaway}_banned.json

With the files to process in place, run the following command:

    yarn execute <NETWORK> ./scripts/giveaway/regenerate.ts

The script generates two output files for each giveaway:

    sandbox-smart-contracts/scripts/giveaway/output/mumbai/{giveaway}.json
    sandbox-smart-contracts/scripts/giveaway/output/mumbai/{giveaway}.csv

After running the script, we should have something like this:

    sandbox-smart-contracts/scripts/giveaway/output/mumbai/45.json
    sandbox-smart-contracts/scripts/giveaway/output/mumbai/45.csv
    sandbox-smart-contracts/scripts/giveaway/output/mumbai/64.json
    sandbox-smart-contracts/scripts/giveaway/output/mumbai/64.csv
    ...

Or for Polygon Mainnet:

    sandbox-smart-contracts/scripts/giveaway/output/polygon/45.json
    sandbox-smart-contracts/scripts/giveaway/output/polygon/45.csv
    sandbox-smart-contracts/scripts/giveaway/output/polygon/64.json
    sandbox-smart-contracts/scripts/giveaway/output/polygon/64.csv
    ...

The JSON file has the format to be processed with the current procedure (by hand). The CSV file has the format to be processed by the new giveaway back-office.
