### PR TITLE
feat: remove coverage task dependency on test

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -12,12 +12,5 @@
                 ]
             }
         }
-    },
-    "targetDefaults": {
-        "coverage": {
-            "dependsOn": [
-                "test"
-            ]
-        }
     }
 }


### PR DESCRIPTION
## Description
Remove the dependency of `nx` task `coverage` on the `test` task, this two tasks cannot be run in parallel because coverage and test share the binary output which is different as coverage instruments the code.