### PR TITLE
Ignore yarn.lock

### DIFF
--- a/.nxignore
+++ b/.nxignore
@@ -3,3 +3,6 @@ artifacts/
 cache/
 secret/
 .proof*
+
+# We don't want the CI to run over all the packages, we decided to ignore it for now
+yarn.lock


### PR DESCRIPTION
## Description
We ignore the yarn.lock file in .nxignore so the CI doesn't run the tasks over all the packages when we change it.
