### PR TITLE
feat: fix lcov file detection and choose the right NX_BASE

### DIFF
--- a/.github/setup/action.yml
+++ b/.github/setup/action.yml
@@ -1,0 +1,24 @@
+name: setup
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16.17.0
+        cache: 'yarn'
+
+    - name: Installing dependencies
+      run: yarn install --frozen-lockfile
+      shell: bash
+
+    - name: Derive appropriate SHAs for base and head for `nx affected` commands
+      run: |
+        echo "NX_HEAD=$(git rev-parse HEAD)" >> $GITHUB_ENV
+        echo "NX_BASE=$(git merge-base origin/master HEAD)" >> $GITHUB_ENV
+      shell: bash
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,3 @@
-# TODO: check if we need https://github.com/nrwl/nx-set-shas
 name: CI
 on: push
 jobs:
@@ -17,6 +16,11 @@ jobs:
 
       - name: Installing dependencies
         run: yarn install --frozen-lockfile
+
+      - name: Derive appropriate SHAs for base and head for `nx affected` commands
+        run: |
+          echo "NX_HEAD=$(git rev-parse HEAD)" >> $GITHUB_ENV
+          echo "NX_BASE=$(git merge-base origin/master HEAD)" >> $GITHUB_ENV
 
       - name: Linting
         run: yarn lint:ci
@@ -37,6 +41,11 @@ jobs:
       - name: Installing dependencies
         run: yarn install --frozen-lockfile
 
+      - name: Derive appropriate SHAs for base and head for `nx affected` commands
+        run: |
+          echo "NX_HEAD=$(git rev-parse HEAD)" >> $GITHUB_ENV
+          echo "NX_BASE=$(git merge-base origin/master HEAD)" >> $GITHUB_ENV
+
       - name: Formatting
         run: yarn format:ci
 
@@ -55,6 +64,11 @@ jobs:
 
       - name: Installing dependencies
         run: yarn install --frozen-lockfile
+
+      - name: Derive appropriate SHAs for base and head for `nx affected` commands
+        run: |
+          echo "NX_HEAD=$(git rev-parse HEAD)" >> $GITHUB_ENV
+          echo "NX_BASE=$(git merge-base origin/master HEAD)" >> $GITHUB_ENV
 
       - name: Running tests
         run: yarn test:ci
@@ -75,16 +89,23 @@ jobs:
       - name: Installing dependencies
         run: yarn install --frozen-lockfile
 
+      - name: Derive appropriate SHAs for base and head for `nx affected` commands
+        run: |
+          echo "NX_HEAD=$(git rev-parse HEAD)" >> $GITHUB_ENV
+          echo "NX_BASE=$(git merge-base origin/master HEAD)" >> $GITHUB_ENV
+
       - name: Running coverage
         run: yarn coverage:ci
 
       - name: Coverage created?
         id: check_coverage
         run: |
-          if [ -s ./coverage/lconv.info ] ; then
+          if [ -s $GITHUB_WORKSPACE/coverage/lcov.info ] ; then
             echo "check_result=true" >> $GITHUB_OUTPUT
+            echo "lcov.info FILE exists and has a size greater than zero"
           else
             echo "check_result=false" >> $GITHUB_OUTPUT
+            echo "lcov.info does not exists or has size zero"
           fi
 
       - name: Report coverage
@@ -116,6 +137,11 @@ jobs:
 
       - name: Installing dependencies
         run: yarn install --frozen-lockfile
+
+      - name: Derive appropriate SHAs for base and head for `nx affected` commands
+        run: |
+          echo "NX_HEAD=$(git rev-parse HEAD)" >> $GITHUB_ENV
+          echo "NX_BASE=$(git merge-base origin/master HEAD)" >> $GITHUB_ENV
 
       - name: Deploy contracts
         run: yarn deploy:ci

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,22 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.17.0
-          cache: 'yarn'
-
-      - name: Installing dependencies
-        run: yarn install --frozen-lockfile
-
-      - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        run: |
-          echo "NX_HEAD=$(git rev-parse HEAD)" >> $GITHUB_ENV
-          echo "NX_BASE=$(git merge-base origin/master HEAD)" >> $GITHUB_ENV
+      - uses: "./.github/setup"
 
       - name: Linting
         run: yarn lint:ci
@@ -29,22 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.17.0
-          cache: 'yarn'
-
-      - name: Installing dependencies
-        run: yarn install --frozen-lockfile
-
-      - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        run: |
-          echo "NX_HEAD=$(git rev-parse HEAD)" >> $GITHUB_ENV
-          echo "NX_BASE=$(git merge-base origin/master HEAD)" >> $GITHUB_ENV
+      - uses: "./.github/setup"
 
       - name: Formatting
         run: yarn format:ci
@@ -53,22 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.17.0
-          cache: 'yarn'
-
-      - name: Installing dependencies
-        run: yarn install --frozen-lockfile
-
-      - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        run: |
-          echo "NX_HEAD=$(git rev-parse HEAD)" >> $GITHUB_ENV
-          echo "NX_BASE=$(git merge-base origin/master HEAD)" >> $GITHUB_ENV
+      - uses: "./.github/setup"
 
       - name: Running tests
         run: yarn test:ci
@@ -77,22 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.17.0
-          cache: 'yarn'
-
-      - name: Installing dependencies
-        run: yarn install --frozen-lockfile
-
-      - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        run: |
-          echo "NX_HEAD=$(git rev-parse HEAD)" >> $GITHUB_ENV
-          echo "NX_BASE=$(git merge-base origin/master HEAD)" >> $GITHUB_ENV
+      - uses: "./.github/setup"
 
       - name: Running coverage
         run: yarn coverage:ci
@@ -126,22 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.17.0
-          cache: 'yarn'
-
-      - name: Installing dependencies
-        run: yarn install --frozen-lockfile
-
-      - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        run: |
-          echo "NX_HEAD=$(git rev-parse HEAD)" >> $GITHUB_ENV
-          echo "NX_BASE=$(git merge-base origin/master HEAD)" >> $GITHUB_ENV
+      - uses: "./.github/setup"
 
       - name: Deploy contracts
         run: yarn deploy:ci

--- a/nx.json
+++ b/nx.json
@@ -19,9 +19,5 @@
                 "test"
             ]
         }
-    },
-    "defaultBase": "origin/master",
-    "affected": {
-        "defaultBase": "origin/master"
     }
 }


### PR DESCRIPTION
## Description
Fix two thing in github actions:

1. There is a typo in the coverage output check lconv insted on lcov, the file was not found and we end up always skipping the coverage.
2. Now we set the shas of the two commits that `nx` will use to compare changed packages. We choose the latest commit where master and HEAD diverged as the base of the comparison. This way if master evolved and has new changes after the fork the comparison doesn't include those changes.
```
            old_master
---------------|------- master
               \-------------------- HEAD
```
Instead of comparing HEAD to master we compare HEAD to old_master.

This is different from what [nx-set-shas](https://github.com/nrwl/nx-set-shas) does. They are searching for the last successful run on the master branch of the tree. In this case they will end up choosing master as base.