### PR TITLE
Auth super validator

### DIFF
--- a/packages/asset/contracts/AssetCreate.sol
+++ b/packages/asset/contracts/AssetCreate.sol
@@ -8,7 +8,7 @@ import {
     ContextUpgradeable
 } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import {TokenIdUtils} from "./libraries/TokenIdUtils.sol";
-import {AuthValidator} from "./AuthValidator.sol";
+import {AuthSuperValidator} from "./AuthSuperValidator.sol";
 import {ERC2771Handler} from "./ERC2771Handler.sol";
 import {IAsset} from "./interfaces/IAsset.sol";
 import {ICatalyst} from "./interfaces/ICatalyst.sol";
@@ -22,7 +22,7 @@ contract AssetCreate is IAssetCreate, Initializable, ERC2771Handler, EIP712Upgra
 
     IAsset private assetContract;
     ICatalyst private catalystContract;
-    AuthValidator private authValidator;
+    AuthSuperValidator private authValidator;
 
     // mapping of creator address to creator nonce, a nonce is incremented every time a creator mints a new token
     mapping(address => uint16) public creatorNonces;
@@ -44,7 +44,7 @@ contract AssetCreate is IAssetCreate, Initializable, ERC2771Handler, EIP712Upgra
 
     /// @notice Initialize the contract
     /// @param _assetContract The address of the asset contract
