### PR TITLE
revert: removed indexed from SuperOperator and Minter event

### DIFF
--- a/packages/core/src/solc_0.5/Land/erc721/LandBaseTokenV3.sol
+++ b/packages/core/src/solc_0.5/Land/erc721/LandBaseTokenV3.sol
@@ -22,7 +22,7 @@ contract LandBaseTokenV3 is ERC721BaseTokenV2 {
     uint256 internal constant LAYER_24x24 = 0x0400000000000000000000000000000000000000000000000000000000000000;
 
     mapping(address => bool) internal _minters;
-    event Minter(address indexed superOperator, bool enabled);
+    event Minter(address superOperator, bool enabled);
 
     struct Land {
         uint256 x;

--- a/packages/core/src/solc_0.5/contracts_common/BaseWithStorage/MetaTransactionReceiverV2.sol
+++ b/packages/core/src/solc_0.5/contracts_common/BaseWithStorage/MetaTransactionReceiverV2.sol
@@ -12,7 +12,7 @@ contract MetaTransactionReceiverV2 is AdminV2 {
     using AddressUtils for address;
 
     mapping(address => bool) internal _metaTransactionContracts;
-    event MetaTransactionProcessor(address indexed metaTransactionProcessor, bool enabled);
+    event MetaTransactionProcessor(address metaTransactionProcessor, bool enabled);
 
     /// @notice Enable or disable the ability of `metaTransactionProcessor` to perform meta-tx (metaTransactionProcessor rights).
     /// @param metaTransactionProcessor address that will be given/removed metaTransactionProcessor rights.

--- a/packages/core/src/solc_0.5/contracts_common/BaseWithStorage/SuperOperatorsV2.sol
+++ b/packages/core/src/solc_0.5/contracts_common/BaseWithStorage/SuperOperatorsV2.sol
@@ -11,7 +11,7 @@ contract SuperOperatorsV2 is AdminV2 {
 
     mapping(address => bool) internal _superOperators;
 
-    event SuperOperator(address indexed superOperator, bool enabled);
+    event SuperOperator(address superOperator, bool enabled);
 
     /// @notice Enable or disable the ability of `superOperator` to transfer tokens of all (superOperator rights).
     /// @param superOperator address that will be given/removed superOperator right.

--- a/packages/core/src/solc_0.8/polygon/child/land/PolygonLandBaseTokenV2.sol
+++ b/packages/core/src/solc_0.8/polygon/child/land/PolygonLandBaseTokenV2.sol
@@ -28,7 +28,7 @@ abstract contract PolygonLandBaseTokenV2 is IPolygonLand, Initializable, ERC721B
 
     mapping(address => bool) internal _minters;
 
-    event Minter(address indexed minter, bool enabled);
+    event Minter(address minter, bool enabled);
 
     struct Land {
         uint256 x;


### PR DESCRIPTION
## Description
Due to the change on 2 events for the Land and PolygonLand contracts (LandNew on the backend) the listeners get stuck under one of two conditions:
The contract is on the syncing process and is upgraded, this will cause the transactions of the new implementation to not go through until the ABI is updated.
The contract ABI is updated but there is a resync ongoing, this will cause the transactions of the old implementation to not go through until the ABI is updated.

**So, for now this PR reverts the event modifications to the previous version.**

[Link to Jira Issue or relevant doc](https://sandboxgame.atlassian.net/secure/RapidBoard.jspa?rapidView=50&projectKey=TSB3D)

## Dev
Any explanation for the devs that will review your implementation/code.

## Qa
Any guidance or important information for the team that will be testing your solution.

> Note: you can add any additional information you think is important for giving context to your PR.

## Checklist and Markdown
* [ ] Remember you could add any type of formatting to enhance your PR.
* [ ] Like this checklist
* [ ] And with **this** markdown format