### PR TITLE
Add MisteryBox contract

### DIFF
--- a/src/solc_0.8/misteryBox/MisteryBox.md
+++ b/src/solc_0.8/misteryBox/MisteryBox.md
@@ -2,5 +2,26 @@
 
 Documentation is oriented for auditors, internal developers and external developer contributors.
 
+# Features
+
+The "MisteryBox" contract allows the contract owner to perform multiple safe transfers of ERC721 and ERC1155 tokens.
+
 # Methods
-...
+
+Contract functions should respect [order-of-functions solidity style guide](https://docs.soliditylang.org/en/v0.8.17/style-guide.html#order-of-functions)
+
+----
+
+```Solidity
+function safeBatchTransferFrom(
+    TransferData[] memory transfers
+) external onlyOwner
+```
+The safeBatchTransferFrom() function is designed to be executed only by the contract owner to perform multiple safe transfers. Within the function, it iterates through all transfers in the array and validates the sender and receiver addresses and the contract type. If the contract type is ERC721, it requires the amount to be one and uses the safeTransferFrom() function of the ERC721 contract to perform the transfer. If the contract type is ERC1155, it requires the amount to be greater than or equal to 1 and uses the safeTransferFrom() function of the ERC1155 contract to perform the transfer.
+* `transfers`: an array of "TransferData" data structures. Each "TransferData" structure contains information about the token transfer, including the contract type (ERC721 or ERC1155), the contract address, the sender and receiver addresses, the token ID, and the transfer amount.
+
+# Links
+
+Deployment scripts for contracts extending `MisteryBox.sol` are found in [deploy/](../../../deploy/) (anything with `*_mistery_box_*` in the name).
+
+Testing scripts are found, for each extending contract, in [test/misteryBox/](../../../test/misteryBox/) 

--- a/src/solc_0.8/misteryBox/MisteryBox.md
+++ b/src/solc_0.8/misteryBox/MisteryBox.md
@@ -1,0 +1,6 @@
+# Audience
+
+Documentation is oriented for auditors, internal developers and external developer contributors.
+
+# Methods
+...

--- a/src/solc_0.8/misteryBox/MisteryBox.sol
+++ b/src/solc_0.8/misteryBox/MisteryBox.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.2;
+
+import "@openzeppelin/contracts-0.8/access/Ownable.sol";
+import "@openzeppelin/contracts-0.8/token/ERC1155/IERC1155.sol";
+import "@openzeppelin/contracts-0.8/token/ERC721/IERC721.sol";
+import "@openzeppelin/contracts-0.8/utils/math/SafeMath.sol";
+import "./libraries/MisteryBoxHelper.sol";
+
+contract MisteryBox is Ownable {
+    using MisteryBoxHelper for MisteryBoxHelper.ContractType;
+    using MisteryBoxHelper for MisteryBoxHelper.TransferData;
+    using SafeMath for uint256;
+
+    function safeBatchTransferFrom(MisteryBoxHelper.TransferData[] memory transfers) external onlyOwner {
+        uint256 numTransfers = transfers.length;
+        for (uint256 i = 0; i < numTransfers; i++) {
+            require(transfers[i].from != address(0), "FROM IS ZERO ADDRESS");
+            require(transfers[i].to != address(0), "CAN'T SEND TO ZERO ADDRESS");
+            require(MisteryBoxHelper.isContractTypeValid(transfers[i].contractType), "INVALID CONTRACT TYPE");
+
+            uint8 contractType = transfers[i].contractType;
+            address contractAddress = transfers[i].contractAddress;
+            address from = transfers[i].from;
+            address to = transfers[i].to;
+            uint256 tokenId = transfers[i].tokenId;
+            uint256 amount = transfers[i].amount;
+
+            if (MisteryBoxHelper.isERC721(contractType)) {
+                require(amount == 1, "AMOUNT MUST BE 1 FOR ERC721");
+                IERC721(contractAddress).safeTransferFrom(from, to, tokenId);
+            } else if (MisteryBoxHelper.isERC1155(contractType)) {
+                require(amount >= 1, "AMOUNT MUST BE GREATER OR EQUAL THAN 1 FOR ERC1155");
+                IERC1155(contractAddress).safeTransferFrom(from, to, tokenId, amount, "");
+            }
+        }
+    }
+}

--- a/src/solc_0.8/misteryBox/libraries/MisteryBoxHelper.sol
+++ b/src/solc_0.8/misteryBox/libraries/MisteryBoxHelper.sol
@@ -1,0 +1,27 @@
+//SPDX-License-Identifier: MIT
+pragma solidity 0.8.2;
+
+library MisteryBoxHelper {
+    enum ContractType {ERC721, ERC1155}
+
+    struct TransferData {
+        uint8 contractType;
+        address contractAddress;
+        address from;
+        address to;
+        uint256 tokenId;
+        uint256 amount;
+    }
+
+    function isContractTypeValid(uint8 contractType) internal pure returns (bool) {
+        return contractType == uint8(ContractType.ERC721) || contractType == uint8(ContractType.ERC1155);
+    }
+
+    function isERC721(uint8 contractType) internal pure returns (bool) {
+        return contractType == uint8(ContractType.ERC721);
+    }
+
+    function isERC1155(uint8 contractType) internal pure returns (bool) {
+        return contractType == uint8(ContractType.ERC1155);
+    }
+}

--- a/test/misteryBox/fixtures.ts
+++ b/test/misteryBox/fixtures.ts
@@ -1,0 +1,90 @@
+import {ethers, deployments} from 'hardhat';
+import {
+  withSnapshot,
+  expectEventWithArgs,
+  expectEventWithArgsFromReceipt,
+} from '../utils';
+
+export const setupMisteryBox = withSnapshot([], async function () {
+  const [deployer, account1, account2] = await ethers.getSigners();
+
+  const MockAssetERC721 = await ethers.getContractFactory('MockAssetERC721');
+  const mockAssetERC721 = await MockAssetERC721.deploy();
+  await mockAssetERC721.deployed();
+
+  const {deploy} = deployments;
+
+  const ERC1155ERC721HelperLib = await deploy('ERC1155ERC721Helper', {
+    from: deployer.address,
+    log: true,
+    skipIfAlreadyDeployed: true,
+  });
+
+  const MockAssetERC1155 = await ethers.getContractFactory('MockAssetERC1155', {
+    libraries: {
+      ERC1155ERC721Helper: ERC1155ERC721HelperLib.address,
+    },
+  });
+
+  const mockAssetERC1155 = await MockAssetERC1155.deploy();
+  await mockAssetERC1155.deployed();
+
+  const MisteryBox = await ethers.getContractFactory('MisteryBox');
+  const misteryBox = await MisteryBox.deploy();
+
+  await misteryBox.deployed();
+
+  async function mintAssetERC721({to, id}: {to: string; id: number}) {
+    const receipt = await mockAssetERC721.mintWithOutMinterCheck(to, id);
+    const event = await expectEventWithArgsFromReceipt(
+      mockAssetERC721,
+      receipt,
+      'Transfer'
+    );
+    const tokenId = event.args[2];
+    return {receipt, tokenId};
+  }
+
+  async function mintAssetERC1155({
+    creatorAddress,
+    packId,
+    hash,
+    supply,
+    ownerAddress,
+    data,
+  }: {
+    creatorAddress: string;
+    packId: number;
+    hash: string;
+    supply: number;
+    ownerAddress: string;
+    data: string;
+  }) {
+    const receipt = await mockAssetERC1155.mintWithOutBouncerCheck(
+      creatorAddress,
+      packId,
+      hash,
+      supply,
+      ownerAddress,
+      data
+    );
+    const transferEvent = await expectEventWithArgs(
+      mockAssetERC1155,
+      receipt,
+      'TransferSingle'
+    );
+    const tokenId = transferEvent.args[3];
+    return {tokenId};
+  }
+
+  return {
+    misteryBox,
+    mockAssetERC721,
+    mockAssetERC1155,
+    deployer,
+    account1,
+    account2,
+    mintAssetERC721,
+    mintAssetERC1155,
+  };
+});

--- a/test/misteryBox/misteryBox.test.ts
+++ b/test/misteryBox/misteryBox.test.ts
@@ -1,0 +1,197 @@
+import {expect} from '../chai-setup';
+import {ethers, deployments} from 'hardhat';
+import {Contract} from 'ethers';
+import {SignerWithAddress} from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
+import {expectEventWithArgs} from '../utils';
+
+describe('MisteryBox', function () {
+  let owner: SignerWithAddress;
+  let addr1: SignerWithAddress;
+  let addr2: SignerWithAddress;
+  let misteryBox: Contract;
+  let mockAssetERC721: Contract;
+  let mockAssetERC1155: Contract;
+
+  beforeEach(async function () {
+    const [deployer, account1, account2] = await ethers.getSigners();
+    owner = deployer;
+    addr1 = account1;
+    addr2 = account2;
+
+    const MockAssetERC721 = await ethers.getContractFactory('MockAssetERC721');
+    mockAssetERC721 = await MockAssetERC721.deploy();
+    await mockAssetERC721.deployed();
+
+    const {deploy} = deployments;
+
+    const ERC1155ERC721HelperLib = await deploy('ERC1155ERC721Helper', {
+      from: deployer.address,
+      log: true,
+      skipIfAlreadyDeployed: true,
+    });
+
+    const MockAssetERC1155 = await ethers.getContractFactory(
+      'MockAssetERC1155',
+      {
+        libraries: {
+          ERC1155ERC721Helper: ERC1155ERC721HelperLib.address,
+        },
+      }
+    );
+
+    mockAssetERC1155 = await MockAssetERC1155.deploy();
+    await mockAssetERC1155.deployed();
+
+    const MisteryBox = await ethers.getContractFactory('MisteryBox');
+    misteryBox = await MisteryBox.deploy();
+
+    await misteryBox.deployed();
+  });
+
+  it('should safely transfer an ERC721 token', async function () {
+    // Mint an ERC721 token and approve the MisteryBox contract
+    await mockAssetERC721
+      .connect(addr1)
+      .mintWithOutMinterCheck(addr1.address, 1);
+    await mockAssetERC721.connect(addr1).approve(misteryBox.address, 1);
+
+    const transferData = [
+      {
+        contractType: 0, // ERC721
+        contractAddress: mockAssetERC721.address,
+        from: addr1.address,
+        to: addr2.address,
+        tokenId: 1,
+        amount: 1,
+      },
+    ];
+
+    await misteryBox.connect(owner).safeBatchTransferFrom(transferData);
+
+    expect(await mockAssetERC721.ownerOf(1)).to.equal(addr2.address);
+  });
+
+  it('should safely transfer an ERC1155 token', async function () {
+    // Mint an ERC1155 token and approve the MisteryBox contract
+    const creatorAddress = addr1.address;
+    const packId = 1;
+    const ipfsHashString =
+      '0x78b9f42c22c3c8b260b781578da3151e8200c741c6b7437bafaff5a9df9b403e';
+    const supply = 1000;
+    const ownerAddress = addr1.address;
+    const data = '0x';
+
+    const receipt = await mockAssetERC1155.mintWithOutBouncerCheck(
+      creatorAddress,
+      packId,
+      ipfsHashString,
+      supply,
+      ownerAddress,
+      data
+    );
+    const transferEvent = await expectEventWithArgs(
+      mockAssetERC1155,
+      receipt,
+      'TransferSingle'
+    );
+    const tokenId = transferEvent.args[3];
+    await mockAssetERC1155
+      .connect(addr1)
+      .setApprovalForAll(misteryBox.address, true);
+    const transferData = [
+      {
+        contractType: 1, // ERC1155
+        contractAddress: mockAssetERC1155.address,
+        from: addr1.address,
+        to: addr2.address,
+        tokenId: tokenId,
+        amount: 3,
+      },
+    ];
+    await misteryBox.connect(owner).safeBatchTransferFrom(transferData);
+    expect(await mockAssetERC1155.balanceOf(addr2.address, tokenId)).to.equal(
+      3
+    );
+  });
+
+  it('should fail when using an invalid contract type', async function () {
+    const transferData = [
+      {
+        contractType: 2, // Invalid contract type
+        contractAddress: mockAssetERC721.address,
+        from: addr1.address,
+        to: addr2.address,
+        tokenId: 1,
+        amount: 1,
+      },
+    ];
+
+    await expect(
+      misteryBox.connect(owner).safeBatchTransferFrom(transferData)
+    ).to.be.revertedWith('INVALID CONTRACT TYPE');
+  });
+
+  it('should fail when attempting to transfer ERC721 token with an amount different than 1', async function () {
+    await mockAssetERC721
+      .connect(addr1)
+      .mintWithOutMinterCheck(addr1.address, 1);
+    await mockAssetERC721.connect(addr1).approve(misteryBox.address, 1);
+
+    const transferData = [
+      {
+        contractType: 0, // ERC721
+        contractAddress: mockAssetERC721.address,
+        from: addr1.address,
+        to: addr2.address,
+        tokenId: 1,
+        amount: 2, // Invalid amount for ERC721
+      },
+    ];
+
+    await expect(
+      misteryBox.connect(owner).safeBatchTransferFrom(transferData)
+    ).to.be.revertedWith('AMOUNT MUST BE 1 FOR ERC721');
+  });
+
+  it('should fail when attempting to transfer ERC1155 token with an amount less than 1', async function () {
+    // Mint an ERC1155 token and approve the MisteryBox contract
+    const creatorAddress = addr1.address;
+    const packId = 1;
+    const ipfsHashString =
+      '0x78b9f42c22c3c8b260b781578da3151e8200c741c6b7437bafaff5a9df9b403e';
+    const supply = 1000;
+    const ownerAddress = addr1.address;
+    const data = '0x';
+
+    const receipt = await mockAssetERC1155.mintWithOutBouncerCheck(
+      creatorAddress,
+      packId,
+      ipfsHashString,
+      supply,
+      ownerAddress,
+      data
+    );
+    const transferEvent = await expectEventWithArgs(
+      mockAssetERC1155,
+      receipt,
+      'TransferSingle'
+    );
+    const tokenId = transferEvent.args[3];
+    await mockAssetERC1155
+      .connect(addr1)
+      .setApprovalForAll(misteryBox.address, true);
+    const transferData = [
+      {
+        contractType: 1, // ERC1155
+        contractAddress: mockAssetERC1155.address,
+        from: addr1.address,
+        to: addr2.address,
+        tokenId: tokenId,
+        amount: 0,
+      },
+    ];
+    await expect(
+      misteryBox.connect(owner).safeBatchTransferFrom(transferData)
+    ).to.be.revertedWith('AMOUNT MUST BE GREATER OR EQUAL THAN 1 FOR ERC1155');
+  });
+});

--- a/test/misteryBox/misteryBox.test.ts
+++ b/test/misteryBox/misteryBox.test.ts
@@ -1,197 +1,215 @@
 import {expect} from '../chai-setup';
-import {ethers, deployments} from 'hardhat';
-import {Contract} from 'ethers';
-import {SignerWithAddress} from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
-import {expectEventWithArgs} from '../utils';
+import {setupMisteryBox} from './fixtures';
 
 describe('MisteryBox', function () {
-  let owner: SignerWithAddress;
-  let addr1: SignerWithAddress;
-  let addr2: SignerWithAddress;
-  let misteryBox: Contract;
-  let mockAssetERC721: Contract;
-  let mockAssetERC1155: Contract;
-
-  beforeEach(async function () {
-    const [deployer, account1, account2] = await ethers.getSigners();
-    owner = deployer;
-    addr1 = account1;
-    addr2 = account2;
-
-    const MockAssetERC721 = await ethers.getContractFactory('MockAssetERC721');
-    mockAssetERC721 = await MockAssetERC721.deploy();
-    await mockAssetERC721.deployed();
-
-    const {deploy} = deployments;
-
-    const ERC1155ERC721HelperLib = await deploy('ERC1155ERC721Helper', {
-      from: deployer.address,
-      log: true,
-      skipIfAlreadyDeployed: true,
-    });
-
-    const MockAssetERC1155 = await ethers.getContractFactory(
-      'MockAssetERC1155',
-      {
-        libraries: {
-          ERC1155ERC721Helper: ERC1155ERC721HelperLib.address,
-        },
-      }
-    );
-
-    mockAssetERC1155 = await MockAssetERC1155.deploy();
-    await mockAssetERC1155.deployed();
-
-    const MisteryBox = await ethers.getContractFactory('MisteryBox');
-    misteryBox = await MisteryBox.deploy();
-
-    await misteryBox.deployed();
-  });
-
   it('should safely transfer an ERC721 token', async function () {
+    const {
+      misteryBox,
+      deployer,
+      account1,
+      account2,
+      mockAssetERC721,
+      mintAssetERC721,
+    } = await setupMisteryBox();
+
     // Mint an ERC721 token and approve the MisteryBox contract
+    const {tokenId} = await mintAssetERC721({to: account1.address, id: 1});
     await mockAssetERC721
-      .connect(addr1)
-      .mintWithOutMinterCheck(addr1.address, 1);
-    await mockAssetERC721.connect(addr1).approve(misteryBox.address, 1);
+      .connect(account1)
+      .approve(misteryBox.address, tokenId);
 
     const transferData = [
       {
         contractType: 0, // ERC721
         contractAddress: mockAssetERC721.address,
-        from: addr1.address,
-        to: addr2.address,
-        tokenId: 1,
+        from: account1.address,
+        to: account2.address,
+        tokenId,
         amount: 1,
       },
     ];
 
-    await misteryBox.connect(owner).safeBatchTransferFrom(transferData);
-
-    expect(await mockAssetERC721.ownerOf(1)).to.equal(addr2.address);
+    await misteryBox.connect(deployer).safeBatchTransferFrom(transferData);
+    expect(await mockAssetERC721.ownerOf(tokenId)).to.equal(account2.address);
   });
 
   it('should safely transfer an ERC1155 token', async function () {
-    // Mint an ERC1155 token and approve the MisteryBox contract
-    const creatorAddress = addr1.address;
-    const packId = 1;
-    const ipfsHashString =
-      '0x78b9f42c22c3c8b260b781578da3151e8200c741c6b7437bafaff5a9df9b403e';
-    const supply = 1000;
-    const ownerAddress = addr1.address;
-    const data = '0x';
-
-    const receipt = await mockAssetERC1155.mintWithOutBouncerCheck(
-      creatorAddress,
-      packId,
-      ipfsHashString,
-      supply,
-      ownerAddress,
-      data
-    );
-    const transferEvent = await expectEventWithArgs(
+    const {
+      misteryBox,
+      deployer,
+      account1,
+      account2,
       mockAssetERC1155,
-      receipt,
-      'TransferSingle'
-    );
-    const tokenId = transferEvent.args[3];
+      mintAssetERC1155,
+    } = await setupMisteryBox();
+
+    // Mint an ERC1155 token and approve the MisteryBox contract
+    const {tokenId} = await mintAssetERC1155({
+      creatorAddress: account1.address,
+      packId: 1,
+      hash:
+        '0x78b9f42c22c3c8b260b781578da3151e8200c741c6b7437bafaff5a9df9b403e',
+      supply: 1000,
+      ownerAddress: account1.address,
+      data: '0x',
+    });
+
     await mockAssetERC1155
-      .connect(addr1)
+      .connect(account1)
       .setApprovalForAll(misteryBox.address, true);
+
     const transferData = [
       {
         contractType: 1, // ERC1155
         contractAddress: mockAssetERC1155.address,
-        from: addr1.address,
-        to: addr2.address,
-        tokenId: tokenId,
+        from: account1.address,
+        to: account2.address,
+        tokenId,
         amount: 3,
       },
     ];
-    await misteryBox.connect(owner).safeBatchTransferFrom(transferData);
-    expect(await mockAssetERC1155.balanceOf(addr2.address, tokenId)).to.equal(
-      3
-    );
+
+    await misteryBox.connect(deployer).safeBatchTransferFrom(transferData);
+    expect(
+      await mockAssetERC1155.balanceOf(account2.address, tokenId)
+    ).to.equal(3);
+  });
+
+  it('should safely transfer multiple tokens', async function () {
+    const {
+      misteryBox,
+      deployer,
+      account1,
+      account2,
+      mockAssetERC721,
+      mintAssetERC721,
+      mockAssetERC1155,
+      mintAssetERC1155,
+    } = await setupMisteryBox();
+
+    // Mint an ERC721 token and approve the MisteryBox contract
+    const {tokenId: tokenIdERC721} = await mintAssetERC721({
+      to: account1.address,
+      id: 1,
+    });
+
+    await mockAssetERC721
+      .connect(account1)
+      .approve(misteryBox.address, tokenIdERC721);
+
+    // Mint an ERC1155 token and approve the MisteryBox contract
+    const {tokenId: tokenIdERC1155} = await mintAssetERC1155({
+      creatorAddress: account1.address,
+      packId: 1,
+      hash:
+        '0x78b9f42c22c3c8b260b781578da3151e8200c741c6b7437bafaff5a9df9b403e',
+      supply: 1000,
+      ownerAddress: account1.address,
+      data: '0x',
+    });
+
+    await mockAssetERC1155
+      .connect(account1)
+      .setApprovalForAll(misteryBox.address, true);
+
+    const transferData = [
+      {
+        contractType: 0, // ERC721
+        contractAddress: mockAssetERC721.address,
+        from: account1.address,
+        to: account2.address,
+        tokenId: tokenIdERC721,
+        amount: 1,
+      },
+      {
+        contractType: 1, // ERC1155
+        contractAddress: mockAssetERC1155.address,
+        from: account1.address,
+        to: account2.address,
+        tokenId: tokenIdERC1155,
+        amount: 3,
+      },
+    ];
+
+    await misteryBox.connect(deployer).safeBatchTransferFrom(transferData);
+
+    expect(await mockAssetERC721.balanceOf(account2.address)).to.equal(1);
+    expect(
+      await mockAssetERC1155.balanceOf(account2.address, tokenIdERC1155)
+    ).to.equal(3);
   });
 
   it('should fail when using an invalid contract type', async function () {
+    const {
+      misteryBox,
+      deployer,
+      account1,
+      account2,
+      mockAssetERC721,
+    } = await setupMisteryBox();
+
     const transferData = [
       {
         contractType: 2, // Invalid contract type
         contractAddress: mockAssetERC721.address,
-        from: addr1.address,
-        to: addr2.address,
+        from: account1.address,
+        to: account2.address,
         tokenId: 1,
         amount: 1,
       },
     ];
 
     await expect(
-      misteryBox.connect(owner).safeBatchTransferFrom(transferData)
+      misteryBox.connect(deployer).safeBatchTransferFrom(transferData)
     ).to.be.revertedWith('INVALID CONTRACT TYPE');
   });
 
   it('should fail when attempting to transfer ERC721 token with an amount different than 1', async function () {
-    await mockAssetERC721
-      .connect(addr1)
-      .mintWithOutMinterCheck(addr1.address, 1);
-    await mockAssetERC721.connect(addr1).approve(misteryBox.address, 1);
+    const {
+      misteryBox,
+      deployer,
+      account1,
+      account2,
+      mockAssetERC721,
+    } = await setupMisteryBox();
 
     const transferData = [
       {
         contractType: 0, // ERC721
         contractAddress: mockAssetERC721.address,
-        from: addr1.address,
-        to: addr2.address,
+        from: account1.address,
+        to: account2.address,
         tokenId: 1,
         amount: 2, // Invalid amount for ERC721
       },
     ];
 
     await expect(
-      misteryBox.connect(owner).safeBatchTransferFrom(transferData)
+      misteryBox.connect(deployer).safeBatchTransferFrom(transferData)
     ).to.be.revertedWith('AMOUNT MUST BE 1 FOR ERC721');
   });
 
   it('should fail when attempting to transfer ERC1155 token with an amount less than 1', async function () {
-    // Mint an ERC1155 token and approve the MisteryBox contract
-    const creatorAddress = addr1.address;
-    const packId = 1;
-    const ipfsHashString =
-      '0x78b9f42c22c3c8b260b781578da3151e8200c741c6b7437bafaff5a9df9b403e';
-    const supply = 1000;
-    const ownerAddress = addr1.address;
-    const data = '0x';
-
-    const receipt = await mockAssetERC1155.mintWithOutBouncerCheck(
-      creatorAddress,
-      packId,
-      ipfsHashString,
-      supply,
-      ownerAddress,
-      data
-    );
-    const transferEvent = await expectEventWithArgs(
+    const {
+      misteryBox,
+      deployer,
+      account1,
+      account2,
       mockAssetERC1155,
-      receipt,
-      'TransferSingle'
-    );
-    const tokenId = transferEvent.args[3];
-    await mockAssetERC1155
-      .connect(addr1)
-      .setApprovalForAll(misteryBox.address, true);
+    } = await setupMisteryBox();
+
     const transferData = [
       {
         contractType: 1, // ERC1155
         contractAddress: mockAssetERC1155.address,
-        from: addr1.address,
-        to: addr2.address,
-        tokenId: tokenId,
+        from: account1.address,
+        to: account2.address,
+        tokenId: 1,
         amount: 0,
       },
     ];
     await expect(
-      misteryBox.connect(owner).safeBatchTransferFrom(transferData)
+      misteryBox.connect(deployer).safeBatchTransferFrom(transferData)
     ).to.be.revertedWith('AMOUNT MUST BE GREATER OR EQUAL THAN 1 FOR ERC1155');
   });
 });


### PR DESCRIPTION
# Description

The "MisteryBox" contract allows the contract owner to perform safe batch transfers of ERC721 and ERC1155 tokens.

The contract has a primary function called safeBatchTransferFrom(), which takes an array of "TransferData" data structures as an argument. Each "TransferData" structure contains information about the token transfer, including the contract type (ERC721 or ERC1155), the contract address, the sender and receiver addresses, the token ID, and the transfer amount.

The safeBatchTransferFrom() function is designed to be executed only by the contract owner, as indicated by the "onlyOwner" modifier. Within the function, it iterates through all transfers in the array and validates the sender and receiver addresses and the contract type. If the contract type is ERC721, it requires the amount to be one and uses the safeTransferFrom() function of the ERC721 contract to perform the transfer. If the contract type is ERC1155, it requires the amount to be greater than or equal to 1 and uses the safeTransferFrom() function of the ERC1155 contract to perform the transfer.

# Checklist

- [ ] Pull Request references Clickup task
- [x] Pull Request applies to a single purpose
- [x] I've added comments to my code where needed
- [ ] I've added / updated natspec
- [x] I've added / updated tests to show that my changes achieve the desired results
- [x] I've reviewed my code
- [x] I've followed established naming conventions and formatting
- [ ] I've generated a coverage report and included a screenshot
- [x] All tests are passing locally
- [x] I've added / updated a `.md` documentation file per smart contract (in the contract directory) based on `.docs.example`