-    /// @param _authValidator The address of the AuthValidator contract
+    /// @param _authValidator The address of the AuthSuperValidator contract
     /// @param _forwarder The address of the forwarder contract
     function initialize(
         string memory _name,
@@ -57,7 +57,7 @@ contract AssetCreate is IAssetCreate, Initializable, ERC2771Handler, EIP712Upgra
     ) public initializer {
         assetContract = IAsset(_assetContract);
         catalystContract = ICatalyst(_catalystContract);
-        authValidator = AuthValidator(_authValidator);
+        authValidator = AuthSuperValidator(_authValidator);
         __ERC2771Handler_initialize(_forwarder);
         __EIP712_init(_name, _version);
         __AccessControl_init();

--- a/packages/asset/contracts/AssetReveal.sol
+++ b/packages/asset/contracts/AssetReveal.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.18;
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {EIP712Upgradeable} from "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol";
 import {TokenIdUtils} from "./libraries/TokenIdUtils.sol";
-import {AuthValidator} from "./AuthValidator.sol";
+import {AuthSuperValidator} from "./AuthSuperValidator.sol";
 import {ERC2771Handler} from "./ERC2771Handler.sol";
 import {IAsset} from "./interfaces/IAsset.sol";
 import {IAssetReveal} from "./interfaces/IAssetReveal.sol";
@@ -15,7 +15,7 @@ import {IAssetReveal} from "./interfaces/IAssetReveal.sol";
 contract AssetReveal is IAssetReveal, Initializable, ERC2771Handler, EIP712Upgradeable {
     using TokenIdUtils for uint256;
     IAsset private assetContract;
-    AuthValidator private authValidator;
+    AuthSuperValidator private authValidator;
 
     // mapping of creator to asset id to asset's reveal nonce
     mapping(address => mapping(uint256 => uint16)) internal revealIds;
@@ -44,7 +44,7 @@ contract AssetReveal is IAssetReveal, Initializable, ERC2771Handler, EIP712Upgra
 
     /// @notice Initialize the contract
     /// @param _assetContract The address of the asset contract
-    /// @param _authValidator The address of the AuthValidator contract
+    /// @param _authValidator The address of the AuthSuperValidator contract
     /// @param _forwarder The address of the forwarder contract
     function initialize(
         string memory _name,
@@ -54,7 +54,7 @@ contract AssetReveal is IAssetReveal, Initializable, ERC2771Handler, EIP712Upgra
         address _forwarder
     ) public initializer {
         assetContract = IAsset(_assetContract);
-        authValidator = AuthValidator(_authValidator);
+        authValidator = AuthSuperValidator(_authValidator);
         __ERC2771Handler_initialize(_forwarder);
         __EIP712_init(_name, _version);
     }

--- a/packages/asset/contracts/AuthSuperValidator.sol
+++ b/packages/asset/contracts/AuthSuperValidator.sol
@@ -5,10 +5,10 @@ pragma solidity 0.8.18;
 import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 
-/// @title AuthValidator
+/// @title AuthSuperValidator
 /// @author The Sandbox
 /// @notice This contract is used to validate the signatures of the backend, each contract can have a separate signer assigned
-contract AuthValidator is AccessControl {
+contract AuthSuperValidator is AccessControl {
     mapping(address => address) private _signers;
 
     /// @dev Constructor
@@ -39,7 +39,7 @@ contract AuthValidator is AccessControl {
     /// @return bool
     function verify(bytes memory signature, bytes32 digest) public view returns (bool) {
         address signer = _signers[msg.sender];
-        require(signer != address(0), "AuthValidator: signer not set");
+        require(signer != address(0), "AuthSuperValidator: signer not set");
         address recoveredSigner = ECDSA.recover(digest, signature);
         return recoveredSigner == signer;
     }

--- a/packages/asset/contracts/AuthSuperValidator.sol
+++ b/packages/asset/contracts/AuthSuperValidator.sol
@@ -38,7 +38,7 @@ contract AuthSuperValidator is AccessControl {
     /// @param digest Digest hash
     /// @return bool
     function verify(bytes memory signature, bytes32 digest) public view returns (bool) {
-        address signer = _signers[msg.sender];
+        address signer = _signers[_msgSender()];
         require(signer != address(0), "AuthSuperValidator: signer not set");
         address recoveredSigner = ECDSA.recover(digest, signature);
         return recoveredSigner == signer;

--- a/packages/asset/test/AssetCreate.test.ts
+++ b/packages/asset/test/AssetCreate.test.ts
@@ -4,7 +4,7 @@ import {runCreateTestSetup} from './fixtures/assetCreateFixtures';
 
 // TODO: missing AssetCreate DEFAULT_ADMIN, trustedForwarder tests, setTrustedForwarder
 
-describe('AssetCreate', function () {
+describe('AssetCreate (/packages/asset/contracts/AssetCreate.sol)', function () {
   describe('General', function () {
     it('should initialize with the correct values', async function () {
       const {

--- a/packages/asset/test/AssetReveal.test.ts
+++ b/packages/asset/test/AssetReveal.test.ts
@@ -13,7 +13,7 @@ const revealHashF = formatBytes32String('revealHashF');
 // TODO 2: test reveal nonce incrementation
 // we have AccessControlUpgradeable on AssetCreate, why not here?
 
-describe('AssetReveal', function () {
+describe('AssetReveal (/packages/asset/contracts/AssetReveal.sol)', function () {
   describe('General', function () {
     it('Should deploy correctly', async function () {
       const {AssetRevealContract} = await runRevealTestSetup();

--- a/packages/asset/test/AuthSuperValidator.test.ts
+++ b/packages/asset/test/AuthSuperValidator.test.ts
@@ -105,7 +105,7 @@ describe('AuthValidator, (/packages/asset/contracts/AuthValidator.sol)', functio
       );
       await expect(
         AuthValidatorContractAsAdmin.verify(signature, digest)
-      ).to.be.revertedWith('AuthValidator: signer not set');
+      ).to.be.revertedWith('AuthSuperValidator: signer not set');
     });
   });
 });

--- a/packages/asset/test/AuthValidator.test.ts
+++ b/packages/asset/test/AuthValidator.test.ts
@@ -1,0 +1,111 @@
+import {ethers} from 'ethers';
+import {expect} from 'chai';
+import runSetup from './fixtures/authValidatorFixture';
+
+describe('AuthValidator, (/packages/asset/contracts/AuthValidator.sol)', function () {
+  describe('General', function () {
+    it('should assign DEFAULT_ADMIN_ROLE to the admin address from the constructor', async function () {
+      const {authValidatorAdmin, AuthValidatorContract} = await runSetup();
+      const DEFAULT_ADMIN_ROLE =
+        await AuthValidatorContract.DEFAULT_ADMIN_ROLE();
+      const hasRole = await AuthValidatorContract.hasRole(
+        DEFAULT_ADMIN_ROLE,
+        authValidatorAdmin.address
+      );
+      expect(hasRole).to.equal(true);
+    });
+    it('should allow admin to set signer for a given contract address', async function () {
+      const {MockContract, AuthValidatorContractAsAdmin, backendSigner} =
+        await runSetup();
+      await expect(
+        AuthValidatorContractAsAdmin.setSigner(
+          MockContract.address,
+          backendSigner.address
+        )
+      ).to.not.be.reverted;
+      const assignedSigner = await AuthValidatorContractAsAdmin.getSigner(
+        MockContract.address
+      );
+      expect(assignedSigner).to.equal(backendSigner.address);
+    });
+    it('should allow admin to remove signer for a given contract address', async function () {
+      const {MockContract, AuthValidatorContractAsAdmin, backendSigner} =
+        await runSetup();
+      await AuthValidatorContractAsAdmin.setSigner(
+        MockContract.address,
+        backendSigner.address
+      );
+      await AuthValidatorContractAsAdmin.setSigner(
+        MockContract.address,
+        ethers.constants.AddressZero
+      );
+      const assignedSigner = await AuthValidatorContractAsAdmin.getSigner(
+        MockContract.address
+      );
+      expect(assignedSigner).to.equal(ethers.constants.AddressZero);
+    });
+  });
+  describe('Signature verification', function () {
+    it('should correctly verify signature when a signer is set', async function () {
+      const {
+        AuthValidatorContractAsAdmin,
+        backendSigner,
+        authValidatorAdmin,
+        createMockSignature,
+      } = await runSetup();
+      await AuthValidatorContractAsAdmin.setSigner(
+        authValidatorAdmin.address,
+        backendSigner.address
+      );
+      const {signature, digest} = await createMockSignature(
+        authValidatorAdmin.address,
+        backendSigner
+      );
+      const isValid = await AuthValidatorContractAsAdmin.verify(
+        signature,
+        digest
+      );
+      expect(isValid).to.equal(true);
+    });
+    it('should revert when signature is not valid', async function () {
+      const {
+        AuthValidatorContractAsAdmin,
+        backendSigner,
+        authValidatorAdmin,
+        createMockSignature,
+        createMockDigest,
+      } = await runSetup();
+      await AuthValidatorContractAsAdmin.setSigner(
+        authValidatorAdmin.address,
+        backendSigner.address
+      );
+
+      // digest is using different address on purpose
+      const digest = createMockDigest(backendSigner.address);
+      const {signature} = await createMockSignature(
+        authValidatorAdmin.address,
+        backendSigner
+      );
+      const isValid = await AuthValidatorContractAsAdmin.verify(
+        signature,
+        digest
+      );
+      expect(isValid).to.equal(false);
+    });
+    it('should revert when there is no signer assigned for a given contract address', async function () {
+      const {
+        AuthValidatorContractAsAdmin,
+        createMockSignature,
+        authValidatorAdmin,
+        backendSigner,
+      } = await runSetup();
+      const {signature, digest} = await createMockSignature(
+        authValidatorAdmin.address,
+        backendSigner
+      );
+      await expect(
+        AuthValidatorContractAsAdmin.verify(signature, digest)
+      ).to.be.revertedWith('AuthValidator: signer not set');
+    });
+  });
+});

--- a/packages/asset/test/Catalyst.test.ts
+++ b/packages/asset/test/Catalyst.test.ts
@@ -9,7 +9,7 @@ import {
 const catalystArray = [1, 2, 3, 4, 5, 6];
 const zeroAddress = '0x0000000000000000000000000000000000000000';
 
-describe('catalyst Contract', function () {
+describe('Catalyst (/packages/asset/contracts/Catalyst.sol)', function () {
   describe('Contract setup', function () {
     it('Should deploy correctly', async function () {
       const {

--- a/packages/asset/test/fixtures/assetCreateFixtures.ts
+++ b/packages/asset/test/fixtures/assetCreateFixtures.ts
@@ -67,9 +67,10 @@ export async function runCreateTestSetup() {
 
   const AuthValidatorFactory = await ethers.getContractFactory('AuthValidator');
   const AuthValidatorContract = await AuthValidatorFactory.deploy(
-    authValidatorAdmin.address,
-    backendAuthWallet.address
+    authValidatorAdmin.address
   );
+
+  await AuthValidatorContract.deployed();
 
   // END DEPLOY DEPENDENCIES
 
@@ -94,6 +95,12 @@ export async function runCreateTestSetup() {
   await AssetCreateContract.deployed();
 
   const AssetCreateContractAsUser = AssetCreateContract.connect(user);
+
+  // SETUP VALIDATOR
+  await AuthValidatorContract.connect(authValidatorAdmin).setSigner(
+    AssetCreateContract.address,
+    backendAuthWallet.address
+  );
 
   // SETUP ROLES
   // get AssetContract as DEFAULT_ADMIN_ROLE

--- a/packages/asset/test/fixtures/assetCreateFixtures.ts
+++ b/packages/asset/test/fixtures/assetCreateFixtures.ts
@@ -65,7 +65,9 @@ export async function runCreateTestSetup() {
 
   await CatalystContract.deployed();
 
-  const AuthValidatorFactory = await ethers.getContractFactory('AuthValidator');
+  const AuthValidatorFactory = await ethers.getContractFactory(
+    'AuthSuperValidator'
+  );
   const AuthValidatorContract = await AuthValidatorFactory.deploy(
     authValidatorAdmin.address
   );

--- a/packages/asset/test/fixtures/assetRevealFixtures.ts
+++ b/packages/asset/test/fixtures/assetRevealFixtures.ts
@@ -68,9 +68,10 @@ export async function runRevealTestSetup() {
 
   const AuthValidatorFactory = await ethers.getContractFactory('AuthValidator');
   const AuthValidatorContract = await AuthValidatorFactory.deploy(
-    authValidatorAdmin.address,
-    backendAuthWallet.address
+    authValidatorAdmin.address
   );
+
+  await AuthValidatorContract.deployed();
 
   // END DEPLOY DEPENDENCIES
 
@@ -91,6 +92,12 @@ export async function runRevealTestSetup() {
   );
 
   await AssetRevealContract.deployed();
+
+  // SETUP VALIDATOR
+  await AuthValidatorContract.connect(authValidatorAdmin).setSigner(
+    AssetRevealContract.address,
+    backendAuthWallet.address
+  );
 
   // SET UP ROLES
   const AssetRevealContractAsUser = AssetRevealContract.connect(user);

--- a/packages/asset/test/fixtures/assetRevealFixtures.ts
+++ b/packages/asset/test/fixtures/assetRevealFixtures.ts
@@ -66,7 +66,9 @@ export async function runRevealTestSetup() {
 
   await CatalystContract.deployed();
 
-  const AuthValidatorFactory = await ethers.getContractFactory('AuthValidator');
+  const AuthValidatorFactory = await ethers.getContractFactory(
+    'AuthSuperValidator'
+  );
   const AuthValidatorContract = await AuthValidatorFactory.deploy(
     authValidatorAdmin.address
   );

--- a/packages/asset/test/fixtures/authValidatorFixture.ts
+++ b/packages/asset/test/fixtures/authValidatorFixture.ts
@@ -26,6 +26,7 @@ const runSetup = async () => {
     AuthValidatorContractAsAdmin,
     MockContract,
     backendSigner,
+    deployer,
     createMockDigest,
     createMockSignature,
   };

--- a/packages/asset/test/fixtures/authValidatorFixture.ts
+++ b/packages/asset/test/fixtures/authValidatorFixture.ts
@@ -4,7 +4,9 @@ const runSetup = async () => {
   const [deployer, authValidatorAdmin, backendSigner] =
     await ethers.getSigners();
 
-  const AuthValidatorFactory = await ethers.getContractFactory('AuthValidator');
+  const AuthValidatorFactory = await ethers.getContractFactory(
+    'AuthSuperValidator'
+  );
   const AuthValidatorContract = await AuthValidatorFactory.connect(
     deployer
   ).deploy(authValidatorAdmin.address);

--- a/packages/asset/test/fixtures/authValidatorFixture.ts
+++ b/packages/asset/test/fixtures/authValidatorFixture.ts
@@ -1,0 +1,32 @@
+import {ethers} from 'hardhat';
+import {createMockDigest, createMockSignature} from '../utils/createSignature';
+const runSetup = async () => {
+  const [deployer, authValidatorAdmin, backendSigner] =
+    await ethers.getSigners();
+
+  const AuthValidatorFactory = await ethers.getContractFactory('AuthValidator');
+  const AuthValidatorContract = await AuthValidatorFactory.connect(
+    deployer
+  ).deploy(authValidatorAdmin.address);
+  await AuthValidatorContract.deployed();
+
+  const AuthValidatorContractAsAdmin = await AuthValidatorContract.connect(
+    authValidatorAdmin
+  );
+
+  const MockContractFactory = await ethers.getContractFactory('MockAsset');
+  const MockContract = await MockContractFactory.connect(deployer).deploy();
+  await MockContract.deployed();
+
+  return {
+    authValidatorAdmin,
+    AuthValidatorContract,
+    AuthValidatorContractAsAdmin,
+    MockContract,
+    backendSigner,
+    createMockDigest,
+    createMockSignature,
+  };
+};
+
+export default runSetup;

--- a/packages/asset/test/utils/createSignature.ts
+++ b/packages/asset/test/utils/createSignature.ts
@@ -1,3 +1,4 @@
+import {ethers} from 'ethers';
 import hre from 'hardhat';
 import {Contract} from 'ethers';
 import {SignerWithAddress} from '@nomiclabs/hardhat-ethers/signers';
@@ -95,4 +96,65 @@ const createMultipleAssetsMintSignature = async (
   return signature;
 };
 
-export {createAssetMintSignature, createMultipleAssetsMintSignature};
+const createMockSignature = async (
+  creator: string,
+  signer: SignerWithAddress
+) => {
+  const data = {
+    types: {
+      Basic: [{name: 'creator', type: 'address'}],
+    },
+    domain: {
+      name: 'The Sandbox',
+      version: '1.0',
+      chainId: hre.network.config.chainId,
+    },
+    message: {
+      creator,
+    },
+  };
+
+  const signature = await signer._signTypedData(
+    data.domain,
+    data.types,
+    data.message
+  );
+
+  const digest = ethers.utils._TypedDataEncoder.hash(
+    data.domain,
+    data.types,
+    data.message
+  );
+
+  return {signature, digest};
+};
+
+const createMockDigest = async (creator: string) => {
+  const data = {
+    types: {
+      Basic: [{name: 'creator', type: 'address'}],
+    },
+    domain: {
+      name: 'The Sandbox',
+      version: '1.0',
+      chainId: hre.network.config.chainId,
+    },
+    message: {
+      creator,
+    },
+  };
+  const digest = ethers.utils._TypedDataEncoder.hash(
+    data.domain,
+    data.types,
+    data.message
+  );
+
+  return digest;
+};
+
+export {
+  createAssetMintSignature,
+  createMultipleAssetsMintSignature,
+  createMockSignature,
+  createMockDigest,
+};

--- a/packages/deploy/deploy/400_asset/400_deploy_asset_auth_validator.ts
+++ b/packages/deploy/deploy/400_asset/400_deploy_asset_auth_validator.ts
@@ -8,7 +8,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const {deployer, assetAdmin} = await getNamedAccounts();
   await deploy('AssetAuthValidator', {
     from: deployer,
-    contract: 'AuthValidator',
+    contract: 'AuthSuperValidator',
     args: [assetAdmin],
     log: true,
   });

--- a/packages/deploy/deploy/400_asset/400_deploy_asset_auth_validator.ts
+++ b/packages/deploy/deploy/400_asset/400_deploy_asset_auth_validator.ts
@@ -5,11 +5,11 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const {deployments, getNamedAccounts} = hre;
   const {deploy} = deployments;
 
-  const {deployer, assetAdmin, backendAuthWallet} = await getNamedAccounts();
+  const {deployer, assetAdmin} = await getNamedAccounts();
   await deploy('AssetAuthValidator', {
     from: deployer,
     contract: 'AuthValidator',
-    args: [assetAdmin, backendAuthWallet],
+    args: [assetAdmin],
     log: true,
   });
 };

--- a/packages/deploy/deploy/400_asset/400_deploy_asset_auth_validator.ts
+++ b/packages/deploy/deploy/400_asset/400_deploy_asset_auth_validator.ts
@@ -6,7 +6,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const {deploy} = deployments;
 
   const {deployer, assetAdmin} = await getNamedAccounts();
-  await deploy('AssetAuthValidator', {
+  await deploy('AuthSuperValidator', {
     from: deployer,
     contract: 'AuthSuperValidator',
     args: [assetAdmin],
@@ -14,4 +14,4 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   });
 };
 export default func;
-func.tags = ['AssetAuthValidator', 'AssetAuthValidator_deploy', 'L2'];
+func.tags = ['AuthSuperValidator', 'AuthSuperValidator_deploy', 'L2'];

--- a/packages/deploy/deploy/400_asset/403_deploy_asset_create.ts
+++ b/packages/deploy/deploy/400_asset/403_deploy_asset_create.ts
@@ -45,6 +45,6 @@ func.tags = ['Asset', 'AssetCreate', 'AssetCreate_deploy', 'L2'];
 func.dependencies = [
   'Asset_deploy',
   'Catalyst',
-  'AssetAuthValidator_deploy',
+  'AuthSuperValidator_deploy',
   'TRUSTED_FORWARDER_V2',
 ];

--- a/packages/deploy/deploy/400_asset/403_deploy_asset_create.ts
+++ b/packages/deploy/deploy/400_asset/403_deploy_asset_create.ts
@@ -7,7 +7,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const {deployer, assetAdmin, upgradeAdmin} = await getNamedAccounts();
 
   const AssetContract = await deployments.get('Asset');
-  const AuthValidatorContract = await deployments.get('AssetAuthValidator');
+  const AuthValidatorContract = await deployments.get('AuthSuperValidator');
   const CatalystContract = await deployments.get('Catalyst');
 
   const name = 'Sandbox Asset Create';

--- a/packages/deploy/deploy/400_asset/404_deploy_asset_reveal.ts
+++ b/packages/deploy/deploy/400_asset/404_deploy_asset_reveal.ts
@@ -44,6 +44,6 @@ func.tags = ['Asset', 'AssetReveal', 'AssetReveal_deploy', 'L2'];
 func.dependencies = [
   'Asset_deploy',
   'Catalyst_deploy',
-  'AssetAuthValidator_deploy',
+  'AuthSuperValidator_deploy',
   'TRUSTED_FORWARDER_V2',
 ];

--- a/packages/deploy/deploy/400_asset/404_deploy_asset_reveal.ts
+++ b/packages/deploy/deploy/400_asset/404_deploy_asset_reveal.ts
@@ -7,7 +7,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const {deployer, upgradeAdmin} = await getNamedAccounts();
 
   const AssetContract = await deployments.get('Asset');
-  const AuthValidatorContract = await deployments.get('AssetAuthValidator');
+  const AuthValidatorContract = await deployments.get('AuthSuperValidator');
 
   const name = 'Sandbox Asset Reveal';
   const version = '1.0';

--- a/packages/deploy/deploy/400_asset/405_asset_setup.ts
+++ b/packages/deploy/deploy/400_asset/405_asset_setup.ts
@@ -42,7 +42,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   await catchUnknownSigner(
     execute(
-      'AssetAuthValidator',
+      'AuthSuperValidator',
       {from: assetAdmin, log: true},
       'setSigner',
       assetCreate.address,
@@ -50,11 +50,11 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     )
   );
 
-  log(`AssetAuthValidator signer for Asset Create set to ${backendAuthWallet}`);
+  log(`AuthSuperValidator signer for Asset Create set to ${backendAuthWallet}`);
 
   await catchUnknownSigner(
     execute(
-      'AssetAuthValidator',
+      'AuthSuperValidator',
       {from: assetAdmin, log: true},
       'setSigner',
       assetReveal.address,
@@ -62,7 +62,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     )
   );
 
-  log(`AssetAuthValidator signer for Asset Reveal set to ${backendAuthWallet}`);
+  log(`AuthSuperValidator signer for Asset Reveal set to ${backendAuthWallet}`);
 };
 
 export default func;


### PR DESCRIPTION
# Auth Validator Changes

Upgrade the AuthValidator used in asset contracts to enhance security by assigning a signer per contract rather than having a single one that can sign anything.

- Contract Updated
- Added new tests for the AuthValidator.sol
- Updated other tests affected by the change
- Updated deploy scripts