### PR TITLE
Improve the way nonces are handled

### DIFF
--- a/packages/asset/contracts/AssetReveal.sol
+++ b/packages/asset/contracts/AssetReveal.sol
@@ -26,16 +26,18 @@ contract AssetReveal is
     mapping(address => mapping(uint256 => uint16)) revealIds;
     // signature nonces to prevent replay attacks
     mapping(address => uint32) public nonce;
-    // nonces used in signature validation
-    mapping(address => mapping(uint32 => bool)) noncesUsed;
 
     bytes32 public constant REVEAL_TYPEHASH =
         keccak256(
             "Reveal(address recipient,uint256 prevTokenId,uint32 nonce,uint256[] amounts,string[] metadataHashes)"
         );
+    bytes32 public constant BATCH_REVEAL_TYPEHASH =
+        keccak256(
+            "BatchReveal(address recipient,uint256[] prevTokenIds,uint32 nonce,uint256[][] amounts,string[][] metadataHashes)"
+        );
     bytes32 public constant INSTANT_REVEAL_TYPEHASH =
         keccak256(
-            "InstantReveal(address recipient,uint256 prevTokenId,uint256[] amounts,string[] metadataHashes)"
+            "InstantReveal(address recipient,uint256 prevTokenId,uint32 nonce,uint256[] amounts,string[] metadataHashes)"
         );
 
     /// @custom:oz-upgrades-unsafe-allow constructor
@@ -65,19 +67,7 @@ contract AssetReveal is
     /// @param tokenId the tokenId of id idasset to reveal
     /// @param amount the amount of tokens to reveal
     function revealBurn(uint256 tokenId, uint256 amount) public {
-        require(amount > 0, "Amount should be greater than 0");
-        IAsset.AssetData memory data = tokenId.getData();
-        require(!data.revealed, "Asset is already revealed");
-        assetContract.burnFrom(_msgSender(), tokenId, amount);
-        nonce[_msgSender()]++;
-        emit AssetRevealBurn(
-            _msgSender(),
-            tokenId,
-            nonce[_msgSender()],
-            data.creator,
-            data.tier,
-            amount
-        );
+        _burnAsset(tokenId, amount);
     }
 
     /// @notice Burn multiple assets to be able to reveal them later
@@ -90,7 +80,7 @@ contract AssetReveal is
     ) external {
         require(tokenIds.length == amounts.length, "Invalid input");
         for (uint256 i = 0; i < tokenIds.length; i++) {
-            revealBurn(tokenIds[i], amounts[i]);
+            _burnAsset(tokenIds[i], amounts[i]);
         }
     }
 
@@ -103,7 +93,6 @@ contract AssetReveal is
     function revealMint(
         bytes memory signature,
         uint256 prevTokenId,
-        uint32 signatureNonce,
         uint256[] calldata amounts,
         string[] calldata metadataHashes
     ) public {
@@ -113,76 +102,48 @@ contract AssetReveal is
                 _hashReveal(
                     _msgSender(),
                     prevTokenId,
-                    signatureNonce,
+                    nonce[_msgSender()]++,
                     amounts,
                     metadataHashes
                 )
             ),
             "Invalid signature"
         );
-        require(
-            !noncesUsed[_msgSender()][signatureNonce],
-            "Signature has already been used"
-        );
-        noncesUsed[_msgSender()][signatureNonce] = true;
-
         require(amounts.length == metadataHashes.length, "Invalid amount");
-        uint256[] memory newTokenIds = getRevealedTokenIds(
-            amounts,
-            metadataHashes,
-            prevTokenId
-        );
-
-        if (newTokenIds.length == 1) {
-            assetContract.mint(
-                _msgSender(),
-                newTokenIds[0],
-                amounts[0],
-                metadataHashes[0]
-            );
-        } else {
-            assetContract.mintBatch(
-                _msgSender(),
-                newTokenIds,
-                amounts,
-                metadataHashes
-            );
-        }
-
-        emit AssetsRevealed(
-            _msgSender(),
-            prevTokenId,
-            signatureNonce,
-            amounts,
-            newTokenIds
-        );
+        _revealAsset(prevTokenId, metadataHashes, amounts);
     }
 
     /// @notice Mint multiple assets with revealed abilities and enhancements
     /// @dev Can be used to reveal multiple copies of the same token id
