### PR TITLE
Avatar contract audit: N-02 fix

### DIFF
--- a/packages/core/src/solc_0.8.15/proxy/CollectionFactory.sol
+++ b/packages/core/src/solc_0.8.15/proxy/CollectionFactory.sol
@@ -221,7 +221,7 @@ contract CollectionFactory is Ownable2Step {
         onlyOwner
         beaconIsAvailable(beaconAlias)
     {
-        require(newBeaconOwner != address(0), "CollectionFactory: new owner cannot be 0 address");
+        // "owner not zero address" check is done in UpgradeableBeacon::Ownable::transferOwnership
         address beacon = aliasToBeacon[beaconAlias];
         delete aliasToBeacon[beaconAlias];
         beaconCount -= 1;
@@ -330,7 +330,7 @@ contract CollectionFactory is Ownable2Step {
      * @param newCollectionOwner the new owner of the beacon. It will be changed to this before transfer
      */
     function transferCollections(address[] calldata _collections, address newCollectionOwner) external onlyOwner {
-        require(newCollectionOwner != address(0), "CollectionFactory: new owner cannot be 0 address");
+        // "owner not zero address" check done in CollectionProxy::changeCollectionProxyAdmin::_changeAdmin::_setAdmin
         bool success;
         uint256 collectionsLength = _collections.length;
         collectionCount -= collectionsLength;

--- a/packages/core/src/solc_0.8.15/proxy/CollectionFactory.sol
+++ b/packages/core/src/solc_0.8.15/proxy/CollectionFactory.sol
@@ -333,7 +333,6 @@ contract CollectionFactory is Ownable2Step {
         // "owner not zero address" check done in CollectionProxy::changeCollectionProxyAdmin::_changeAdmin::_setAdmin
         bool success;
         uint256 collectionsLength = _collections.length;
-        collectionCount -= collectionsLength;
 
         for (uint256 index; index < collectionsLength; ) {
             CollectionProxy collection = CollectionProxy(payable(_collections[index]));
@@ -347,6 +346,8 @@ contract CollectionFactory is Ownable2Step {
 
             unchecked {++index;}
         }
+
+        collectionCount -= collectionsLength;
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/packages/core/test/polygon/avatar/CollectionFactory/CollectionFactory.test.ts
+++ b/packages/core/test/polygon/avatar/CollectionFactory/CollectionFactory.test.ts
@@ -241,7 +241,7 @@ describe(targetContractName, function () {
     // new beacon cannot be 0 address
     await expect(
       factoryContractAsOwner.transferBeacon(implementationAlias, AddressZero)
-    ).to.be.revertedWith('CollectionFactory: new owner cannot be 0 address');
+    ).to.be.revertedWith('Ownable: new owner is the zero address');
 
     // sanity check beacon owner is address
     const oldOwnership = await beaconAddress.owner();
@@ -468,120 +468,120 @@ describe(targetContractName, function () {
     );
   });
 
-  // it('transferCollections works accordingly', async function () {
-  //   const {
-  //     randomAddress,
-  //     factoryContractAsOwner,
-  //     factoryContractAsRandomWallet,
-  //     mockUpgradableContract,
-  //   } = await setupFactory();
+  it('transferCollections works accordingly', async function () {
+    const {
+      randomAddress,
+      factoryContractAsOwner,
+      factoryContractAsRandomWallet,
+      mockUpgradableContract,
+    } = await setupFactory();
 
-  //   const implementationAlias = ethers.utils.formatBytes32String('main-avatar');
-  //   const initializationArgs = getMockInitializationArgs(
-  //     mockUpgradableContract
-  //   );
-  //   await deployBeacon(
-  //     factoryContractAsOwner,
-  //     mockUpgradableContract.address,
-  //     implementationAlias
-  //   );
-  //   await factoryContractAsOwner.deployCollection(
-  //     implementationAlias,
-  //     initializationArgs
-  //   );
-  //   const collectionAddedEvents = await factoryContractAsOwner.queryFilter(
-  //     factoryContractAsOwner.filters.CollectionAdded()
-  //   );
-  //   const collectionAddress = collectionAddedEvents[0].args?.[1];
+    const implementationAlias = ethers.utils.formatBytes32String('main-avatar');
+    const initializationArgs = getMockInitializationArgs(
+      mockUpgradableContract
+    );
+    await deployBeacon(
+      factoryContractAsOwner,
+      mockUpgradableContract.address,
+      implementationAlias
+    );
+    await factoryContractAsOwner.deployCollection(
+      implementationAlias,
+      initializationArgs
+    );
+    const collectionAddedEvents = await factoryContractAsOwner.queryFilter(
+      factoryContractAsOwner.filters.CollectionAdded()
+    );
+    const collectionAddress = collectionAddedEvents[0].args?.[1];
 
-  //   const collections: string[] = [collectionAddress];
+    const collections: string[] = [collectionAddress];
 
-  //   // input validations
-  //   await expect(
-  //     factoryContractAsRandomWallet.transferCollections(
-  //       collections,
-  //       randomAddress
-  //     )
-  //   ).to.be.revertedWith('Ownable: caller is not the owner');
+    // input validations
+    await expect(
+      factoryContractAsRandomWallet.transferCollections(
+        collections,
+        randomAddress
+      )
+    ).to.be.revertedWith('Ownable: caller is not the owner');
 
-  //   await expect(
-  //     factoryContractAsOwner.transferCollections(collections, AddressZero)
-  //   ).to.be.revertedWith('CollectionFactory: new owner cannot be 0 address');
+    await expect(
+      factoryContractAsOwner.transferCollections(collections, AddressZero)
+    ).to.be.revertedWith('ERC1967: new admin is the zero address');
 
-  //   // sanity checks
-  //   const collectionContract = await collectionProxyAsContract(
-  //     collectionAddress
-  //   );
-  //   const beforeCollectionCount = await factoryContractAsRandomWallet.collectionCount();
-  //   const beforeCollections: string[] = await factoryContractAsRandomWallet.getCollections();
-  //   assert.isTrue(
-  //     beforeCollections.includes(collectionAddress),
-  //     'beforeCollections includes sanity check failed'
-  //   );
-  //   assert.equal(
-  //     beforeCollections.length,
-  //     1,
-  //     'beforeCollections sanity check failed'
-  //   );
-  //   assert.equal(
-  //     beforeCollectionCount,
-  //     1,
-  //     'beforeCollectionCount sanity check failed'
-  //   );
-  //   assert.equal(
-  //     await collectionContract.proxyAdmin(),
-  //     factoryContractAsOwner.address,
-  //     'initial proxyAdmin address set ok'
-  //   );
+    // sanity checks
+    const collectionContract = await collectionProxyAsContract(
+      collectionAddress
+    );
+    const beforeCollectionCount = await factoryContractAsRandomWallet.collectionCount();
+    const beforeCollections: string[] = await factoryContractAsRandomWallet.getCollections();
+    assert.isTrue(
+      beforeCollections.includes(collectionAddress),
+      'beforeCollections includes sanity check failed'
+    );
+    assert.equal(
+      beforeCollections.length,
+      1,
+      'beforeCollections sanity check failed'
+    );
+    assert.equal(
+      beforeCollectionCount,
+      1,
+      'beforeCollectionCount sanity check failed'
+    );
+    assert.equal(
+      await collectionContract.proxyAdmin(),
+      factoryContractAsOwner.address,
+      'initial proxyAdmin address set ok'
+    );
 
-  //   // normal usage
-  //   await factoryContractAsOwner.transferCollections(
-  //     collections,
-  //     randomAddress
-  //   );
+    // normal usage
+    await factoryContractAsOwner.transferCollections(
+      collections,
+      randomAddress
+    );
 
-  //   // check that the admin address was actually changed
-  //   assert.equal(
-  //     await collectionContract.proxyAdmin(),
-  //     randomAddress,
-  //     'proxyAdmin failed to change'
-  //   );
+    // check that the admin address was actually changed
+    assert.equal(
+      await collectionContract.proxyAdmin(),
+      randomAddress,
+      'proxyAdmin failed to change'
+    );
 
-  //   // check that internal accounting changed
-  //   const afterCollectionCount = await factoryContractAsRandomWallet.collectionCount();
-  //   const afterCollections: string[] = await factoryContractAsRandomWallet.getCollections();
+    // check that internal accounting changed
+    const afterCollectionCount = await factoryContractAsRandomWallet.collectionCount();
+    const afterCollections: string[] = await factoryContractAsRandomWallet.getCollections();
 
-  //   assert.equal(afterCollections.length, 0, 'afterCollections check failed');
-  //   assert.equal(
-  //     afterCollectionCount.toNumber(),
-  //     0,
-  //     'afterCollectionCount check failed'
-  //   );
+    assert.equal(afterCollections.length, 0, 'afterCollections check failed');
+    assert.equal(
+      afterCollectionCount.toNumber(),
+      0,
+      'afterCollectionCount check failed'
+    );
 
-  //   // check events were sent
-  //   const collectionRemovedEvents = await factoryContractAsOwner.queryFilter(
-  //     factoryContractAsOwner.filters.CollectionRemoved()
-  //   );
-  //   assert.equal(
-  //     collectionRemovedEvents.length,
-  //     1,
-  //     'collectionRemovedEvents check event failed'
-  //   );
+    // check events were sent
+    const collectionRemovedEvents = await factoryContractAsOwner.queryFilter(
+      factoryContractAsOwner.filters.CollectionRemoved()
+    );
+    assert.equal(
+      collectionRemovedEvents.length,
+      1,
+      'collectionRemovedEvents check event failed'
+    );
 
-  //   const collectionProxyAdminChangedEvents = await factoryContractAsOwner.queryFilter(
-  //     factoryContractAsOwner.filters.CollectionProxyAdminChanged()
-  //   );
-  //   assert.equal(
-  //     collectionProxyAdminChangedEvents.length,
-  //     1,
-  //     'collectionProxyAdminChangedEvents check event failed'
-  //   );
+    const collectionProxyAdminChangedEvents = await factoryContractAsOwner.queryFilter(
+      factoryContractAsOwner.filters.CollectionProxyAdminChanged()
+    );
+    assert.equal(
+      collectionProxyAdminChangedEvents.length,
+      1,
+      'collectionProxyAdminChangedEvents check event failed'
+    );
 
-  //   // check that removing an inexistent collection fails
-  //   await expect(
-  //     factoryContractAsOwner.transferCollections(collections, randomAddress)
-  //   ).to.be.revertedWith('CollectionFactory: failed to remove collection');
-  // });
+    // check that removing an inexistent collection fails
+    await expect(
+      factoryContractAsOwner.transferCollections(collections, randomAddress)
+    ).to.be.revertedWith('CollectionFactory: failed to remove collection');
+  });
 
   it('addCollections works accordingly', async function () {
     // setup start


### PR DESCRIPTION
## Description
Contains
- Fix for N-02; removed redundant checks
- resolved corner case when attempting to remove more collections then existing
    - reverted with with panic code 0x11 (Arithmetic operation underflowed or overflowed outside of an unchecked block) instead of meaningful message
- updated tests