### PR TITLE
Keep the reveal DRY 🌵

### DIFF
--- a/packages/asset/contracts/AssetReveal.sol
+++ b/packages/asset/contracts/AssetReveal.sol
@@ -174,18 +174,14 @@ contract AssetReveal is IAssetReveal, Initializable, ERC2771Handler, EIP712Upgra
         uint256[] calldata amounts,
         bytes32[] calldata revealHashes
     ) internal {
-        uint256[] memory newTokenIds = getRevealedTokenIds(amounts, metadataHashes, prevTokenId);
+        uint256[] memory newTokenIds = getRevealedTokenIds(metadataHashes, prevTokenId);
+        for (uint256 i = 0; i < revealHashes.length; i++) {
+            require(revealHashesUsed[revealHashes[i]] == false, "Invalid revealHash");
+            revealHashesUsed[revealHashes[i]] = true;
+        }
         if (newTokenIds.length == 1) {
-            // ensure that revealHash is not already used then flag it as used
-            require(revealHashesUsed[revealHashes[0]] == false, "Invalid revealHash");
-            revealHashesUsed[revealHashes[0]] = true;
             assetContract.mint(_msgSender(), newTokenIds[0], amounts[0], metadataHashes[0]);
         } else {
-            // ensure that revealHashes are not already used then flag them as used
-            for (uint256 i = 0; i < newTokenIds.length; i++) {
-                require(revealHashesUsed[revealHashes[i]] == false, "Invalid revealHash");
-                revealHashesUsed[revealHashes[i]] = true;
-            }
             assetContract.mintBatch(_msgSender(), newTokenIds, amounts, metadataHashes);
         }
         emit AssetRevealMint(_msgSender(), prevTokenId, amounts, newTokenIds, revealHashes);
@@ -332,23 +328,21 @@ contract AssetReveal is IAssetReveal, Initializable, ERC2771Handler, EIP712Upgra
 
     /// @notice Checks if each metadatahash has been used before to either get the tokenId that was already created for it or generate a new one if it hasn't
     /// @dev This function also validates that we're not trying to reveal a tokenId that has already been revealed
-    /// @param amounts The amounts of tokens to mint
     /// @param metadataHashes The hashes of the metadata
     /// @param prevTokenId The previous token id from which the assets are revealed
     /// @return tokenIdArray The array of tokenIds to mint
     function getRevealedTokenIds(
-        uint256[] calldata amounts,
         string[] calldata metadataHashes,
         uint256 prevTokenId
     ) internal returns (uint256[] memory) {
         IAsset.AssetData memory data = prevTokenId.getData();
         require(!data.revealed, "Asset: already revealed");
-
-        uint256[] memory tokenIdArray = new uint256[](amounts.length);
-        for (uint256 i = 0; i < amounts.length; i++) {
+        uint256[] memory tokenIdArray = new uint256[](metadataHashes.length);
+        for (uint256 i = 0; i < metadataHashes.length; i++) {
             uint256 tokenId = assetContract.getTokenIdByMetadataHash(metadataHashes[i]);
             if (tokenId != 0) {
-                tokenId = assetContract.getTokenIdByMetadataHash(metadataHashes[i]);
+                tokenIdArray[i] = tokenId;
+                continue;
             } else {
                 uint16 revealNonce = ++revealIds[data.creator][prevTokenId];
                 tokenId = TokenIdUtils.generateTokenId(

--- a/packages/asset/contracts/interfaces/IAsset.sol
+++ b/packages/asset/contracts/interfaces/IAsset.sol
@@ -15,13 +15,10 @@ interface IAsset {
         bool bridged;
     }
 
+    event TrustedForwarderChanged(address indexed newTrustedForwarderAddress);
+
     // Functions
-    function mint(
-        address to,
-        uint256 id,
-        uint256 amount,
-        string memory metadataHash
-    ) external;
+    function mint(address to, uint256 id, uint256 amount, string memory metadataHash) external;
 
     function mintBatch(
         address to,
@@ -30,17 +27,9 @@ interface IAsset {
         string[] memory metadataHashes
     ) external;
 
-    function burnFrom(
-        address account,
-        uint256 id,
-        uint256 amount
-    ) external;
+    function burnFrom(address account, uint256 id, uint256 amount) external;
 
-    function burnBatchFrom(
-        address account,
-        uint256[] memory ids,
-        uint256[] memory amounts
-    ) external;
+    function burnBatchFrom(address account, uint256[] memory ids, uint256[] memory amounts) external;
 
     function getTokenIdByMetadataHash(string memory metadataHash) external view returns (uint256);
 }

--- a/packages/asset/test/Asset.test.ts
+++ b/packages/asset/test/Asset.test.ts
@@ -1,561 +1,394 @@
 import {expect} from 'chai';
-import {expectEventWithArgs} from '../util';
-import {ethers} from 'hardhat';
 import {runAssetSetup} from './fixtures/assetFixture';
+import {ethers} from 'hardhat';
 
-// TODO: test all events
-// TODO: test all reverts
-// TODO: trustedForwarder tests
-// TODO: missing setTrustedForwarder default admin function
-// TODO: tokenId tests (TokenIdUtils.sol)
-describe('AssetContract', function () {
-  it('Should deploy correctly', async function () {
-    const {AssetContract} = await runAssetSetup();
-    expect(AssetContract.address).to.be.properAddress;
-  });
-
-  describe('uri_and_baseUri', function () {
-    it('Should return correct asset uri ', async function () {
-      const {AssetContractAsMinter, AssetContract, owner, uris, baseUri} =
+describe('Base Asset Contract (/packages/asset/contracts/Asset.sol)', function () {
+  describe('Base URI', async function () {
+    it('Should have correct base URI set in the constructor', async function () {
+      const {AssetContract, mintOne, baseURI} = await runAssetSetup();
+      const {tokenId, metadataHash} = await mintOne();
+      const tokenURI = await AssetContract.uri(tokenId);
+      const extractedBaseURI = tokenURI.split(metadataHash)[0];
+      expect(extractedBaseURI).to.be.equal(baseURI);
+    });
+    it('Should allow DEFAULT_ADMIN to change base URI', async function () {
+      const {AssetContract, AssetContractAsAdmin, mintOne} =
         await runAssetSetup();
-      const tnx = await AssetContractAsMinter.mint(
-        owner.address,
-        10,
-        3,
-        uris[0]
-      );
-      const args = await expectEventWithArgs(
-        AssetContractAsMinter,
-        tnx,
-        'TransferSingle'
-      );
-      const tokenId = args.args.id;
-      expect(await AssetContract.uri(tokenId)).to.be.equal(
-        `${baseUri}${uris[0]}`
+      await AssetContractAsAdmin.setBaseURI('newBaseURI');
+      const {tokenId, metadataHash} = await mintOne();
+      const tokenURI = await AssetContract.uri(tokenId);
+      const extractedBaseURI = tokenURI.split(metadataHash)[0];
+      expect(extractedBaseURI).to.be.equal('newBaseURI');
+    });
+    it('Should not allow non-DEFAULT_ADMIN to change base URI', async function () {
+      const {AssetContractAsMinter, minter, defaultAdminRole} =
+        await runAssetSetup();
+      await expect(
+        AssetContractAsMinter.setBaseURI('newBaseURI')
+      ).to.be.revertedWith(
+        `AccessControl: account ${minter.address.toLowerCase()} is missing role ${defaultAdminRole}`
       );
     });
-
-    it("DEFAULT_ADMIN can change an asset's uri ", async function () {
+  });
+  describe('Token URI', async function () {
+    it('Should return correct token URI', async function () {
+      const {AssetContract, mintOne, baseURI, metadataHashes} =
+        await runAssetSetup();
+      const {tokenId} = await mintOne();
+      const tokenURI = await AssetContract.uri(tokenId);
+      expect(tokenURI).to.be.equal(baseURI + metadataHashes[0]);
+    });
+    it('Should allow DEFAULT_ADMIN to change token URI', async function () {
       const {
-        AssetContractAsMinter,
         AssetContract,
         AssetContractAsAdmin,
-        owner,
-        uris,
-        baseUri,
+        mintOne,
+        metadataHashes,
+        baseURI,
       } = await runAssetSetup();
-      const tnx = await AssetContractAsMinter.mint(
-        owner.address,
-        10,
-        3,
-        uris[0]
-      );
-      const args = await expectEventWithArgs(
-        AssetContractAsMinter,
-        tnx,
-        'TransferSingle'
-      );
-      const tokenId = args.args.id;
-      expect(await AssetContract.uri(tokenId)).to.be.equal(
-        `${baseUri}${uris[0]}`
-      );
-
-      await AssetContractAsAdmin.setTokenUri(tokenId, uris[1]);
-      expect(await AssetContract.uri(tokenId)).to.be.equal(
-        `${baseUri}${uris[1]}`
-      );
+      const {tokenId} = await mintOne();
+      const tokenURI = await AssetContract.uri(tokenId);
+      expect(tokenURI).to.be.equal(baseURI + metadataHashes[0]);
+      await AssetContractAsAdmin.setTokenURI(tokenId, metadataHashes[1]);
+      const newTokenURI = await AssetContract.uri(tokenId);
+      expect(newTokenURI).to.be.equal(baseURI + metadataHashes[1]);
     });
-
-    it("DEFAULT_ADMIN can change the contract's base uri ", async function () {
-      const {AssetContractAsAdmin} = await runAssetSetup();
-      await expect(AssetContractAsAdmin.setBaseURI('newUri')).to.not.be
-        .reverted;
+    it('Should not allow DEFAULT_ADMIN to change token URI to already used hash', async function () {
+      const {
+        AssetContract,
+        AssetContractAsAdmin,
+        mintOne,
+        metadataHashes,
+        baseURI,
+      } = await runAssetSetup();
+      const {tokenId} = await mintOne();
+      await mintOne(undefined, undefined, undefined, metadataHashes[1]);
+      const tokenURI = await AssetContract.uri(tokenId);
+      expect(tokenURI).to.be.equal(baseURI + metadataHashes[0]);
+      await expect(
+        AssetContractAsAdmin.setTokenURI(tokenId, metadataHashes[1])
+      ).to.be.revertedWith('Asset: not allowed to reuse metadata hash');
     });
-
-    it('if not DEFAULT_ADMIN cannot change an asset uri ', async function () {
+    it('Should not allow non-DEFAULT_ADMIN to change token URI', async function () {
       const {
         AssetContractAsMinter,
-        AssetContract,
-        AssetContractAsOwner,
-        owner,
-        uris,
-        baseUri,
+        minter,
+        mintOne,
+        metadataHashes,
         defaultAdminRole,
       } = await runAssetSetup();
-      const tnx = await AssetContractAsMinter.mint(
-        owner.address,
-        10,
-        3,
-        uris[0]
-      );
-      const args = await expectEventWithArgs(
-        AssetContractAsMinter,
-        tnx,
-        'TransferSingle'
-      );
-      const tokenId = args.args.id;
-      expect(await AssetContract.uri(tokenId)).to.be.equal(
-        `${baseUri}${uris[0]}`
-      );
+      const {tokenId} = await mintOne();
       await expect(
-        AssetContractAsOwner.setTokenUri(tokenId, uris[2])
+        AssetContractAsMinter.setTokenURI(tokenId, metadataHashes[1])
       ).to.be.revertedWith(
-        `AccessControl: account ${owner.address.toLocaleLowerCase()} is missing role ${defaultAdminRole}`
+        `AccessControl: account ${minter.address.toLowerCase()} is missing role ${defaultAdminRole}`
       );
-      expect(await AssetContract.uri(tokenId)).to.be.equal(
-        `${baseUri}${uris[0]}`
-      );
-    });
-
-    it("if not DEFAULT_ADMIN cannot change the contract's base uri ", async function () {
-      const {AssetContractAsOwner, owner, defaultAdminRole} =
-        await runAssetSetup();
-      await expect(
-        AssetContractAsOwner.setBaseURI('newUri')
-      ).to.be.revertedWith(
-        `AccessControl: account ${owner.address.toLocaleLowerCase()} is missing role ${defaultAdminRole}`
-      );
-    });
-
-    it('no two asset can have same uri ', async function () {
-      const {AssetContractAsMinter, owner, uris} = await runAssetSetup();
-      await AssetContractAsMinter.mint(owner.address, 10, 3, uris[0]);
-
-      await expect(
-        AssetContractAsMinter.mint(owner.address, 11, 3, uris[0])
-      ).to.be.revertedWith('metadata hash mismatch for tokenId');
     });
   });
-
   describe('Minting', function () {
-    it('Should mint an asset', async function () {
-      const {AssetContractAsMinter, AssetContract, owner, uris} =
-        await runAssetSetup();
-      const tnx = await AssetContractAsMinter.mint(
-        owner.address,
-        10,
-        3,
-        uris[0]
-      );
-      const args = await expectEventWithArgs(
+    it('Should allow account with MINTER_ROLE to mint', async function () {
+      const {
         AssetContractAsMinter,
-        tnx,
-        'TransferSingle'
-      );
-      const tokenId = args.args.id;
-      expect(await AssetContract.balanceOf(owner.address, tokenId)).to.be.equal(
-        3
-      );
-    });
-
-    it('only minter can mint an asset', async function () {
-      const {AssetContract, owner, minterRole, uris} = await runAssetSetup();
+        generateRandomTokenId,
+        minter,
+        metadataHashes,
+      } = await runAssetSetup();
+      const tokenId = generateRandomTokenId();
+      const amount = 1;
       await expect(
-        AssetContract.connect(owner).mint(owner.address, 10, 3, uris[0])
-      ).to.be.revertedWith(
-        `AccessControl: account ${owner.address.toLocaleLowerCase()} is missing role ${minterRole}`
-      );
+        AssetContractAsMinter.mint(
+          minter.address,
+          tokenId,
+          amount,
+          metadataHashes[0]
+        )
+      ).to.not.be.reverted;
     });
-
-    it('Should mint Batch assets', async function () {
-      const {AssetContractAsMinter, AssetContract, owner} =
-        await runAssetSetup();
-      const tnx = await AssetContractAsMinter.mintBatch(
-        owner.address,
-        [1, 2, 3, 4],
-        [5, 5, 100, 1],
-        ['xyz', 'abc', 'anotherUri', 'andAgain']
-      );
-      const args = await expectEventWithArgs(
-        AssetContractAsMinter,
-        tnx,
-        'TransferBatch'
-      );
-      const tokenIds = args.args.ids;
-      expect(tokenIds[0]).to.be.equal(1);
-      expect(tokenIds[1]).to.be.equal(2);
-      expect(tokenIds[2]).to.be.equal(3);
-      expect(tokenIds[3]).to.be.equal(4);
-      expect(await AssetContract.balanceOf(owner.address, 1)).to.be.equal(5);
-      expect(await AssetContract.balanceOf(owner.address, 2)).to.be.equal(5);
-      expect(await AssetContract.balanceOf(owner.address, 3)).to.be.equal(100);
-      expect(await AssetContract.balanceOf(owner.address, 4)).to.be.equal(1);
-    });
-
-    it('only minter can mint batch an asset', async function () {
-      const {AssetContract, owner, minterRole} = await runAssetSetup();
+    it('Should not allow account without MINTER_ROLE to mint', async function () {
+      const {
+        AssetContractAsAdmin,
+        generateRandomTokenId,
+        assetAdmin,
+        metadataHashes,
+        minterRole,
+      } = await runAssetSetup();
+      const tokenId = generateRandomTokenId();
+      const amount = 1;
       await expect(
-        AssetContract.connect(owner).mintBatch(
-          owner.address,
-          [1, 2, 3, 4],
-          [5, 5, 100, 1],
-          ['xyz', 'abc', 'anotherUri', 'andAgain']
+        AssetContractAsAdmin.mint(
+          assetAdmin.address,
+          tokenId,
+          amount,
+          metadataHashes[0]
         )
       ).to.be.revertedWith(
-        `AccessControl: account ${owner.address.toLocaleLowerCase()} is missing role ${minterRole}`
+        `AccessControl: account ${assetAdmin.address.toLowerCase()} is missing role ${minterRole}`
+      );
+    });
+    it('Should mark the metadata hash as used after minting', async function () {
+      const {AssetContract, mintOne} = await runAssetSetup();
+      const {tokenId, metadataHash} = await mintOne();
+      const linkedTokenId = await AssetContract.hashUsed(metadataHash);
+      expect(linkedTokenId).to.be.equal(ethers.utils.hexlify(tokenId));
+    });
+    describe('Single Mint', function () {
+      it('Should mint tokens with correct amounts', async function () {
+        const {AssetContract, mintOne, minter} = await runAssetSetup();
+        const amount = 3;
+        const {tokenId} = await mintOne(undefined, undefined, amount);
+        const balance = await AssetContract.balanceOf(minter.address, tokenId);
+        expect(balance).to.be.equal(3);
+      });
+      it('Should mint tokens with correct URI', async function () {
+        const {AssetContract, mintOne, metadataHashes, baseURI} =
+          await runAssetSetup();
+        const {tokenId} = await mintOne();
+        const tokenURI = await AssetContract.uri(tokenId);
+        expect(tokenURI).to.be.equal(baseURI + metadataHashes[0]);
+      });
+      it('Should mint tokens with correct owner', async function () {
+        const {AssetContract, mintOne, owner} = await runAssetSetup();
+        const amount = 1;
+        const {tokenId} = await mintOne(owner.address, undefined, amount);
+        const balance = await AssetContract.balanceOf(owner.address, tokenId);
+        expect(balance).to.be.equal(amount);
+      });
+      it('should not allow minting with duplicate metadata hash', async function () {
+        const {mintOne, metadataHashes} = await runAssetSetup();
+        await mintOne(undefined, undefined, undefined, metadataHashes[0]);
+        await expect(
+          mintOne(undefined, undefined, undefined, metadataHashes[0])
+        ).to.be.revertedWith('Asset: not allowed to reuse metadata hash');
+      });
+    });
+    describe('Batch Mint', function () {
+      it('Should mint tokens with correct amounts', async function () {
+        const {AssetContract, mintBatch, minter} = await runAssetSetup();
+        const amounts = [2, 4];
+        const {tokenIds} = await mintBatch(undefined, undefined, amounts);
+        const balance = await AssetContract.balanceOfBatch(
+          new Array(tokenIds.length).fill(minter.address),
+          tokenIds
+        );
+        expect(balance).to.be.deep.equal(amounts);
+      });
+      it('Should mint tokens with correct URIs', async function () {
+        const {AssetContract, mintBatch, metadataHashes, baseURI} =
+          await runAssetSetup();
+        const hashes = [metadataHashes[2], metadataHashes[3]];
+        const {tokenIds} = await mintBatch(
+          undefined,
+          undefined,
+          undefined,
+          hashes
+        );
+        const tokenURI1 = await AssetContract.uri(tokenIds[0]);
+        const tokenURI2 = await AssetContract.uri(tokenIds[1]);
+        expect(tokenURI1).to.be.equal(baseURI + hashes[0]);
+        expect(tokenURI2).to.be.equal(baseURI + hashes[1]);
+      });
+      it('Should mint tokens with correct owner', async function () {
+        const {AssetContract, mintBatch, owner} = await runAssetSetup();
+        const amounts = [2, 4];
+        const {tokenIds} = await mintBatch(owner.address, undefined, amounts);
+        const balance = await AssetContract.balanceOfBatch(
+          new Array(tokenIds.length).fill(owner.address),
+          tokenIds
+        );
+        expect(balance).to.be.deep.equal(amounts);
+      });
+      it('should not allow minting with duplicate metadata hash in a batch', async function () {
+        const {mintBatch, metadataHashes} = await runAssetSetup();
+        await expect(
+          mintBatch(undefined, undefined, undefined, [
+            metadataHashes[0],
+            metadataHashes[0],
+          ])
+        ).to.be.revertedWith('Asset: not allowed to reuse metadata hash');
+      });
+      it('should not allow minting with already existing metadata hash', async function () {
+        const {mintOne, mintBatch, metadataHashes} = await runAssetSetup();
+        await mintOne(undefined, undefined, undefined, metadataHashes[0]);
+        await expect(
+          mintBatch(undefined, undefined, undefined, [
+            metadataHashes[0],
+            metadataHashes[1],
+          ])
+        ).to.be.revertedWith('Asset: not allowed to reuse metadata hash');
+      });
+      it("should not allow minting if the length of the ids and amounts don't match", async function () {
+        const {AssetContractAsMinter, generateRandomTokenId, minter} =
+          await runAssetSetup();
+        const tokenIds = [
+          generateRandomTokenId(),
+          generateRandomTokenId(),
+          generateRandomTokenId(),
+        ];
+        const amounts = [1, 2];
+        const hashes = ['0x1', '0x2', '0x3'];
+        await expect(
+          AssetContractAsMinter.mintBatch(
+            minter.address,
+            tokenIds,
+            amounts,
+            hashes
+          )
+        ).to.be.revertedWith('Asset: ids and amounts length mismatch');
+      });
+      it("should not allow minting if the length of the ids and hashes don't match", async function () {
+        const {AssetContractAsMinter, generateRandomTokenId, minter} =
+          await runAssetSetup();
+        const tokenIds = [generateRandomTokenId(), generateRandomTokenId()];
+        const amounts = [1, 2];
+        const hashes = ['0x1'];
+        await expect(
+          AssetContractAsMinter.mintBatch(
+            minter.address,
+            tokenIds,
+            amounts,
+            hashes
+          )
+        ).to.be.revertedWith('Asset: ids and metadataHash length mismatch');
+      });
+    });
+    describe('Mint Events', function () {
+      it('Should emit TransferSingle event on single mint', async function () {
+        const {AssetContract, mintOne} = await runAssetSetup();
+
+        const {tx} = await mintOne();
+        await expect(tx).to.emit(AssetContract, 'TransferSingle');
+      });
+      it('Should emit TransferSingle event with correct args on single mint', async function () {
+        const {AssetContract, mintOne, generateRandomTokenId, minter} =
+          await runAssetSetup();
+        const tokenId = generateRandomTokenId();
+        const amount = 3;
+        const recipient = minter.address;
+        const {tx} = await mintOne(recipient, tokenId, amount);
+        await expect(tx)
+          .to.emit(AssetContract, 'TransferSingle')
+          .withArgs(
+            minter.address,
+            ethers.constants.AddressZero,
+            recipient,
+            tokenId,
+            amount
+          );
+      });
+      it('Should emit TransferBatch event on batch mint', async function () {
+        const {AssetContract, mintBatch} = await runAssetSetup();
+        const {tx} = await mintBatch();
+        await expect(tx).to.emit(AssetContract, 'TransferBatch');
+      });
+      it('Should emit TransferBatch event with correct args on batch mint', async function () {
+        const {AssetContract, mintBatch, generateRandomTokenId, minter} =
+          await runAssetSetup();
+        const tokenIds = [generateRandomTokenId(), generateRandomTokenId()];
+        const amounts = [7, 2];
+        const recipient = minter.address;
+        const {tx} = await mintBatch(recipient, tokenIds, amounts);
+        await expect(tx)
+          .to.emit(AssetContract, 'TransferBatch')
+          .withArgs(
+            minter.address,
+            ethers.constants.AddressZero,
+            recipient,
+            [
+              ethers.utils.hexlify(tokenIds[0]),
+              ethers.utils.hexlify(tokenIds[1]),
+            ],
+            amounts
+          );
+      });
+    });
+  });
+  describe('Burning', function () {
+    it('Should allow account with BURNER_ROLE to burn tokens from any account', async function () {
+      const {AssetContract, mintOne, burnOne, owner} = await runAssetSetup();
+      const {tokenId} = await mintOne(owner.address, undefined, 10);
+      expect(await AssetContract.balanceOf(owner.address, tokenId)).to.be.equal(
+        10
+      );
+      await burnOne(owner.address, tokenId, 5);
+      const balanceAfterBurn = await AssetContract.balanceOf(
+        owner.address,
+        tokenId
+      );
+      expect(balanceAfterBurn).to.be.equal(5);
+    });
+    it('Should not allow account without BURNER_ROLE to burn tokens from any account', async function () {
+      const {
+        AssetContract,
+        AssetContractAsMinter,
+        mintOne,
+        owner,
+        burnerRole,
+        minter,
+      } = await runAssetSetup();
+      const {tokenId} = await mintOne(owner.address, undefined, 10);
+      expect(await AssetContract.balanceOf(owner.address, tokenId)).to.be.equal(
+        10
+      );
+      await expect(
+        AssetContractAsMinter.burnFrom(owner.address, tokenId, 5)
+      ).to.be.revertedWith(
+        `AccessControl: account ${minter.address.toLowerCase()} is missing role ${burnerRole}`
+      );
+    });
+    it('Should allow account with BURNER_ROLE to burn batch of tokens from any account', async function () {
+      const {AssetContract, mintBatch, burnBatch, owner} =
+        await runAssetSetup();
+      const amounts = [2, 4];
+      const {tokenIds} = await mintBatch(owner.address, undefined, amounts);
+      const balance = await AssetContract.balanceOfBatch(
+        new Array(tokenIds.length).fill(owner.address),
+        tokenIds
+      );
+      expect(balance).to.be.deep.equal(amounts);
+      await burnBatch(owner.address, tokenIds, [1, 1]);
+      const balanceAfterBurn = await AssetContract.balanceOfBatch(
+        new Array(tokenIds.length).fill(owner.address),
+        tokenIds
+      );
+      expect(balanceAfterBurn).to.be.deep.equal([1, 3]);
+    });
+    it('Should not allow account without BURNER_ROLE to burn batch of tokens from any account', async function () {
+      const {
+        AssetContract,
+        AssetContractAsMinter,
+        mintBatch,
+        owner,
+        burnerRole,
+        minter,
+      } = await runAssetSetup();
+      const amounts = [2, 4];
+      const {tokenIds} = await mintBatch(owner.address, undefined, amounts);
+      const balance = await AssetContract.balanceOfBatch(
+        new Array(tokenIds.length).fill(owner.address),
+        tokenIds
+      );
+      expect(balance).to.be.deep.equal(amounts);
+      await expect(
+        AssetContractAsMinter.burnBatchFrom(owner.address, tokenIds, [1, 1])
+      ).to.be.revertedWith(
+        `AccessControl: account ${minter.address.toLowerCase()} is missing role ${burnerRole}`
       );
     });
   });
-
-  describe('Burn Assets', function () {
-    it('BURNER_ROLE can use burnFrom to burn the asset of any owner', async function () {
-      const {
-        AssetContractAsMinter,
-        AssetContractAsBurner,
-        AssetContract,
-        owner,
-        uris,
-      } = await runAssetSetup();
-      const tnx = await AssetContractAsMinter.mint(
-        owner.address,
-        10,
-        3,
-        uris[0]
-      );
-      const args = await expectEventWithArgs(
-        AssetContractAsMinter,
-        tnx,
-        'TransferSingle'
-      );
-      const tokenId = args.args.id;
-      expect(tokenId).to.be.equal(10);
-      expect(await AssetContract.balanceOf(owner.address, tokenId)).to.be.equal(
-        3
-      );
-      await AssetContractAsBurner.burnFrom(owner.address, tokenId, 2);
-      expect(await AssetContract.balanceOf(owner.address, tokenId)).to.be.equal(
-        1
+  describe('Trusted Forwarder', function () {
+    it('should allow to read the trusted forwarder', async function () {
+      const {AssetContract, trustedForwarder} = await runAssetSetup();
+      expect(await AssetContract.getTrustedForwarder()).to.be.equal(
+        trustedForwarder.address
       );
     });
-
-    it('If not BURNER_ROLE cannot burn asset of any owner', async function () {
-      const {
-        AssetContractAsMinter,
-        owner,
-        AssetContract,
-        secondOwner,
-        burnerRole,
-        uris,
-      } = await runAssetSetup();
-      const tnx = await AssetContractAsMinter.mint(
-        owner.address,
-        10,
-        3,
-        uris[0]
+    it('should allow DEFAULT_ADMIN to set the trusted forwarder ', async function () {
+      const {AssetContract} = await runAssetSetup();
+      const randomAddress = ethers.Wallet.createRandom().address;
+      await AssetContract.setTrustedForwarder(randomAddress);
+      expect(await AssetContract.getTrustedForwarder()).to.be.equal(
+        randomAddress
       );
-      const args = await expectEventWithArgs(
-        AssetContractAsMinter,
-        tnx,
-        'TransferSingle'
-      );
-      const tokenId = args.args.id;
-      expect(tokenId).to.be.equal(10);
-      expect(await AssetContract.balanceOf(owner.address, tokenId)).to.be.equal(
-        3
-      );
-
-      await expect(
-        AssetContract.connect(secondOwner).burnFrom(owner.address, tokenId, 3)
-      ).to.be.revertedWith(
-        `AccessControl: account ${secondOwner.address.toLocaleLowerCase()} is missing role ${burnerRole}`
-      );
-    });
-
-    it('owner can burn their own asset', async function () {
-      const {AssetContractAsMinter, owner, AssetContract, uris} =
-        await runAssetSetup();
-      const tnx = await AssetContractAsMinter.mint(
-        owner.address,
-        10,
-        3,
-        uris[0]
-      );
-      const args = await expectEventWithArgs(
-        AssetContractAsMinter,
-        tnx,
-        'TransferSingle'
-      );
-      const tokenId1 = args.args.id;
-
-      expect(
-        await AssetContract.balanceOf(owner.address, tokenId1)
-      ).to.be.equal(3);
-
-      await AssetContract.connect(owner).burn(owner.address, tokenId1, 3);
-
-      expect(
-        await AssetContract.balanceOf(owner.address, tokenId1)
-      ).to.be.equal(0);
-    });
-
-    it("owner cannot burn someone else's asset", async function () {
-      const {AssetContractAsMinter, owner, AssetContract, uris, secondOwner} =
-        await runAssetSetup();
-      const tnx = await AssetContractAsMinter.mint(
-        owner.address,
-        10,
-        3,
-        uris[0]
-      );
-      await expectEventWithArgs(AssetContractAsMinter, tnx, 'TransferSingle');
-
-      expect(await AssetContract.balanceOf(owner.address, 10)).to.be.equal(3);
-
-      await expect(
-        AssetContract.connect(
-          await ethers.provider.getSigner(secondOwner.address)
-        ).burn(owner.address, 10, 3)
-      ).to.be.revertedWith(`ERC1155: caller is not token owner or approved`);
-
-      expect(await AssetContract.balanceOf(owner.address, 10)).to.be.equal(3);
-    });
-
-    it('owner can batch burn their own assets', async function () {
-      const {AssetContractAsMinter, owner, AssetContract} =
-        await runAssetSetup();
-      const tnx = await AssetContractAsMinter.mintBatch(
-        owner.address,
-        [1, 2, 3, 4],
-        [5, 5, 100, 1],
-        ['xyz', 'abc', 'anotherUri', 'andAgain']
-      );
-      const args = await expectEventWithArgs(
-        AssetContractAsMinter,
-        tnx,
-        'TransferBatch'
-      );
-      const tokenIds = args.args.ids;
-
-      expect(
-        await AssetContract.balanceOf(owner.address, tokenIds[0])
-      ).to.be.equal(5);
-      expect(
-        await AssetContract.balanceOf(owner.address, tokenIds[1])
-      ).to.be.equal(5);
-      expect(
-        await AssetContract.balanceOf(owner.address, tokenIds[2])
-      ).to.be.equal(100);
-      expect(
-        await AssetContract.balanceOf(owner.address, tokenIds[3])
-      ).to.be.equal(1);
-
-      await AssetContract.connect(owner).burnBatch(
-        owner.address,
-        [1, 2, 3, 4],
-        [4, 4, 20, 1]
-      );
-
-      expect(
-        await AssetContract.balanceOf(owner.address, tokenIds[0])
-      ).to.be.equal(1);
-      expect(
-        await AssetContract.balanceOf(owner.address, tokenIds[1])
-      ).to.be.equal(1);
-      expect(
-        await AssetContract.balanceOf(owner.address, tokenIds[2])
-      ).to.be.equal(80);
-      expect(
-        await AssetContract.balanceOf(owner.address, tokenIds[3])
-      ).to.be.equal(0);
-    });
-
-    it("owner cannot batch burn someone else's assets", async function () {
-      const {AssetContractAsMinter, owner, AssetContract, secondOwner} =
-        await runAssetSetup();
-      await AssetContractAsMinter.mintBatch(
-        owner.address,
-        [1, 2, 3, 4],
-        [5, 5, 100, 1],
-        ['xyz', 'abc', 'anotherUri', 'andAgain']
-      );
-
-      await expect(
-        AssetContract.connect(secondOwner).burn(
-          owner.address,
-          [1, 2, 3, 4],
-          [5, 5, 100, 1]
-        )
-      ).to.be.revertedWith(`ERC1155: caller is not token owner or approved`);
-
-      expect(await AssetContract.balanceOf(owner.address, 1)).to.be.equal(5);
-      expect(await AssetContract.balanceOf(owner.address, 2)).to.be.equal(5);
-      expect(await AssetContract.balanceOf(owner.address, 3)).to.be.equal(100);
-      expect(await AssetContract.balanceOf(owner.address, 4)).to.be.equal(1);
-    });
-
-    it('BURNER_ROLE can batch burn the assets of any owner', async function () {
-      const {
-        AssetContractAsMinter,
-        AssetContractAsBurner,
-        owner,
-        AssetContract,
-      } = await runAssetSetup();
-      const tnx = await AssetContractAsMinter.mintBatch(
-        owner.address,
-        [1, 2, 3, 4],
-        [5, 5, 100, 1],
-        ['xyz', 'abc', 'anotherUri', 'andAgain']
-      );
-      const args = await expectEventWithArgs(
-        AssetContractAsMinter,
-        tnx,
-        'TransferBatch'
-      );
-      const tokenIds = args.args.ids;
-
-      expect(
-        await AssetContract.balanceOf(owner.address, tokenIds[0])
-      ).to.be.equal(5);
-      expect(
-        await AssetContract.balanceOf(owner.address, tokenIds[1])
-      ).to.be.equal(5);
-      expect(
-        await AssetContract.balanceOf(owner.address, tokenIds[2])
-      ).to.be.equal(100);
-      expect(
-        await AssetContract.balanceOf(owner.address, tokenIds[3])
-      ).to.be.equal(1);
-
-      await AssetContractAsBurner.burnBatchFrom(
-        owner.address,
-        [1, 2, 3, 4],
-        [4, 4, 20, 1]
-      );
-
-      expect(
-        await AssetContract.balanceOf(owner.address, tokenIds[0])
-      ).to.be.equal(1);
-      expect(
-        await AssetContract.balanceOf(owner.address, tokenIds[1])
-      ).to.be.equal(1);
-      expect(
-        await AssetContract.balanceOf(owner.address, tokenIds[2])
-      ).to.be.equal(80);
-      expect(
-        await AssetContract.balanceOf(owner.address, tokenIds[3])
-      ).to.be.equal(0);
-    });
-
-    it('If not BURNER_ROLE cannot batch burn assets of any owner', async function () {
-      const {
-        AssetContractAsMinter,
-        owner,
-        AssetContract,
-        secondOwner,
-        burnerRole,
-        uris,
-      } = await runAssetSetup();
-      const tnx = await AssetContractAsMinter.mint(
-        owner.address,
-        10,
-        3,
-        uris[0]
-      );
-      const args = await expectEventWithArgs(
-        AssetContractAsMinter,
-        tnx,
-        'TransferSingle'
-      );
-      const tokenId = args.args.id;
-      expect(tokenId).to.be.equal(10);
-      expect(await AssetContract.balanceOf(owner.address, tokenId)).to.be.equal(
-        3
-      );
-
-      await expect(
-        AssetContract.connect(secondOwner).burnFrom(owner.address, tokenId, 3)
-      ).to.be.revertedWith(
-        `AccessControl: account ${secondOwner.address.toLocaleLowerCase()} is missing role ${burnerRole}`
-      );
-    });
-  });
-
-  describe('Token transfer', function () {
-    it('owner can transfer an asset', async function () {
-      const {AssetContractAsMinter, owner, AssetContract, secondOwner, uris} =
-        await runAssetSetup();
-      const tnx = await AssetContractAsMinter.mint(
-        owner.address,
-        10,
-        5,
-        uris[0]
-      );
-      const args = await expectEventWithArgs(
-        AssetContract,
-        tnx,
-        'TransferSingle'
-      );
-      const tokenId1 = args.args.id;
-
-      expect(
-        await AssetContract.balanceOf(owner.address, tokenId1)
-      ).to.be.equal(5);
-
-      await AssetContract.connect(owner).safeTransferFrom(
-        owner.address,
-        secondOwner.address,
-        tokenId1,
-        5,
-        '0x'
-      );
-
-      expect(
-        await AssetContract.balanceOf(secondOwner.address, tokenId1)
-      ).to.be.equal(5);
-    });
-
-    it('owner can batch transfer assets', async function () {
-      const {AssetContractAsMinter, owner, AssetContract, secondOwner} =
-        await runAssetSetup();
-      const tnx = await AssetContractAsMinter.mintBatch(
-        owner.address,
-        [1, 2, 3, 4],
-        [5, 5, 100, 1],
-        ['xyz', 'abc', 'anotherUri', 'andAgain']
-      );
-      const args = await expectEventWithArgs(
-        AssetContract,
-        tnx,
-        'TransferBatch'
-      );
-      const tokenIds = args.args.ids;
-
-      expect(
-        await AssetContract.balanceOf(owner.address, tokenIds[0])
-      ).to.be.equal(5);
-      expect(
-        await AssetContract.balanceOf(owner.address, tokenIds[1])
-      ).to.be.equal(5);
-      expect(
-        await AssetContract.balanceOf(owner.address, tokenIds[2])
-      ).to.be.equal(100);
-      expect(
-        await AssetContract.balanceOf(owner.address, tokenIds[3])
-      ).to.be.equal(1);
-
-      await AssetContract.connect(owner).safeBatchTransferFrom(
-        owner.address,
-        secondOwner.address,
-        [tokenIds[0], tokenIds[1]],
-        [5, 5],
-        '0x'
-      );
-
-      expect(
-        await AssetContract.balanceOf(secondOwner.address, tokenIds[0])
-      ).to.be.equal(5);
-
-      expect(
-        await AssetContract.balanceOf(secondOwner.address, tokenIds[1])
-      ).to.be.equal(5);
-
-      expect(
-        await AssetContract.balanceOf(owner.address, tokenIds[0])
-      ).to.be.equal(0);
-
-      expect(
-        await AssetContract.balanceOf(owner.address, tokenIds[1])
-      ).to.be.equal(0);
     });
   });
 });

--- a/packages/asset/test/fixtures/assetFixture.ts
+++ b/packages/asset/test/fixtures/assetFixture.ts
@@ -38,13 +38,7 @@ export async function runAssetSetup() {
   const AssetFactory = await ethers.getContractFactory('Asset');
   const AssetContract = await upgrades.deployProxy(
     AssetFactory,
-    [
-      trustedForwarder.address,
-      assetAdmin.address,
-      [1, 2, 3, 4, 5, 6],
-      [2, 4, 6, 8, 10, 12],
-      'ipfs://',
-    ],
+    [trustedForwarder.address, assetAdmin.address, 'ipfs://'],
     {
       initializer: 'initialize',
     }
@@ -52,23 +46,25 @@ export async function runAssetSetup() {
 
   await AssetContract.deployed();
 
+  const generateRandomTokenId = () => {
+    return ethers.utils.randomBytes(32);
+  };
+
   // Asset contract is not user-facing and we block users from minting directly
   // Contracts that interact with Asset must have the necessary ROLE
   // Here we set up the necessary roles for testing
-  const AssetContractAsAdmin = await AssetContract.connect(assetAdmin);
-  const AssetContractAsMinter = await AssetContract.connect(minter);
-  const AssetContractAsBurner = await AssetContract.connect(burner);
-  const AssetContractAsOwner = await AssetContract.connect(owner);
+  const AssetContractAsAdmin = AssetContract.connect(assetAdmin);
+  const AssetContractAsMinter = AssetContract.connect(minter);
+  const AssetContractAsBurner = AssetContract.connect(burner);
+  const AssetContractAsOwner = AssetContract.connect(owner);
   const defaultAdminRole = await AssetContract.DEFAULT_ADMIN_ROLE();
   const minterRole = await AssetContract.MINTER_ROLE();
   const burnerRole = await AssetContract.BURNER_ROLE();
-  const bridgeMinterRole = await AssetContract.BRIDGE_MINTER_ROLE();
   await AssetContractAsAdmin.grantRole(minterRole, minter.address);
   await AssetContractAsAdmin.grantRole(burnerRole, burner.address);
-  await AssetContractAsAdmin.grantRole(bridgeMinterRole, bridgeMinter.address);
   // end set up roles
 
-  const uris = [
+  const metadataHashes = [
     'QmSRVTH8VumE42fqmdzPHuA57LjCaUXQRequVzEDTGMyHY',
     'QmTeRr1J2kaKM6e1m8ixLfZ31hcb7XNktpbkWY5tMpjiFR',
     'QmUxnKe5DyjxKuwq2AMGDLYeQALnQxcffCZCgtj5a41DYw',
@@ -77,7 +73,79 @@ export async function runAssetSetup() {
     'QmdRwSPCuPGfxSYTaot9Eqz8eU9w1DGp8mY97pTCjnSWqk',
     'QmNrwUiZfQLYaZFHNLzxqfiLxikKYRzZcdWviyDaNhrVhm',
   ];
-  const baseUri = 'ipfs://';
+  const baseURI = 'ipfs://';
+
+  const mintOne = async (
+    recipient = minter.address,
+    tokenId = generateRandomTokenId(),
+    amount = 10,
+    metadataHash = metadataHashes[0]
+  ) => {
+    const tx = await AssetContractAsMinter.mint(
+      recipient,
+      tokenId,
+      amount,
+      metadataHash
+    );
+    await tx.wait();
+    return {
+      tx,
+      tokenId,
+      metadataHash,
+    };
+  };
+
+  const burnOne = async (
+    account: string,
+    tokenId: Uint8Array,
+    amount: number
+  ) => {
+    const tx = await AssetContractAsBurner.burnFrom(account, tokenId, amount);
+    await tx.wait();
+    return {
+      tx,
+      tokenId,
+    };
+  };
+
+  const mintBatch = async (
+    recipient = minter.address,
+    tokenIds = [generateRandomTokenId(), generateRandomTokenId()],
+    amounts = [10, 5],
+    metadata = [metadataHashes[0], metadataHashes[1]]
+  ) => {
+    const tx = await AssetContractAsMinter.mintBatch(
+      recipient,
+      tokenIds,
+      amounts,
+      metadata
+    );
+    await tx.wait();
+
+    return {
+      tx,
+      tokenIds,
+      metadataHashes,
+    };
+  };
+
+  const burnBatch = async (
+    account: string,
+    tokenIds: Uint8Array[],
+    amounts: number[]
+  ) => {
+    const tx = await AssetContractAsBurner.burnBatchFrom(
+      account,
+      tokenIds,
+      amounts
+    );
+    await tx.wait();
+
+    return {
+      tx,
+      tokenIds,
+    };
+  };
 
   return {
     AssetContract,
@@ -86,13 +154,21 @@ export async function runAssetSetup() {
     AssetContractAsBurner,
     AssetContractAsAdmin,
     owner,
+    assetAdmin,
+    minter,
+    burner,
+    trustedForwarder,
     secondOwner,
     bridgeMinter,
     minterRole,
     burnerRole,
     defaultAdminRole,
-    bridgeMinterRole,
-    uris,
-    baseUri,
+    metadataHashes,
+    baseURI,
+    generateRandomTokenId,
+    mintOne,
+    burnOne,
+    burnBatch,
+    mintBatch,
   };
 }


### PR DESCRIPTION
## Description

Small optimization done to the AssetReveal contract.

- Remove duplicate code inside the reveal function in `AssetReveal` contract.
- Remove unnecessary function argument.