-    /// @param signatures Signatures created on the TSB backend containing REVEAL_TYPEHASH and associated data, must be signed by authorized signer
+    /// @param signature Signatures created on the TSB backend containing REVEAL_TYPEHASH and associated data, must be signed by authorized signer
     /// @param prevTokenIds The tokenId of the unrevealed asset
     /// @param amounts The amount of assets to reveal (must be equal to the length of revealHashes)
     /// @param metadataHashes The array of hashes for asset metadata
     function revealBatchMint(
-        bytes[] calldata signatures,
+        bytes calldata signature,
         uint256[] calldata prevTokenIds,
-        uint32[] calldata signatureNonces,
         uint256[][] calldata amounts,
         string[][] calldata metadataHashes
     ) public {
-        require(signatures.length == prevTokenIds.length, "Invalid input");
+        require(
+            authValidator.verify(
+                signature,
+                _hashBatchReveal(
+                    _msgSender(),
+                    prevTokenIds,
+                    nonce[_msgSender()]++,
+                    amounts,
+                    metadataHashes
+                )
+            ),
+            "Invalid signature"
+        );
+        require(amounts.length == metadataHashes.length, "Invalid amount");
         require(amounts.length == metadataHashes.length, "Invalid input");
         require(prevTokenIds.length == amounts.length, "Invalid input");
 
-        for (uint256 i = 0; i < signatures.length; i++) {
-            revealMint(
-                signatures[i],
-                prevTokenIds[i],
-                signatureNonces[i],
-                amounts[i],
-                metadataHashes[i]
-            );
+        for (uint256 i = 0; i < prevTokenIds.length; i++) {
+            _revealAsset(prevTokenIds[i], metadataHashes[i], amounts[i]);
         }
     }
 
@@ -206,44 +167,85 @@ contract AssetReveal is
                 _hashInstantReveal(
                     _msgSender(),
                     prevTokenId,
+                    nonce[_msgSender()]++,
                     amounts,
                     metadataHashes
                 )
             ),
             "Invalid signature"
         );
-        require(burnAmount > 0, "Amount should be greater than 0");
-        IAsset.AssetData memory data = prevTokenId.getData();
-        require(!data.revealed, "Asset is already revealed");
-        assetContract.burnFrom(_msgSender(), prevTokenId, burnAmount);
+        _burnAsset(prevTokenId, burnAmount);
+        _revealAsset(prevTokenId, metadataHashes, amounts);
+    }
 
