### PR TITLE
feat: force prettier to load prettier-plugin-solidity

### DIFF
--- a/packages/core/.prettierrc.js
+++ b/packages/core/.prettierrc.js
@@ -1,6 +1,7 @@
 module.exports = {
   singleQuote: true,
   bracketSpacing: false,
+  plugins: ['prettier-plugin-solidity'],
   overrides: [
     {
       files: '*.sol',


### PR DESCRIPTION
## Description
By default prettier search pluigns in the [current node_modules directory](https://prettier.io/docs/en/plugins.html). 
When prettier-plugin-solidity is used by two packages it got installed in the root directory and prettier doesn't automatically find it.
In this PR we force prettier to call require("prettier-plugin-solidity") which fixes the issue.