### PR TITLE
Move signature verification to separate contract

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,6 +58,8 @@ jobs:
 
       - name: Running tests
         run: yarn test:ci
+        env:
+          ETH_NODE_URI_POLYGON: ${{ secrets.ETH_NODE_URI_POLYGON }}
 
   coverage:
     runs-on: ubuntu-latest
@@ -121,3 +123,4 @@ jobs:
         run: yarn deploy:ci
         env:
           ETH_NODE_URI_GOERLI: ${{ secrets.ETH_NODE_URI_GOERLI }}
+          ETH_NODE_URI_POLYGON: ${{ secrets.ETH_NODE_URI_POLYGON }}

--- a/packages/asset/contracts/AuthValidator.sol
+++ b/packages/asset/contracts/AuthValidator.sol
@@ -11,6 +11,9 @@ import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 contract AuthValidator is AccessControl {
     bytes32 public constant AUTH_SIGNER_ROLE = keccak256("AUTH_ROLE");
 
+    /// @dev Constructor
+    /// @param admin Address of the admin that will be able to grant roles
+    /// @param initialSigningWallet Address of the initial signing wallet that will be signing on behalf of the backend
     constructor(address admin, address initialSigningWallet) {
         _grantRole(DEFAULT_ADMIN_ROLE, admin);
         _grantRole(AUTH_SIGNER_ROLE, initialSigningWallet);

--- a/packages/asset/contracts/AuthValidator.sol
+++ b/packages/asset/contracts/AuthValidator.sol
@@ -1,0 +1,31 @@
+//SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.18;
+
+import "@openzeppelin/contracts/access/AccessControl.sol";
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+
+/// @title AuthValidator
+/// @author The Sandbox
+/// @notice This contract is used to validate the signature of the backend
+contract AuthValidator is AccessControl {
+    bytes32 public constant AUTH_SIGNER_ROLE = keccak256("AUTH_ROLE");
+
+    constructor(address admin, address initialSigningWallet) {
+        _grantRole(DEFAULT_ADMIN_ROLE, admin);
+        _grantRole(AUTH_SIGNER_ROLE, initialSigningWallet);
+    }
+
+    /// @notice Takes the signature and the digest and returns if the signer has a backend signer role assigned
+    /// @dev Multipurpose function that can be used to verify signatures with different digests
+    /// @param signature Signature hash
+    /// @param digest Digest hash
+    /// @return bool
+    function verify(
+        bytes memory signature,
+        bytes32 digest
+    ) public view returns (bool) {
+        address recoveredSigner = ECDSA.recover(digest, signature);
+        return hasRole(AUTH_SIGNER_ROLE, recoveredSigner);
+    }
+}

--- a/packages/asset/deploy/00_deploy_auth_validator.ts
+++ b/packages/asset/deploy/00_deploy_auth_validator.ts
@@ -1,0 +1,19 @@
+import { DeployFunction } from "hardhat-deploy/types";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts } = hre;
+  const { deploy } = deployments;
+
+  const { deployer, assetAdmin, backendSigner } = await getNamedAccounts();
+
+  await deploy("AuthValidator", {
+    from: deployer,
+    contract: "AuthValidator",
+    args: [assetAdmin, backendSigner],
+    log: true,
+    skipIfAlreadyDeployed: true,
+  });
+};
+export default func;
+func.tags = ["AuthValidator"];

--- a/packages/asset/deploy/03_deploy_assetMinter.ts
+++ b/packages/asset/deploy/03_deploy_assetMinter.ts
@@ -33,5 +33,5 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   });
 };
 export default func;
-func.dependencies = ["Asset", "Catalyst"];
+func.dependencies = ["Asset", "Catalyst", "AuthValidator"];
 func.tags = ["AssetMinter"];

--- a/packages/asset/deploy/03_deploy_assetMinter.ts
+++ b/packages/asset/deploy/03_deploy_assetMinter.ts
@@ -4,11 +4,12 @@ import { DeployFunction } from "hardhat-deploy/types";
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployments, getNamedAccounts } = hre;
   const { deploy } = deployments;
-  const { deployer, revealer, upgradeAdmin, trustedForwarder } =
+  const { deployer, upgradeAdmin, trustedForwarder, tsbAssetMinter } =
     await getNamedAccounts();
 
   const AssetContract = await deployments.get("Asset");
   const CatalystContract = await deployments.get("Catalyst");
+  const AuthValidator = await deployments.get("AuthValidator");
 
   await deploy("AssetMinter", {
     from: deployer,
@@ -22,8 +23,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
           trustedForwarder,
           AssetContract.address,
           CatalystContract.address,
-          deployer,
-          revealer,
+          tsbAssetMinter,
+          AuthValidator.address,
         ],
       },
       upgradeIndex: 0,

--- a/packages/asset/hardhat.config.ts
+++ b/packages/asset/hardhat.config.ts
@@ -31,8 +31,9 @@ const config: HardhatUserConfig = {
     catalystRoyaltyRecipient: "0xB37d8F5d1fEab932f99b2dC8ABda5F413043400B", // testing wallet
     trustedForwarder: "0xf5D0aDF879b717baA5c444B23D7Df0D5e3e3cBD0", // fake
     assetAdmin: "upgradeAdmin",
+    tsbAssetMinter: "upgradeAdmin",
     uriSetter: "upgradeAdmin",
-    revealer: "upgradeAdmin",
+    backendSigner: "upgradeAdmin",
   },
   defaultNetwork: "hardhat",
   networks: {

--- a/packages/asset/hardhat.config.ts
+++ b/packages/asset/hardhat.config.ts
@@ -41,7 +41,7 @@ const config: HardhatUserConfig = {
       forking: {
         enabled: true,
         blockNumber: 16000000,
-        url: process.env.RPC_URL || "http://localhost:8545",
+        url: process.env.ETH_NODE_URI_POLYGON || "http://localhost:8545",
       },
       loggingEnabled: false,
       chainId: 1337,

--- a/packages/asset/hardhat.config.ts
+++ b/packages/asset/hardhat.config.ts
@@ -41,7 +41,7 @@ const config: HardhatUserConfig = {
       forking: {
         enabled: true,
         blockNumber: 16000000,
-        url: "https://mainnet.infura.io/v3/f24e105566724643bd574ed65ff8bd5e",
+        url: process.env.RPC_URL || "http://localhost:8545",
       },
       loggingEnabled: false,
       chainId: 1337,


### PR DESCRIPTION
## Description

Move the signature verification to a separate contract which manages CRUD operations on the backend signers and verifies hashes to see if they have been signed by an authorized wallet.