-        uint256[] memory tokenIds = getRevealedTokenIds(
+    /// @notice Generate new tokenIds for revealed assets and mint them
+    /// @param prevTokenId The tokenId of the unrevealed asset
+    /// @param metadataHashes The array of hashes for asset metadata
+    /// @param amounts The array of amounts to mint
+    function _revealAsset(
+        uint256 prevTokenId,
+        string[] calldata metadataHashes,
+        uint256[] calldata amounts
+    ) internal {
+        uint256[] memory newTokenIds = getRevealedTokenIds(
             amounts,
             metadataHashes,
             prevTokenId
         );
 
-        if (tokenIds.length == 1) {
+        if (newTokenIds.length == 1) {
             assetContract.mint(
                 _msgSender(),
-                tokenIds[0],
+                newTokenIds[0],
                 amounts[0],
                 metadataHashes[0]
             );
         } else {
             assetContract.mintBatch(
                 _msgSender(),
-                tokenIds,
+                newTokenIds,
                 amounts,
                 metadataHashes
             );
         }
+        emit AssetRevealMint(_msgSender(), prevTokenId, amounts, newTokenIds);
+    }
 
-        emit AssetInstantlyRevealed(
-            _msgSender(),
-            prevTokenId,
-            amounts,
-            tokenIds
+    /// @notice Burns an asset to be able to reveal it later
+    /// @param tokenId the tokenId of the asset to burn
+    /// @param amount the amount of the asset to burn
+    function _burnAsset(uint256 tokenId, uint256 amount) internal {
+        require(amount > 0, "Amount should be greater than 0");
+        IAsset.AssetData memory data = tokenId.getData();
+        require(!data.revealed, "Asset is already revealed");
+        assetContract.burnFrom(_msgSender(), tokenId, amount);
+        emit AssetRevealBurn(_msgSender(), tokenId, data.tier, amount);
+    }
+
+    /// @notice Creates a hash of the reveal data
+    /// @param recipient The address of the recipient
+    /// @param prevTokenId The unrevealed token id
+    /// @param signatureNonce The nonce of the signature
+    /// @param amounts The amount of tokens to mint
+    /// @param metadataHashes The array of hashes for new asset metadata
+    function _hashInstantReveal(
+        address recipient,
+        uint256 prevTokenId,
+        uint32 signatureNonce,
+        uint256[] calldata amounts,
+        string[] calldata metadataHashes
+    ) internal view returns (bytes32 digest) {
+        digest = _hashTypedDataV4(
+            keccak256(
+                abi.encode(
+                    INSTANT_REVEAL_TYPEHASH,
+                    recipient,
+                    prevTokenId,
+                    signatureNonce,
+                    keccak256(abi.encodePacked(amounts)),
+                    _encodeHashes(metadataHashes)
+                )
+            )
         );
     }
 
@@ -272,20 +274,26 @@ contract AssetReveal is
         );
     }
 
-    function _hashInstantReveal(
+    /// @notice Creates a hash of the reveal data
+    /// @param prevTokenIds The previous token id
+    /// @param amounts The amount of tokens to mint
+    /// @return digest The hash of the reveal data
+    function _hashBatchReveal(
         address recipient,
-        uint256 prevTokenId,
-        uint256[] calldata amounts,
-        string[] calldata metadataHashes
+        uint256[] calldata prevTokenIds,
+        uint32 signatureNonce,
+        uint256[][] calldata amounts,
+        string[][] calldata metadataHashes
     ) internal view returns (bytes32 digest) {
         digest = _hashTypedDataV4(
             keccak256(
                 abi.encode(
-                    INSTANT_REVEAL_TYPEHASH,
+                    BATCH_REVEAL_TYPEHASH,
                     recipient,
-                    prevTokenId,
-                    keccak256(abi.encodePacked(amounts)),
-                    _encodeHashes(metadataHashes)
+                    keccak256(abi.encodePacked(prevTokenIds)),
+                    signatureNonce,
+                    _encodeBatchAmounts(amounts),
+                    _encodeBatchHashes(metadataHashes)
                 )
             )
         );
@@ -301,18 +309,32 @@ contract AssetReveal is
         for (uint256 i = 0; i < metadataHashes.length; i++) {
             encodedHashes[i] = keccak256((abi.encodePacked(metadataHashes[i])));
         }
-
         return keccak256(abi.encodePacked(encodedHashes));
     }
 
-    function _encodeAmounts(
-        uint256[] memory amounts
+    /// @notice Encodes the hashes of the metadata for signature verification
+    /// @param metadataHashes The hashes of the metadata
+    /// @return encodedHashes The encoded hashes of the metadata
+    function _encodeBatchHashes(
+        string[][] memory metadataHashes
+    ) internal pure returns (bytes32) {
+        bytes32[] memory encodedHashes = new bytes32[](metadataHashes.length);
+        for (uint256 i = 0; i < metadataHashes.length; i++) {
+            encodedHashes[i] = _encodeHashes(metadataHashes[i]);
+        }
+        return keccak256(abi.encodePacked(encodedHashes));
+    }
+
+    /// @notice Encodes the amounts of the tokens for signature verification
+    /// @param amounts The amounts of the tokens
+    /// @return encodedAmounts The encoded amounts of the tokens
+    function _encodeBatchAmounts(
+        uint256[][] memory amounts
     ) internal pure returns (bytes32) {
         bytes32[] memory encodedAmounts = new bytes32[](amounts.length);
         for (uint256 i = 0; i < amounts.length; i++) {
             encodedAmounts[i] = keccak256(abi.encodePacked(amounts[i]));
         }
-
         return keccak256(abi.encodePacked(encodedAmounts));
     }
 

--- a/packages/asset/contracts/AssetReveal.sol
+++ b/packages/asset/contracts/AssetReveal.sol
@@ -25,7 +25,7 @@ contract AssetReveal is
     // mapping of creator to asset id to asset's reveal nonce
     mapping(address => mapping(uint256 => uint16)) revealIds;
     // signature nonces to prevent replay attacks
-    mapping(address => uint32) public nonce;
+    mapping(address => uint32) public signatureNonces;
 
     bytes32 public constant REVEAL_TYPEHASH =
         keccak256(
@@ -102,7 +102,7 @@ contract AssetReveal is
                 _hashReveal(
                     _msgSender(),
                     prevTokenId,
-                    nonce[_msgSender()]++,
+                    signatureNonces[_msgSender()]++,
                     amounts,
                     metadataHashes
                 )
@@ -131,7 +131,7 @@ contract AssetReveal is
                 _hashBatchReveal(
                     _msgSender(),
                     prevTokenIds,
-                    nonce[_msgSender()]++,
+                    signatureNonces[_msgSender()]++,
                     amounts,
                     metadataHashes
                 )
@@ -167,7 +167,7 @@ contract AssetReveal is
                 _hashInstantReveal(
                     _msgSender(),
                     prevTokenId,
-                    nonce[_msgSender()]++,
+                    signatureNonces[_msgSender()]++,
                     amounts,
                     metadataHashes
                 )

--- a/packages/asset/contracts/interfaces/IAssetReveal.sol
+++ b/packages/asset/contracts/interfaces/IAssetReveal.sol
@@ -5,21 +5,11 @@ interface IAssetReveal {
     event AssetRevealBurn(
         address revealer,
         uint256 unrevealedTokenId,
-        uint32 signatureNonce,
-        address assetCreator,
         uint8 tier,
         uint256 amount
     );
 
-    event AssetsRevealed(
-        address recipient,
-        uint256 unrevealedTokenId,
-        uint32 signatureNonce,
-        uint256[] amounts,
-        uint256[] newTokenIds
-    );
-
-    event AssetInstantlyRevealed(
+    event AssetRevealMint(
         address recipient,
         uint256 unrevealedTokenId,
         uint256[] amounts,

--- a/packages/asset/test/AssetReveal.test.ts
+++ b/packages/asset/test/AssetReveal.test.ts
@@ -145,14 +145,14 @@ const runTestSetup = deployments.createFixture(
     };
 
     const generateRevealSignature = async (
-      recipient: string,
+      revealer: string,
       amounts: number[],
       prevTokenId: number,
       metadataHashes: string[]
     ) => {
-      const nonce = await AssetRevealContract.nonce(recipient);
+      const nonce = await AssetRevealContract.signatureNonces(revealer);
       const signature = await createRevealSignature(
-        recipient,
+        revealer,
         amounts,
         prevTokenId,
         nonce,
@@ -162,14 +162,14 @@ const runTestSetup = deployments.createFixture(
     };
 
     const generateBatchRevealSignature = async (
-      recipient: string,
+      revealer: string,
       amounts: number[][],
       prevTokenIds: number[],
       metadataHashes: string[][]
     ) => {
-      const nonce = await AssetRevealContract.nonce(recipient);
+      const nonce = await AssetRevealContract.signatureNonces(revealer);
       const signature = await createBatchRevealSignature(
-        recipient,
+        revealer,
         amounts,
         prevTokenIds,
         nonce,
@@ -179,14 +179,14 @@ const runTestSetup = deployments.createFixture(
     };
 
     const generateBurnAndRevealSignature = async (
-      recipient: string,
+      revealer: string,
       amounts: number[],
       prevTokenId: number,
       metadataHashes: string[]
     ) => {
-      const nonce = await AssetRevealContract.nonce(recipient);
+      const nonce = await AssetRevealContract.signatureNonces(revealer);
       const signature = await createBurnAndRevealSignature(
-        recipient,
+        revealer,
         amounts,
         prevTokenId,
         nonce,

--- a/packages/asset/test/AssetReveal.test.ts
+++ b/packages/asset/test/AssetReveal.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai";
 import { deployments } from "hardhat";
 import {
+  createBatchRevealSignature,
   createBurnAndRevealSignature,
   createRevealSignature,
 } from "./utils/revealSignature";
@@ -75,14 +76,12 @@ const runTestSetup = deployments.createFixture(
     const revealAsset = async (
       signature: string,
       tokenId: number,
-      nonce: number,
       amounts: number[],
       metadataHashes: string[]
     ) => {
       const tx = await AssetRevealContract.revealMint(
         signature,
         tokenId,
-        nonce,
         amounts,
         metadataHashes
       );
@@ -98,16 +97,14 @@ const runTestSetup = deployments.createFixture(
     };
 
     const revealAssetBatch = async (
-      signatures: string[],
+      signature: string,
       tokenIds: number[],
-      nonces: number[],
       amounts: number[][],
       metadataHashes: string[][]
     ) => {
       const tx = await AssetRevealContract.revealBatchMint(
-        signatures,
+        signature,
         tokenIds,
-        nonces,
         amounts,
         metadataHashes
       );
@@ -147,17 +144,34 @@ const runTestSetup = deployments.createFixture(
       return result;
     };
 
-    const generateSignature = async (
+    const generateRevealSignature = async (
       recipient: string,
       amounts: number[],
       prevTokenId: number,
-      nonce: number,
       metadataHashes: string[]
     ) => {
+      const nonce = await AssetRevealContract.nonce(recipient);
       const signature = await createRevealSignature(
         recipient,
         amounts,
         prevTokenId,
+        nonce,
+        metadataHashes
+      );
+      return signature;
+    };
+
+    const generateBatchRevealSignature = async (
+      recipient: string,
+      amounts: number[][],
+      prevTokenIds: number[],
+      metadataHashes: string[][]
+    ) => {
+      const nonce = await AssetRevealContract.nonce(recipient);
+      const signature = await createBatchRevealSignature(
+        recipient,
+        amounts,
+        prevTokenIds,
         nonce,
         metadataHashes
       );
@@ -170,10 +184,12 @@ const runTestSetup = deployments.createFixture(
       prevTokenId: number,
       metadataHashes: string[]
     ) => {
+      const nonce = await AssetRevealContract.nonce(recipient);
       const signature = await createBurnAndRevealSignature(
         recipient,
         amounts,
         prevTokenId,
+        nonce,
         metadataHashes
       );
       return signature;
@@ -181,7 +197,8 @@ const runTestSetup = deployments.createFixture(
 
     return {
       deployer,
-      generateSignature,
+      generateRevealSignature,
+      generateBatchRevealSignature,
       generateBurnAndRevealSignature,
       revealAsset,
       revealAssetBatch,
@@ -285,18 +302,14 @@ describe.only("AssetReveal", () => {
       const burnResult = await burnTx.wait();
       const burnEvent = burnResult.events[1];
       expect(burnEvent.event).to.equal("AssetRevealBurn");
-      // msgSender
+      // revealer
       expect(burnEvent.args[0]).to.equal(deployer);
-      // tokenId
+      // token id that is being revealed
       expect(burnEvent.args[1]).to.equal(unrevealedtokenId);
-      // reveal nonce
-      expect(burnEvent.args[2].toString()).to.equal("1");
-      // creator
-      expect(burnEvent.args[3]).to.equal(deployer);
       // tier
-      expect(burnEvent.args[4].toString()).to.equal("5");
+      expect(burnEvent.args[2].toString()).to.equal("5");
       // amount
-      expect(burnEvent.args[5].toString()).to.equal("1");
+      expect(burnEvent.args[3].toString()).to.equal("1");
     });
     it("Should be able to burn multiple unrevealed owned assets", async () => {
       const {
@@ -306,23 +319,42 @@ describe.only("AssetReveal", () => {
         unrevealedtokenId2,
         deployer,
       } = await runTestSetup();
-      const burnTx = await AssetRevealContract.revealBatchBurn(
-        [unrevealedtokenId, unrevealedtokenId2],
-        [5, 5]
-      );
-      await burnTx.wait();
-
-      const deployerBalance1 = await AssetContract.balanceOf(
+      const amountToBurn1 = 2;
+      const amountToBurn2 = 3;
+      const tk1BalanceBeforeBurn = await AssetContract.balanceOf(
         deployer,
         unrevealedtokenId
       );
-      expect(deployerBalance1.toString()).to.equal("4");
 
-      const deployerBalance2 = await AssetContract.balanceOf(
+      const tk2BalanceBeforeBurn = await AssetContract.balanceOf(
         deployer,
         unrevealedtokenId2
       );
-      expect(deployerBalance2.toString()).to.equal("5");
+
+      const burnTx = await AssetRevealContract.revealBatchBurn(
+        [unrevealedtokenId, unrevealedtokenId2],
+        [amountToBurn1, amountToBurn2]
+      );
+      await burnTx.wait();
+
+      const tk1BalanceAfterBurn = await AssetContract.balanceOf(
+        deployer,
+        unrevealedtokenId
+      );
+
+      // expect(tk1BalanceBeforeBurn.sub(5)).to.equal(tk1BalanceAfterBurn);
+
+      const tk2BalanceAfterBurn = await AssetContract.balanceOf(
+        deployer,
+        unrevealedtokenId2
+      );
+
+      expect(tk1BalanceBeforeBurn.sub(amountToBurn1)).to.equal(
+        tk1BalanceAfterBurn
+      );
+      expect(tk2BalanceBeforeBurn.sub(amountToBurn2)).to.equal(
+        tk2BalanceAfterBurn
+      );
     });
   });
   describe("Minting", () => {
@@ -330,32 +362,28 @@ describe.only("AssetReveal", () => {
       const {
         deployer,
         unrevealedtokenId,
-        burnAsset,
-        generateSignature,
+        generateRevealSignature,
         revealAsset,
         AssetContract,
       } = await runTestSetup();
-      const newMetadataHash = [
+      const newMetadataHashes = [
         "QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJF",
       ];
-      const amount = 1;
-      const { nonce } = await burnAsset(unrevealedtokenId, amount);
+      const amounts = [1];
 
-      const signature = await generateSignature(
+      const signature = await generateRevealSignature(
         deployer,
-        [amount],
+        amounts,
         unrevealedtokenId,
-        nonce,
-        newMetadataHash
+        newMetadataHashes
       );
       const result = await revealAsset(
         signature,
         unrevealedtokenId,
-        nonce,
-        [amount],
-        newMetadataHash
+        amounts,
+        newMetadataHashes
       );
-      expect(result.events[2].event).to.equal("AssetsRevealed");
+      expect(result.events[2].event).to.equal("AssetRevealMint");
 
       const newTokenId = result.events[2].args.newTokenIds[0];
       const balance = await AssetContract.balanceOf(deployer, newTokenId);
@@ -365,80 +393,69 @@ describe.only("AssetReveal", () => {
       const {
         deployer,
         unrevealedtokenId,
-        burnAsset,
         revealAsset,
-        generateSignature,
+        generateRevealSignature,
       } = await runTestSetup();
-      const newMetadataHash = [
+      const newMetadataHashes = [
         "QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJF",
       ];
-      const amount = 2;
-      const { nonce } = await burnAsset(unrevealedtokenId, amount);
-      const signature = await generateSignature(
+      const amounts = [2];
+      const signature = await generateRevealSignature(
         deployer,
-        [amount],
+        amounts,
         unrevealedtokenId,
-        nonce,
-        newMetadataHash
+        newMetadataHashes
       );
 
       const result = await revealAsset(
         signature,
         unrevealedtokenId,
-        nonce,
-        [amount],
-        newMetadataHash
+        amounts,
+        newMetadataHashes
       );
 
-      expect(result.events[2].event).to.equal("AssetsRevealed");
+      expect(result.events[2].event).to.equal("AssetRevealMint");
       expect(result.events[2].args["newTokenIds"].length).to.equal(1);
     });
     it("should increase the tokens supply for tokens with same metadata hash", async () => {
       const {
         deployer,
         unrevealedtokenId,
-        burnAsset,
-        generateSignature,
+        generateRevealSignature,
         revealAsset,
         AssetContract,
       } = await runTestSetup();
-      const newMetadataHash = [
+      const newMetadataHashes = [
         "QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJF",
       ];
-      const amount = 1;
-      const { nonce: firstNonce } = await burnAsset(unrevealedtokenId, amount);
-      const signature = await generateSignature(
+      const amounts = [1];
+      const signature = await generateRevealSignature(
         deployer,
-        [amount],
+        amounts,
         unrevealedtokenId,
-        firstNonce,
-        newMetadataHash
+        newMetadataHashes
       );
       const result = await revealAsset(
         signature,
         unrevealedtokenId,
-        firstNonce,
-        [amount],
-        newMetadataHash
+        amounts,
+        newMetadataHashes
       );
       const newTokenId = result.events[2].args.newTokenIds[0];
       const balance = await AssetContract.balanceOf(deployer, newTokenId);
       expect(balance.toString()).to.equal("1");
 
-      const { nonce: secondNonce } = await burnAsset(unrevealedtokenId, amount);
-      const signature2 = await generateSignature(
+      const signature2 = await generateRevealSignature(
         deployer,
-        [amount],
+        amounts,
         unrevealedtokenId,
-        secondNonce,
-        newMetadataHash
+        newMetadataHashes
       );
       await revealAsset(
         signature2,
         unrevealedtokenId,
-        secondNonce,
-        [amount],
-        newMetadataHash
+        amounts,
+        newMetadataHashes
       );
       const balance2 = await AssetContract.balanceOf(deployer, newTokenId);
       expect(balance2.toString()).to.equal("2");
@@ -447,56 +464,41 @@ describe.only("AssetReveal", () => {
       const {
         deployer,
         revealAssetBatch,
-        burnAssetBatch,
-        generateSignature,
+        generateBatchRevealSignature,
         unrevealedtokenId,
         unrevealedtokenId2,
       } = await runTestSetup();
-      const newMetadataHash1 = [
+      const newMetadataHashes1 = [
         "QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJF",
       ];
-      const newMetadataHash2 = [
+      const newMetadataHashes2 = [
         "QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJZ",
       ];
-      const amount1 = 1;
-      const amount2 = 1;
+      const amounts1 = [1];
+      const amounts2 = [1];
 
-      const { nonces } = await burnAssetBatch(
+      const signature = await generateBatchRevealSignature(
+        deployer,
+        [amounts1, amounts2],
         [unrevealedtokenId, unrevealedtokenId2],
-        [amount1, amount2]
-      );
-      const signature1 = await generateSignature(
-        deployer,
-        [amount1],
-        unrevealedtokenId,
-        nonces[0],
-        newMetadataHash1
+        [newMetadataHashes1, newMetadataHashes2]
       );
 
-      const signature2 = await generateSignature(
-        deployer,
-        [amount2],
-        unrevealedtokenId2,
-        nonces[1],
-        newMetadataHash2
-      );
       const result = await revealAssetBatch(
-        [signature1, signature2],
+        signature,
         [unrevealedtokenId, unrevealedtokenId2],
-        nonces,
-        [[amount1], [amount2]],
-        [newMetadataHash1, newMetadataHash2]
+        [amounts1, amounts2],
+        [newMetadataHashes1, newMetadataHashes2]
       );
 
       // expect two events with name AssetsRevealed
-      expect(result.events[2].event).to.equal("AssetsRevealed");
-      expect(result.events[5].event).to.equal("AssetsRevealed");
+      expect(result.events[2].event).to.equal("AssetRevealMint");
+      expect(result.events[5].event).to.equal("AssetRevealMint");
     });
     it("Should allow revealing multiple copies at the same time", async () => {
       const {
         deployer,
-        generateSignature,
-        burnAsset,
+        generateRevealSignature,
         revealAsset,
         unrevealedtokenId,
       } = await runTestSetup();
@@ -509,23 +511,20 @@ describe.only("AssetReveal", () => {
         "QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJ6",
       ];
       const amountToMint = [1, 2, 1, 7, 1, 2];
-      const { nonce } = await burnAsset(unrevealedtokenId, 1);
-      const signature = await generateSignature(
+      const signature = await generateRevealSignature(
         deployer,
         amountToMint,
         unrevealedtokenId,
-        nonce,
         newMetadataHashes
       );
 
       const result = await revealAsset(
         signature,
         unrevealedtokenId,
-        nonce,
         amountToMint,
         newMetadataHashes
       );
-      expect(result.events[7].event).to.equal("AssetsRevealed");
+      expect(result.events[7].event).to.equal("AssetRevealMint");
       expect(result.events[7].args["newTokenIds"].length).to.equal(6);
     });
     it("Should allow instant reveal when authorized by the backed", async () => {
@@ -538,11 +537,11 @@ describe.only("AssetReveal", () => {
       const newMetadataHash = [
         "QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJF",
       ];
-      const amount = 1;
+      const amounts = [1];
 
       const signature = await generateBurnAndRevealSignature(
         deployer,
-        [amount],
+        amounts,
         unrevealedtokenId,
         newMetadataHash
       );
@@ -550,148 +549,106 @@ describe.only("AssetReveal", () => {
       const result = await instantReveal(
         signature,
         unrevealedtokenId,
-        amount,
-        [amount],
+        amounts[0],
+        amounts,
         newMetadataHash
       );
-      expect(result.events[3].event).to.equal("AssetInstantlyRevealed");
+      expect(result.events[4].event).to.equal("AssetRevealMint");
     });
     it("Should not allow minting with invalid signature", async () => {
       const { revealAsset, unrevealedtokenId } = await runTestSetup();
-      const newMetadataHash = [
+      const newMetadataHashes = [
         "QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJF",
       ];
-      const amountToMint = [1];
+      const amounts = [1];
       await expect(
         revealAsset(
           "0x1556a70d76cc452ae54e83bb167a9041f0d062d000fa0dcb42593f77c544f6471643d14dbd6a6edc658f4b16699a585181a08dba4f6d16a9273e0e2cbed622da1b",
           unrevealedtokenId,
-          0,
-          amountToMint,
-          newMetadataHash
+          amounts,
+          newMetadataHashes
         )
       ).to.be.revertedWith("Invalid signature");
     });
     it("Should not allow minting with invalid prevTokenId", async () => {
       const {
         deployer,
-        generateSignature,
-        burnAsset,
+        generateRevealSignature,
         unrevealedtokenId,
         AssetRevealContract,
       } = await runTestSetup();
-      const newMetadataHash = [
+      const newMetadataHashes = [
         "QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJF",
       ];
-      const amount = 1;
-      const { nonce } = await burnAsset(unrevealedtokenId, amount);
-      const signature = await generateSignature(
+      const amounts = [1];
+      const signature = await generateRevealSignature(
         deployer,
-        [amount],
+        amounts,
         unrevealedtokenId,
-        nonce,
-        newMetadataHash
+        newMetadataHashes
       );
 
       await expect(
         AssetRevealContract.revealMint(
           signature,
           123,
-          nonce,
-          [amount],
-          newMetadataHash
+          amounts,
+          newMetadataHashes
         )
       ).to.be.revertedWith("Invalid signature");
     });
     it("Should not allow minting with invalid amount", async () => {
       const {
         deployer,
-        generateSignature,
-        burnAsset,
+        generateRevealSignature,
         unrevealedtokenId,
         AssetRevealContract,
       } = await runTestSetup();
-      const newMetadataHash = [
+      const newMetadataHashes = [
         "QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJF",
       ];
-      const amount = 1;
-      const { nonce } = await burnAsset(unrevealedtokenId, amount);
-      const signature = await generateSignature(
+      const amounts = [1];
+      const signature = await generateRevealSignature(
         deployer,
-        [amount],
+        amounts,
         unrevealedtokenId,
-        nonce,
-        newMetadataHash
+        newMetadataHashes
       );
 
       await expect(
         AssetRevealContract.revealMint(
           signature,
           unrevealedtokenId,
-          nonce,
+
           [123],
-          newMetadataHash
+          newMetadataHashes
         )
       ).to.be.revertedWith("Invalid signature");
     });
     it("Should not allow minting with invalid metadataHashes", async () => {
       const {
         deployer,
-        generateSignature,
-        burnAsset,
+        generateRevealSignature,
         unrevealedtokenId,
         AssetRevealContract,
       } = await runTestSetup();
-      const newMetadataHash = [
+      const newMetadataHashes = [
         "QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJF",
       ];
-      const amount = 1;
-      const { nonce } = await burnAsset(unrevealedtokenId, amount);
-      const signature = await generateSignature(
+      const amounts = [1];
+      const signature = await generateRevealSignature(
         deployer,
-        [amount],
+        amounts,
         unrevealedtokenId,
-        nonce,
-        newMetadataHash
+        newMetadataHashes
       );
 
       await expect(
         AssetRevealContract.revealMint(
           signature,
           unrevealedtokenId,
-          nonce,
-          [amount],
-          ["QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJE"]
-        )
-      ).to.be.revertedWith("Invalid signature");
-    });
-    it("Should not allow minting with invalid nonce", async () => {
-      const {
-        deployer,
-        generateSignature,
-        burnAsset,
-        unrevealedtokenId,
-        AssetRevealContract,
-      } = await runTestSetup();
-      const newMetadataHash = [
-        "QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJF",
-      ];
-      const amount = 1;
-      const { nonce } = await burnAsset(unrevealedtokenId, amount);
-      const signature = await generateSignature(
-        deployer,
-        [amount],
-        unrevealedtokenId,
-        nonce,
-        newMetadataHash
-      );
 
-      await expect(
-        AssetRevealContract.revealMint(
-          signature,
-          unrevealedtokenId,
-          3,
-          [amount],
+          amounts,
           ["QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJE"]
         )
       ).to.be.revertedWith("Invalid signature");
@@ -699,42 +656,37 @@ describe.only("AssetReveal", () => {
     it("Should not allow using the same signature twice", async () => {
       const {
         deployer,
-        generateSignature,
-        burnAsset,
+        generateRevealSignature,
         revealAsset,
         unrevealedtokenId,
         AssetRevealContract,
       } = await runTestSetup();
-      const newMetadataHash = [
+      const newMetadataHashes = [
         "QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJF",
       ];
-      const amount = 1;
-      const { nonce } = await burnAsset(unrevealedtokenId, amount);
-      const signature = await generateSignature(
+      const amounts = [1];
+      const signature = await generateRevealSignature(
         deployer,
-        [amount],
+        amounts,
         unrevealedtokenId,
-        nonce,
-        newMetadataHash
+        newMetadataHashes
       );
 
       await revealAsset(
         signature,
         unrevealedtokenId,
-        nonce,
-        [amount],
-        newMetadataHash
+        amounts,
+        newMetadataHashes
       );
 
       await expect(
         AssetRevealContract.revealMint(
           signature,
           unrevealedtokenId,
-          nonce,
-          [amount],
-          newMetadataHash
+          amounts,
+          newMetadataHashes
         )
-      ).to.be.revertedWith("Signature has already been used");
+      ).to.be.revertedWith("Invalid signature");
     });
   });
 });


### PR DESCRIPTION
# Description

This PR introduces changes to handling the signature nonces in the Asset Reveal contract and does some minor code refactoring to remove sections of duplicated code.

The changes were inspired by @mvanmeerbeck's comments in the parent PR.

- The nonces are no longer emitted in burn events
- The nonce is increased each time its used to verify a signature
- There is no more need to generate more than 1 signature when revealing batches of assets which saves us a significant amount of gas and will allow for larger batches to be revealed at once.

### How does that affect the reveal process?
- Previously we had to use a single nonce for the batch of assets that were burned together, right now we can have much more flexibility on the backend side and generate them according to user's requests. The means burning of 10 copies can result in 10 individual reveal transactions (even if there are duplicates in the revealed results!) or just one.

We need to keep a secure record on the backend of how many assets can be revealed, the backend will now have even more power.

The metadata hashes should still be generated when burn event is received so that metadata hashes remain the same for the user that wants to mint them even if she/he cancels the transaction multiple times before sending it.
