### PR TITLE
Add burner role to catalyst and update deploy scripts and tests

### DIFF
--- a/packages/asset/contracts/Catalyst.sol
+++ b/packages/asset/contracts/Catalyst.sol
@@ -41,6 +41,7 @@ contract Catalyst is
     OperatorFiltererUpgradeable
 {
     bytes32 public constant MINTER_ROLE = keccak256("MINTER");
+    bytes32 public constant BURNER_ROLE = keccak256("BURNER");
 
     uint256 public tokenCount;
 
@@ -136,7 +137,7 @@ contract Catalyst is
         address account,
         uint256 id,
         uint256 amount
-    ) external onlyRole(MINTER_ROLE) {
+    ) external onlyRole(BURNER_ROLE) {
         _burn(account, id, amount);
     }
 
@@ -148,7 +149,7 @@ contract Catalyst is
         address account,
         uint256[] memory ids,
         uint256[] memory amounts
-    ) external onlyRole(MINTER_ROLE) {
+    ) external onlyRole(BURNER_ROLE) {
         _burnBatch(account, ids, amounts);
     }
 

--- a/packages/asset/contracts/Catalyst.sol
+++ b/packages/asset/contracts/Catalyst.sol
@@ -40,8 +40,8 @@ contract Catalyst is
     AccessControlUpgradeable,
     OperatorFiltererUpgradeable
 {
-    bytes32 public constant MINTER_ROLE = keccak256("MINTER");
-    bytes32 public constant BURNER_ROLE = keccak256("BURNER");
+    bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
+    bytes32 public constant BURNER_ROLE = keccak256("BURNER_ROLE");
 
     uint256 public tokenCount;
 

--- a/packages/asset/test/AssetCreate.test.ts
+++ b/packages/asset/test/AssetCreate.test.ts
@@ -213,8 +213,9 @@ describe('AssetCreate', function () {
 
       // TODO:
       // get tokenId from the event
-      const tokenId = (await AssetCreateContract.queryFilter('AssetMinted'))[0]
-        .args.tokenId;
+      const tokenId = (
+        await AssetCreateContract.queryFilter('AssetMinted')
+      )?.[0].args?.tokenId;
 
       expect(await AssetContract.balanceOf(user.address, tokenId)).to.equal(
         BigNumber.from(5)

--- a/packages/asset/test/Catalyst.test.ts
+++ b/packages/asset/test/Catalyst.test.ts
@@ -506,7 +506,8 @@ describe('catalyst Contract', function () {
       }
     });
     it('Total Supply decrease on burning', async function () {
-      const {catalyst, user1, catalystAsMinter} = await runCatalystSetup();
+      const {catalyst, user1, catalystAsBurner, catalystAsMinter} =
+        await runCatalystSetup();
       const catalystAmount = [];
       for (let i = 0; i < catalystArray.length; i++) {
         expect(await catalyst.totalSupply(catalystArray[i])).to.be.equal(0);
@@ -522,14 +523,15 @@ describe('catalyst Contract', function () {
           catalystAmount[i]
         );
 
-        await catalystAsMinter.burnFrom(user1.address, catalystArray[i], 2);
+        await catalystAsBurner.burnFrom(user1.address, catalystArray[i], 2);
         expect(await catalyst.totalSupply(catalystArray[i])).to.be.equal(
           catalystArray[i] * 2 - 2
         );
       }
     });
     it('Total Supply decrease on batch burning', async function () {
-      const {catalyst, user1, catalystAsMinter} = await runCatalystSetup();
+      const {catalyst, user1, catalystAsMinter, catalystAsBurner} =
+        await runCatalystSetup();
       for (let i = 0; i < catalystArray.length; i++) {
         expect(await catalyst.totalSupply(catalystArray[i])).to.equal(0);
       }
@@ -555,7 +557,7 @@ describe('catalyst Contract', function () {
         catalystAmount.push(1);
       }
 
-      await catalystAsMinter.burnBatchFrom(
+      await catalystAsBurner.burnBatchFrom(
         user1.address,
         catalystId,
         catalystAmount
@@ -569,14 +571,16 @@ describe('catalyst Contract', function () {
   });
   describe('Burn catalyst', function () {
     it("minter can burn user's catalyst", async function () {
-      const {catalyst, user1, catalystAsMinter} = await runCatalystSetup();
+      const {catalyst, user1, catalystAsMinter, catalystAsBurner} =
+        await runCatalystSetup();
       await catalystAsMinter.mint(user1.address, 1, 5);
       expect(await catalyst.balanceOf(user1.address, 1)).to.be.equal(5);
-      await catalystAsMinter.burnFrom(user1.address, 1, 2);
+      await catalystAsBurner.burnFrom(user1.address, 1, 2);
       expect(await catalyst.balanceOf(user1.address, 1)).to.be.equal(3);
     });
     it("minter can batch burn user's catalyst", async function () {
-      const {catalyst, user1, catalystAsMinter} = await runCatalystSetup();
+      const {catalyst, user1, catalystAsMinter, catalystAsBurner} =
+        await runCatalystSetup();
       await catalystAsMinter.mint(user1.address, 1, 5);
       await catalystAsMinter.mint(user1.address, 2, 6);
 
@@ -584,7 +588,7 @@ describe('catalyst Contract', function () {
       expect(await catalyst.balanceOf(user1.address, 2)).to.be.equal(6);
       const catalystId = [1, 2];
       const catalystAmount = [2, 2];
-      await catalystAsMinter.burnBatchFrom(
+      await catalystAsBurner.burnBatchFrom(
         user1.address,
         catalystId,
         catalystAmount

--- a/packages/asset/test/fixtures/assetCreateFixtures.ts
+++ b/packages/asset/test/fixtures/assetCreateFixtures.ts
@@ -103,9 +103,9 @@ export async function runCreateTestSetup() {
 
   // get CatalystContract as DEFAULT_ADMIN_ROLE
   const CatalystAsAdmin = CatalystContract.connect(catalystAdmin);
-  const CatalystMinterRole = await CatalystAsAdmin.MINTER_ROLE();
+  const CatalystBurnerRole = await CatalystAsAdmin.BURNER_ROLE();
   await CatalystAsAdmin.grantRole(
-    CatalystMinterRole,
+    CatalystBurnerRole,
     AssetCreateContract.address
   );
 

--- a/packages/asset/test/fixtures/catalystFixture.ts
+++ b/packages/asset/test/fixtures/catalystFixture.ts
@@ -42,10 +42,17 @@ export async function runCatalystSetup() {
   );
   await catalyst.deployed();
 
+  // grant burner role to catalystMinter
+  const catMinterRole = await catalyst.BURNER_ROLE();
+  await catalyst
+    .connect(catalystAdmin)
+    .grantRole(catMinterRole, catalystMinter.address);
+
   const catalystAsAdmin = await catalyst.connect(catalystAdmin);
   const minterRole = await catalyst.MINTER_ROLE();
   const catalystAdminRole = await catalyst.DEFAULT_ADMIN_ROLE();
   const catalystAsMinter = await catalyst.connect(catalystMinter);
+  const catalystAsBurner = await catalyst.connect(catalystMinter);
   return {
     deployer,
     catalyst,
@@ -57,6 +64,7 @@ export async function runCatalystSetup() {
     catalystAdminRole,
     upgradeAdmin,
     catalystMinter,
+    catalystAsBurner,
     catalystAdmin,
     catalystRoyaltyRecipient,
     trustedForwarder,

--- a/packages/deploy/deploy/400_asset/405_asset_setup.ts
+++ b/packages/deploy/deploy/400_asset/405_asset_setup.ts
@@ -22,7 +22,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     log(`Asset MINTER_ROLE granted to ${assetCreate.address}`);
   }
 
-  const catMinterRole = await read('Catalyst', 'MINTER_ROLE');
+  const catMinterRole = await read('Catalyst', 'BURNER_ROLE');
   if (
     !(await read('Catalyst', 'hasRole', catMinterRole, assetCreate.address))
   ) {
@@ -35,7 +35,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
         assetCreate.address
       )
     );
-    log(`Catalyst MINTER_ROLE granted to ${assetCreate.address}`);
+    log(`Catalyst BURNER_ROLE granted to ${assetCreate.address}`);
   }
 };
 


### PR DESCRIPTION
## Description

We want to separate responsibilities in the Catalyst contract between the minter and burner.
It also makes sense semantically to have them separated.

- Updated the contract with new role
- Updated test cases
- Updated deploy script 
