### PR TITLE
add: grant Catalyst MINTER_ROLE to AssetCreate

### DIFF
--- a/packages/deploy/deploy/400_asset/405_asset_setup.ts
+++ b/packages/deploy/deploy/400_asset/405_asset_setup.ts
@@ -7,7 +7,6 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const {assetAdmin, catalystAdmin} = await getNamedAccounts();
 
   const assetCreate = await deployments.get('AssetCreate');
-  const catalyst = await deployments.get('Catalyst');
 
   const minterRole = await read('Asset', 'MINTER_ROLE');
   if (!(await read('Asset', 'hasRole', minterRole, assetCreate.address))) {
@@ -24,7 +23,9 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   }
 
   const catMinterRole = await read('Catalyst', 'MINTER_ROLE');
-  if (!(await read('Catalyst', 'hasRole', catMinterRole, assetCreate.address))) {
+  if (
+    !(await read('Catalyst', 'hasRole', catMinterRole, assetCreate.address))
+  ) {
     await catchUnknownSigner(
       execute(
         'Catalyst',
@@ -37,7 +38,6 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     log(`Catalyst MINTER_ROLE granted to ${assetCreate.address}`);
   }
 };
-
 
 export default func;
 

--- a/packages/deploy/deploy/400_asset/405_asset_setup.ts
+++ b/packages/deploy/deploy/400_asset/405_asset_setup.ts
@@ -4,9 +4,11 @@ import {DeployFunction} from 'hardhat-deploy/types';
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const {deployments, getNamedAccounts} = hre;
   const {execute, log, read, catchUnknownSigner} = deployments;
-  const {assetAdmin} = await getNamedAccounts();
+  const {assetAdmin, catalystAdmin} = await getNamedAccounts();
 
   const assetCreate = await deployments.get('AssetCreate');
+  const catalyst = await deployments.get('Catalyst');
+
   const minterRole = await read('Asset', 'MINTER_ROLE');
   if (!(await read('Asset', 'hasRole', minterRole, assetCreate.address))) {
     await catchUnknownSigner(
@@ -18,10 +20,26 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
         assetCreate.address
       )
     );
-    log(`MINTER_ROLE granted to ${assetCreate.address}`);
+    log(`Asset MINTER_ROLE granted to ${assetCreate.address}`);
+  }
+
+  const catMinterRole = await read('Catalyst', 'MINTER_ROLE');
+  if (!(await read('Catalyst', 'hasRole', catMinterRole, assetCreate.address))) {
+    await catchUnknownSigner(
+      execute(
+        'Catalyst',
+        {from: catalystAdmin, log: true},
+        'grantRole',
+        catMinterRole,
+        assetCreate.address
+      )
+    );
+    log(`Catalyst MINTER_ROLE granted to ${assetCreate.address}`);
   }
 };
+
+
 export default func;
 
 func.tags = ['Asset', 'Asset_role_setup'];
-func.dependencies = ['Asset_deploy', 'AssetCreate_deploy'];
+func.dependencies = ['Asset_deploy', 'Catalyst_deploy', 'AssetCreate_deploy'];


### PR DESCRIPTION
## Description
Grant Catalyst MINTER_ROLE to AssetCreate so as not to block b/e development.
Note: BURNER_ROLE to be added to Catalyst burn functions ahead of next deploy.