### PR TITLE
Asset reveal tests

### DIFF
--- a/packages/asset/contracts/AssetReveal.sol
+++ b/packages/asset/contracts/AssetReveal.sol
@@ -163,6 +163,7 @@ contract AssetReveal is IAssetReveal, Initializable, AccessControlUpgradeable, E
             "AssetReveal: Invalid burnAndReveal signature"
         );
         _burnAsset(prevTokenId, burnAmount);
+        emit AssetRevealBurn(_msgSender(), prevTokenId, burnAmount);
         _revealAsset(prevTokenId, metadataHashes, amounts, revealHashes);
     }
 

--- a/packages/asset/contracts/AssetReveal.sol
+++ b/packages/asset/contracts/AssetReveal.sol
@@ -3,7 +3,10 @@ pragma solidity 0.8.18;
 
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {EIP712Upgradeable} from "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol";
-import {AccessControlUpgradeable, ContextUpgradeable} from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import {
+    AccessControlUpgradeable,
+    ContextUpgradeable
+} from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import {TokenIdUtils} from "./libraries/TokenIdUtils.sol";
 import {AuthValidator} from "./AuthValidator.sol";
 import {ERC2771Handler} from "./ERC2771Handler.sol";
@@ -343,10 +346,10 @@ contract AssetReveal is IAssetReveal, Initializable, AccessControlUpgradeable, E
     /// @param metadataHashes The hashes of the metadata
     /// @param prevTokenId The previous token id from which the assets are revealed
     /// @return tokenIdArray The array of tokenIds to mint
-    function getRevealedTokenIds(
-        string[] calldata metadataHashes,
-        uint256 prevTokenId
-    ) internal returns (uint256[] memory) {
+    function getRevealedTokenIds(string[] calldata metadataHashes, uint256 prevTokenId)
+        internal
+        returns (uint256[] memory)
+    {
         IAsset.AssetData memory data = prevTokenId.getData();
         require(!data.revealed, "AssetReveal: already revealed");
         uint256[] memory tokenIdArray = new uint256[](metadataHashes.length);

--- a/packages/asset/contracts/AssetReveal.sol
+++ b/packages/asset/contracts/AssetReveal.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.18;
 
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {EIP712Upgradeable} from "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol";
+import {AccessControlUpgradeable, ContextUpgradeable} from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import {TokenIdUtils} from "./libraries/TokenIdUtils.sol";
 import {AuthValidator} from "./AuthValidator.sol";
 import {ERC2771Handler} from "./ERC2771Handler.sol";
@@ -12,7 +13,7 @@ import {IAssetReveal} from "./interfaces/IAssetReveal.sol";
 /// @title AssetReveal
 /// @author The Sandbox
 /// @notice Contract for burning and revealing assets
-contract AssetReveal is IAssetReveal, Initializable, ERC2771Handler, EIP712Upgradeable {
+contract AssetReveal is IAssetReveal, Initializable, AccessControlUpgradeable, ERC2771Handler, EIP712Upgradeable {
     using TokenIdUtils for uint256;
     IAsset private assetContract;
     AuthValidator private authValidator;
@@ -51,12 +52,14 @@ contract AssetReveal is IAssetReveal, Initializable, ERC2771Handler, EIP712Upgra
         string memory _version,
         address _assetContract,
         address _authValidator,
-        address _forwarder
+        address _forwarder,
+        address _defaultAdmin
     ) public initializer {
         assetContract = IAsset(_assetContract);
         authValidator = AuthValidator(_authValidator);
         __ERC2771Handler_initialize(_forwarder);
         __EIP712_init(_name, _version);
+        _grantRole(DEFAULT_ADMIN_ROLE, _defaultAdmin);
     }
 
     /// @notice Reveal an asset to view its abilities and enhancements
@@ -65,6 +68,7 @@ contract AssetReveal is IAssetReveal, Initializable, ERC2771Handler, EIP712Upgra
     /// @param amount the amount of tokens to reveal
     function revealBurn(uint256 tokenId, uint256 amount) public {
         _burnAsset(tokenId, amount);
+        emit AssetRevealBurn(_msgSender(), tokenId, amount);
     }
 
     /// @notice Burn multiple assets to be able to reveal them later
@@ -72,10 +76,8 @@ contract AssetReveal is IAssetReveal, Initializable, ERC2771Handler, EIP712Upgra
     /// @param tokenIds the tokenIds of the assets to burn
     /// @param amounts the amounts of the assets to burn
     function revealBatchBurn(uint256[] calldata tokenIds, uint256[] calldata amounts) external {
-        require(tokenIds.length == amounts.length, "Invalid input");
-        for (uint256 i = 0; i < tokenIds.length; i++) {
-            _burnAsset(tokenIds[i], amounts[i]);
-        }
+        _burnAssetBatch(tokenIds, amounts);
+        emit AssetRevealBatchBurn(_msgSender(), tokenIds, amounts);
     }
 
     /// @notice Reveal assets to view their abilities and enhancements
@@ -92,14 +94,14 @@ contract AssetReveal is IAssetReveal, Initializable, ERC2771Handler, EIP712Upgra
         string[] calldata metadataHashes,
         bytes32[] calldata revealHashes
     ) public {
-        require(amounts.length == metadataHashes.length, "Invalid amounts");
-        require(amounts.length == revealHashes.length, "Invalid revealHashes");
+        require(amounts.length == metadataHashes.length, "AssetReveal: Invalid amounts length");
+        require(amounts.length == revealHashes.length, "AssetReveal: Invalid revealHashes length");
         require(
             authValidator.verify(
                 signature,
                 _hashReveal(_msgSender(), prevTokenId, amounts, metadataHashes, revealHashes)
             ),
-            "Invalid revealMint signature"
+            "AssetReveal: Invalid revealMint signature"
         );
         _revealAsset(prevTokenId, metadataHashes, amounts, revealHashes);
     }
@@ -118,15 +120,15 @@ contract AssetReveal is IAssetReveal, Initializable, ERC2771Handler, EIP712Upgra
         string[][] calldata metadataHashes,
         bytes32[][] calldata revealHashes
     ) public {
-        require(prevTokenIds.length == amounts.length, "Invalid amounts");
-        require(amounts.length == metadataHashes.length, "Invalid metadataHashes");
-        require(prevTokenIds.length == revealHashes.length, "Invalid revealHashes");
+        require(prevTokenIds.length == amounts.length, "AssetReveal: Invalid amounts length");
+        require(amounts.length == metadataHashes.length, "AssetReveal: Invalid metadataHashes length");
+        require(prevTokenIds.length == revealHashes.length, "AssetReveal: Invalid revealHashes length");
         require(
             authValidator.verify(
                 signature,
                 _hashBatchReveal(_msgSender(), prevTokenIds, amounts, metadataHashes, revealHashes)
             ),
-            "Invalid revealBatchMint signature"
+            "AssetReveal: Invalid revealBatchMint signature"
         );
         for (uint256 i = 0; i < prevTokenIds.length; i++) {
             // require(revealHashesUsed[revealHashes[i]] == false, "Invalid revealHash");
@@ -151,14 +153,14 @@ contract AssetReveal is IAssetReveal, Initializable, ERC2771Handler, EIP712Upgra
         string[] calldata metadataHashes,
         bytes32[] calldata revealHashes
     ) external {
-        require(amounts.length == metadataHashes.length, "Invalid amounts");
-        require(amounts.length == revealHashes.length, "Invalid revealHashes");
+        require(amounts.length == metadataHashes.length, "AssetReveal: Invalid amounts length");
+        require(amounts.length == revealHashes.length, "AssetReveal: Invalid revealHashes length");
         require(
             authValidator.verify(
                 signature,
                 _hashInstantReveal(_msgSender(), prevTokenId, amounts, metadataHashes, revealHashes)
             ),
-            "Invalid burnAndReveal signature"
+            "AssetReveal: Invalid burnAndReveal signature"
         );
         _burnAsset(prevTokenId, burnAmount);
         _revealAsset(prevTokenId, metadataHashes, amounts, revealHashes);
@@ -176,7 +178,7 @@ contract AssetReveal is IAssetReveal, Initializable, ERC2771Handler, EIP712Upgra
     ) internal {
         uint256[] memory newTokenIds = getRevealedTokenIds(metadataHashes, prevTokenId);
         for (uint256 i = 0; i < revealHashes.length; i++) {
-            require(revealHashesUsed[revealHashes[i]] == false, "Invalid revealHash");
+            require(revealHashesUsed[revealHashes[i]] == false, "AssetReveal: RevealHash already used");
             revealHashesUsed[revealHashes[i]] = true;
         }
         if (newTokenIds.length == 1) {
@@ -191,11 +193,22 @@ contract AssetReveal is IAssetReveal, Initializable, ERC2771Handler, EIP712Upgra
     /// @param tokenId the tokenId of the asset to burn
     /// @param amount the amount of the asset to burn
     function _burnAsset(uint256 tokenId, uint256 amount) internal {
-        require(amount > 0, "Amount should be greater than 0");
-        IAsset.AssetData memory data = tokenId.getData();
-        require(!data.revealed, "Asset is already revealed");
+        _verifyBurnData(tokenId, amount);
         assetContract.burnFrom(_msgSender(), tokenId, amount);
-        emit AssetRevealBurn(_msgSender(), tokenId, data.tier, amount);
+    }
+
+    function _burnAssetBatch(uint256[] calldata tokenIds, uint256[] calldata amounts) internal {
+        require(tokenIds.length == amounts.length, "AssetReveal: Invalid input");
+        for (uint256 i = 0; i < tokenIds.length; i++) {
+            _verifyBurnData(tokenIds[i], amounts[i]);
+        }
+        assetContract.burnBatchFrom(_msgSender(), tokenIds, amounts);
+    }
+
+    function _verifyBurnData(uint256 tokenId, uint256 amount) internal pure {
+        IAsset.AssetData memory data = tokenId.getData();
+        require(!data.revealed, "AssetReveal: Asset is already revealed");
+        require(amount > 0, "AssetReveal: Burn amount should be greater than 0");
     }
 
     /// @notice Creates a hash of the reveal data
@@ -331,12 +344,12 @@ contract AssetReveal is IAssetReveal, Initializable, ERC2771Handler, EIP712Upgra
     /// @param metadataHashes The hashes of the metadata
     /// @param prevTokenId The previous token id from which the assets are revealed
     /// @return tokenIdArray The array of tokenIds to mint
-    function getRevealedTokenIds(string[] calldata metadataHashes, uint256 prevTokenId)
-        internal
-        returns (uint256[] memory)
-    {
+    function getRevealedTokenIds(
+        string[] calldata metadataHashes,
+        uint256 prevTokenId
+    ) internal returns (uint256[] memory) {
         IAsset.AssetData memory data = prevTokenId.getData();
-        require(!data.revealed, "Asset: already revealed");
+        require(!data.revealed, "AssetReveal: already revealed");
         uint256[] memory tokenIdArray = new uint256[](metadataHashes.length);
         for (uint256 i = 0; i < metadataHashes.length; i++) {
             uint256 tokenId = assetContract.getTokenIdByMetadataHash(metadataHashes[i]);
@@ -371,5 +384,22 @@ contract AssetReveal is IAssetReveal, Initializable, ERC2771Handler, EIP712Upgra
     /// @return The auth validator address
     function getAuthValidator() external view returns (address) {
         return address(authValidator);
+    }
+
+    /// @notice Set a new trusted forwarder address, limited to DEFAULT_ADMIN_ROLE only
+    /// @dev Change the address of the trusted forwarder for meta-TX
+    /// @param trustedForwarder The new trustedForwarder
+    function setTrustedForwarder(address trustedForwarder) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        require(trustedForwarder != address(0), "AssetReveal: trusted forwarder can't be zero address");
+        _trustedForwarder = trustedForwarder;
+        emit TrustedForwarderChanged(trustedForwarder);
+    }
+
+    function _msgSender() internal view virtual override(ContextUpgradeable, ERC2771Handler) returns (address sender) {
+        return ERC2771Handler._msgSender();
+    }
+
+    function _msgData() internal view virtual override(ContextUpgradeable, ERC2771Handler) returns (bytes calldata) {
+        return ERC2771Handler._msgData();
     }
 }

--- a/packages/asset/contracts/interfaces/IAssetReveal.sol
+++ b/packages/asset/contracts/interfaces/IAssetReveal.sol
@@ -2,8 +2,9 @@
 pragma solidity 0.8.18;
 
 interface IAssetReveal {
-    event AssetRevealBurn(address revealer, uint256 unrevealedTokenId, uint8 tier, uint256 amount);
-
+    event TrustedForwarderChanged(address indexed newTrustedForwarderAddress);
+    event AssetRevealBurn(address revealer, uint256 unrevealedTokenId, uint256 amount);
+    event AssetRevealBatchBurn(address revealer, uint256[] unrevealedTokenIds, uint256[] amounts);
     event AssetRevealMint(
         address recipient,
         uint256 unrevealedTokenId,

--- a/packages/asset/contracts/mock/MockAssetReveal.sol
+++ b/packages/asset/contracts/mock/MockAssetReveal.sol
@@ -1,0 +1,12 @@
+//SPDX-License-Identifier: MIT
+pragma solidity 0.8.18;
+
+// mock the asset contract to test the _msgData() function to satisfy the coverage
+
+import {AssetReveal} from "../AssetReveal.sol";
+
+contract MockAssetReveal is AssetReveal {
+    function msgData() external view returns (bytes memory) {
+        return _msgData();
+    }
+}

--- a/packages/asset/test/Asset.test.ts
+++ b/packages/asset/test/Asset.test.ts
@@ -647,6 +647,16 @@ describe('Base Asset Contract (/packages/asset/contracts/Asset.sol)', function (
         randomAddress
       );
     });
+    it("should not allow non-DEFAULT_ADMIN to set the trusted forwarder's address", async function () {
+      const {AssetContractAsMinter, minter, defaultAdminRole} =
+        await runAssetSetup();
+      const randomAddress = ethers.Wallet.createRandom().address;
+      await expect(
+        AssetContractAsMinter.setTrustedForwarder(randomAddress)
+      ).to.be.revertedWith(
+        `AccessControl: account ${minter.address.toLowerCase()} is missing role ${defaultAdminRole}`
+      );
+    });
   });
   describe('Transferring', function () {
     it('should allow owner to transfer a single token', async function () {

--- a/packages/asset/test/AssetReveal.test.ts
+++ b/packages/asset/test/AssetReveal.test.ts
@@ -9,11 +9,10 @@ const revealHashD = formatBytes32String('revealHashD');
 const revealHashE = formatBytes32String('revealHashE');
 const revealHashF = formatBytes32String('revealHashF');
 
-// TODO: missing AssetReveal DEFAULT_ADMIN, trustedForwarder tests, setTrustedForwarder
+// TODO: missing  trustedForwarder tests
 // TODO 2: test reveal nonce incrementation
-// we have AccessControlUpgradeable on AssetCreate, why not here?
 
-describe('AssetReveal', function () {
+describe.only('AssetReveal', function () {
   describe('General', function () {
     it('Should deploy correctly', async function () {
       const {AssetRevealContract} = await runRevealTestSetup();
@@ -30,540 +29,885 @@ describe('AssetReveal', function () {
       const authValidatorAddress = await AssetRevealContract.getAuthValidator();
       expect(authValidatorAddress).to.equal(AuthValidatorContract.address);
     });
+    it('should give DEFAULT_ADMIN_ROLE to the defaultAdmin', async function () {
+      const {AssetRevealContract, assetAdmin} = await runRevealTestSetup();
+      const hasAdminRole = await AssetRevealContract.hasRole(
+        await AssetRevealContract.DEFAULT_ADMIN_ROLE(),
+        assetAdmin.address
+      );
+      expect(hasAdminRole).to.equal(true);
+    });
     it('Should have the forwarder address set correctly', async function () {
       const {AssetRevealContract, trustedForwarder} =
         await runRevealTestSetup();
       const forwarderAddress = await AssetRevealContract.getTrustedForwarder();
       expect(forwarderAddress).to.equal(trustedForwarder.address);
     });
+    it("Should increment the reveal nonce if revealing an asset that hasn't been revealed before", async function () {
+      // TODO
+    });
+    it('Should not increment the reveal nonce if revealing an asset that has already been revealed', async function () {});
   });
 
   describe('Burning', function () {
-    it('User should have correct initial balance', async function () {
-      const {AssetContract, user, unrevealedtokenId, revealedtokenId} =
-        await runRevealTestSetup();
-      const unRevealedBalance = await AssetContract.balanceOf(
-        user.address,
-        unrevealedtokenId
-      );
-      const revealedBalance = await AssetContract.balanceOf(
-        user.address,
-        revealedtokenId
-      );
-      expect(unRevealedBalance.toString()).to.equal('10');
-      expect(revealedBalance.toString()).to.equal('10');
-    });
-    it('Should not be able to burn amount less than one', async function () {
-      const {AssetRevealContractAsUser, unrevealedtokenId} =
-        await runRevealTestSetup();
-      await expect(
-        AssetRevealContractAsUser.revealBurn(unrevealedtokenId, 0)
-      ).to.be.revertedWith('Amount should be greater than 0');
-    });
-    it('Should not be able to burn an asset that is already revealed', async function () {
-      const {AssetRevealContractAsUser, revealedtokenId} =
-        await runRevealTestSetup();
-      await expect(
-        AssetRevealContractAsUser.revealBurn(revealedtokenId, 1)
-      ).to.be.revertedWith('Asset is already revealed');
-    });
-    it('Should not be able to burn more than owned by the caller', async function () {
-      const {
-        user,
-        AssetRevealContractAsUser,
-        AssetContract,
-        unrevealedtokenId,
-      } = await runRevealTestSetup();
-      const balance = await AssetContract.balanceOf(
-        user.address,
-        unrevealedtokenId
-      );
-      await expect(
-        AssetRevealContractAsUser.revealBurn(unrevealedtokenId, balance + 1)
-      ).to.be.revertedWith('ERC1155: burn amount exceeds totalSupply');
-    });
-    it("Should not be able to burn a token that doesn't exist", async function () {
-      const {AssetRevealContractAsUser} = await runRevealTestSetup();
-      await expect(
-        AssetRevealContractAsUser.revealBurn(123, 1)
-      ).to.be.revertedWith('ERC1155: burn amount exceeds totalSupply');
-    });
-    it('Should be able to burn unrevealed owned assets', async function () {
-      const {
-        AssetRevealContractAsUser,
-        AssetContract,
-        unrevealedtokenId,
-        user,
-      } = await runRevealTestSetup();
-      const burnTx = await AssetRevealContractAsUser.revealBurn(
-        unrevealedtokenId,
-        1
-      );
-      await burnTx.wait();
+    describe('Single burn', function () {
+      describe('Success', function () {
+        it('Should be able to burn unrevealed owned assets', async function () {
+          const {
+            AssetRevealContractAsUser,
+            AssetContract,
+            unrevealedtokenId,
+            user,
+          } = await runRevealTestSetup();
+          const burnTx = await AssetRevealContractAsUser.revealBurn(
+            unrevealedtokenId,
+            1
+          );
+          await burnTx.wait();
 
-      const userBalance = await AssetContract.balanceOf(
-        user.address,
-        unrevealedtokenId
-      );
-      expect(userBalance.toString()).to.equal('9');
+          const userBalance = await AssetContract.balanceOf(
+            user.address,
+            unrevealedtokenId
+          );
+          expect(userBalance.toString()).to.equal('9');
+        });
+      });
+      describe('Revert', function () {
+        it('Should not be able to burn amount less than one', async function () {
+          const {AssetRevealContractAsUser, unrevealedtokenId} =
+            await runRevealTestSetup();
+          await expect(
+            AssetRevealContractAsUser.revealBurn(unrevealedtokenId, 0)
+          ).to.be.revertedWith(
+            'AssetReveal: Burn amount should be greater than 0'
+          );
+        });
+        it('Should not be able to burn an asset that is already revealed', async function () {
+          const {AssetRevealContractAsUser, revealedtokenId} =
+            await runRevealTestSetup();
+          await expect(
+            AssetRevealContractAsUser.revealBurn(revealedtokenId, 1)
+          ).to.be.revertedWith('AssetReveal: Asset is already revealed');
+        });
+        it('Should not be able to burn more than owned by the caller', async function () {
+          const {
+            user,
+            AssetRevealContractAsUser,
+            AssetContract,
+            unrevealedtokenId,
+          } = await runRevealTestSetup();
+          const balance = await AssetContract.balanceOf(
+            user.address,
+            unrevealedtokenId
+          );
+          await expect(
+            AssetRevealContractAsUser.revealBurn(unrevealedtokenId, balance + 1)
+          ).to.be.revertedWith('ERC1155: burn amount exceeds totalSupply');
+        });
+        it("Should not be able to burn a token that doesn't exist", async function () {
+          const {AssetRevealContractAsUser} = await runRevealTestSetup();
+          await expect(
+            AssetRevealContractAsUser.revealBurn(123, 1)
+          ).to.be.revertedWith('ERC1155: burn amount exceeds totalSupply');
+        });
+      });
     });
-    it('Should emit burn event with correct data', async function () {
-      const {AssetRevealContractAsUser, unrevealedtokenId, user} =
-        await runRevealTestSetup();
-      const burnTx = await AssetRevealContractAsUser.revealBurn(
-        unrevealedtokenId,
-        1
-      );
-      const burnResult = await burnTx.wait();
-      const burnEvent = burnResult.events[1];
-      expect(burnEvent.event).to.equal('AssetRevealBurn');
-      // revealer
-      expect(burnEvent.args[0]).to.equal(user.address);
-      // token id that is being revealed
-      expect(burnEvent.args[1]).to.equal(unrevealedtokenId);
-      // tier
-      expect(burnEvent.args[2].toString()).to.equal('5');
-      // amount
-      expect(burnEvent.args[3].toString()).to.equal('1');
+    describe('Batch burn', function () {
+      describe('Success', function () {
+        it('Should be able to burn multiple unrevealed owned assets', async function () {
+          const {
+            AssetRevealContractAsUser,
+            AssetContract,
+            unrevealedtokenId,
+            unrevealedtokenId2,
+            user,
+          } = await runRevealTestSetup();
+          const amountToBurn1 = 2;
+          const amountToBurn2 = 3;
+          const tk1BalanceBeforeBurn = await AssetContract.balanceOf(
+            user.address,
+            unrevealedtokenId
+          );
+
+          const tk2BalanceBeforeBurn = await AssetContract.balanceOf(
+            user.address,
+            unrevealedtokenId2
+          );
+
+          const burnTx = await AssetRevealContractAsUser.revealBatchBurn(
+            [unrevealedtokenId, unrevealedtokenId2],
+            [amountToBurn1, amountToBurn2]
+          );
+          await burnTx.wait();
+
+          const tk1BalanceAfterBurn = await AssetContract.balanceOf(
+            user.address,
+            unrevealedtokenId
+          );
+
+          const tk2BalanceAfterBurn = await AssetContract.balanceOf(
+            user.address,
+            unrevealedtokenId2
+          );
+
+          expect(tk1BalanceBeforeBurn.sub(amountToBurn1)).to.equal(
+            tk1BalanceAfterBurn
+          );
+          expect(tk2BalanceBeforeBurn.sub(amountToBurn2)).to.equal(
+            tk2BalanceAfterBurn
+          );
+        });
+      });
+      describe('Revert', function () {
+        it("should revert if ids array and amounts array aren't the same length", async function () {
+          const {AssetRevealContractAsUser, unrevealedtokenId} =
+            await runRevealTestSetup();
+          await expect(
+            AssetRevealContractAsUser.revealBatchBurn(
+              [unrevealedtokenId],
+              [1, 2]
+            )
+          ).to.be.revertedWith('AssetReveal: Invalid input');
+        });
+      });
     });
-    it('Should be able to burn multiple unrevealed owned assets', async function () {
-      const {
-        AssetRevealContractAsUser,
-        AssetContract,
-        unrevealedtokenId,
-        unrevealedtokenId2,
-        user,
-      } = await runRevealTestSetup();
-      const amountToBurn1 = 2;
-      const amountToBurn2 = 3;
-      const tk1BalanceBeforeBurn = await AssetContract.balanceOf(
-        user.address,
-        unrevealedtokenId
-      );
-
-      const tk2BalanceBeforeBurn = await AssetContract.balanceOf(
-        user.address,
-        unrevealedtokenId2
-      );
-
-      const burnTx = await AssetRevealContractAsUser.revealBatchBurn(
-        [unrevealedtokenId, unrevealedtokenId2],
-        [amountToBurn1, amountToBurn2]
-      );
-      await burnTx.wait();
-
-      const tk1BalanceAfterBurn = await AssetContract.balanceOf(
-        user.address,
-        unrevealedtokenId
-      );
-
-      // TODO: fix
-      // expect(tk1BalanceBeforeBurn.sub(5)).to.equal(tk1BalanceAfterBurn);
-
-      const tk2BalanceAfterBurn = await AssetContract.balanceOf(
-        user.address,
-        unrevealedtokenId2
-      );
-
-      expect(tk1BalanceBeforeBurn.sub(amountToBurn1)).to.equal(
-        tk1BalanceAfterBurn
-      );
-      expect(tk2BalanceBeforeBurn.sub(amountToBurn2)).to.equal(
-        tk2BalanceAfterBurn
-      );
+    describe('Burn Events', function () {
+      it('Should emit AssetRevealBurn event with correct data when burning single token', async function () {
+        const {AssetRevealContractAsUser, unrevealedtokenId, user} =
+          await runRevealTestSetup();
+        const burnTx = await AssetRevealContractAsUser.revealBurn(
+          unrevealedtokenId,
+          1
+        );
+        const burnResult = await burnTx.wait();
+        const burnEvent = burnResult.events[1];
+        expect(burnEvent.event).to.equal('AssetRevealBurn');
+        // revealer
+        expect(burnEvent.args[0]).to.equal(user.address);
+        // token id that is being revealed
+        expect(burnEvent.args[1]).to.equal(unrevealedtokenId);
+        // amount
+        expect(burnEvent.args[2].toString()).to.equal('1');
+      });
+      it('should emit AssetRevealBatchBurn event with correct data when burning multiple tokens', async function () {
+        const {
+          AssetRevealContractAsUser,
+          unrevealedtokenId,
+          unrevealedtokenId2,
+          user,
+        } = await runRevealTestSetup();
+        const burnTx = await AssetRevealContractAsUser.revealBatchBurn(
+          [unrevealedtokenId, unrevealedtokenId2],
+          [1, 2]
+        );
+        const burnResult = await burnTx.wait();
+        const burnEvent = burnResult.events[1];
+        expect(burnEvent.event).to.equal('AssetRevealBatchBurn');
+        // revealer
+        expect(burnEvent.args[0]).to.equal(user.address);
+        // token ids that are being revealed
+        expect(burnEvent.args[1].toString()).to.equal(
+          [unrevealedtokenId, unrevealedtokenId2].toString()
+        );
+        // amount
+        expect(burnEvent.args[2].toString()).to.equal([1, 2].toString());
+      });
     });
   });
-  describe('Minting', function () {
-    it('Should allow minting with valid signature', async function () {
-      const {
-        user,
-        unrevealedtokenId,
-        generateRevealSignature,
-        revealAsset,
-        AssetContract,
-      } = await runRevealTestSetup();
-      const newMetadataHashes = [
-        'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJF',
-      ];
-      const amounts = [1];
-
-      const signature = await generateRevealSignature(
-        user.address, // revealer
-        unrevealedtokenId, // prevTokenId
-        amounts,
-        newMetadataHashes,
-        [revealHashA]
-      );
-      const result = await revealAsset(
-        signature,
-        unrevealedtokenId,
-        amounts,
-        newMetadataHashes,
-        [revealHashA]
-      );
-      expect(result.events[2].event).to.equal('AssetRevealMint');
-      const newTokenId = result.events[2].args.newTokenIds[0];
-      const balance = await AssetContract.balanceOf(user.address, newTokenId);
-      expect(balance.toString()).to.equal('1');
-    });
-    it('Should allow minting when multiple copies revealed to the same metadata hash', async function () {
-      const {user, unrevealedtokenId, revealAsset, generateRevealSignature} =
-        await runRevealTestSetup();
-      const newMetadataHashes = [
-        'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJF',
-      ];
-      const amounts = [2];
-      const signature = await generateRevealSignature(
-        user.address,
-        unrevealedtokenId,
-        amounts,
-        newMetadataHashes,
-        [revealHashA]
-      );
-      const result = await revealAsset(
-        signature,
-        unrevealedtokenId,
-        amounts,
-        newMetadataHashes,
-        [revealHashA]
-      );
-      expect(result.events[2].event).to.equal('AssetRevealMint');
-      expect(result.events[2].args['newTokenIds'].length).to.equal(1);
-      // TODO: check supply with new metadataHash has incremented by 2
-    });
-    it('Should not allow minting for multiple copies revealed to the same metadata hash if revealHash is used', async function () {
-      const {user, unrevealedtokenId, revealAsset, generateRevealSignature} =
-        await runRevealTestSetup();
-      const newMetadataHashes = [
-        'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJF',
-      ];
-      const amounts = [2];
-      const signature = await generateRevealSignature(
-        user.address,
-        unrevealedtokenId,
-        amounts,
-        newMetadataHashes,
-        [revealHashA]
-      );
-      await revealAsset(
-        signature,
-        unrevealedtokenId,
-        amounts,
-        newMetadataHashes,
-        [revealHashA]
-      );
-
-      const signature2 = await generateRevealSignature(
-        user.address,
-        unrevealedtokenId,
-        amounts,
-        newMetadataHashes,
-        [revealHashA]
-      );
-      await expect(
-        revealAsset(signature2, unrevealedtokenId, amounts, newMetadataHashes, [
-          revealHashA,
-        ])
-      ).to.be.revertedWith('Invalid revealHash');
-    });
-    it('should increase the tokens supply for tokens with same metadata hash', async function () {
-      const {
-        user,
-        unrevealedtokenId,
-        generateRevealSignature,
-        revealAsset,
-        AssetContract,
-      } = await runRevealTestSetup();
-      const newMetadataHashes = [
-        'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJF',
-      ];
-      const amounts = [1];
-      const signature = await generateRevealSignature(
-        user.address,
-        unrevealedtokenId,
-        amounts,
-        newMetadataHashes,
-        [revealHashA]
-      );
-      const result = await revealAsset(
-        signature,
-        unrevealedtokenId,
-        amounts,
-        newMetadataHashes,
-        [revealHashA]
-      );
-      const newTokenId = result.events[2].args.newTokenIds[0];
-      const balance = await AssetContract.balanceOf(user.address, newTokenId);
-      expect(balance.toString()).to.equal('1');
-      const signature2 = await generateRevealSignature(
-        user.address,
-        unrevealedtokenId,
-        amounts,
-        newMetadataHashes,
-        [revealHashB]
-      );
-      await revealAsset(
-        signature2,
-        unrevealedtokenId,
-        amounts,
-        newMetadataHashes,
-        [revealHashB]
-      );
-      const balance2 = await AssetContract.balanceOf(user.address, newTokenId);
-      expect(balance2.toString()).to.equal('2');
-    });
-    it('Should allow batch reveal minting with valid signatures', async function () {
-      const {
-        user,
-        revealAssetBatch,
-        generateBatchRevealSignature,
-        unrevealedtokenId,
-        unrevealedtokenId2,
-      } = await runRevealTestSetup();
-      const newMetadataHashes1 = [
-        'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJF',
-      ];
-      const newMetadataHashes2 = [
-        'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJZ',
-      ];
-      const amounts1 = [1];
-      const amounts2 = [1];
-
-      const signature = await generateBatchRevealSignature(
-        user.address,
-        [unrevealedtokenId, unrevealedtokenId2],
-        [amounts1, amounts2],
-        [newMetadataHashes1, newMetadataHashes2],
-        [[revealHashA], [revealHashB]]
-      );
-
-      const result = await revealAssetBatch(
-        signature,
-        [unrevealedtokenId, unrevealedtokenId2],
-        [amounts1, amounts2],
-        [newMetadataHashes1, newMetadataHashes2],
-        [[revealHashA], [revealHashB]]
-      );
-
-      // expect two events with name AssetsRevealed
-      expect(result.events[2].event).to.equal('AssetRevealMint');
-      expect(result.events[5].event).to.equal('AssetRevealMint');
-    });
-    it('Should allow revealing multiple copies at the same time', async function () {
-      const {user, generateRevealSignature, revealAsset, unrevealedtokenId} =
-        await runRevealTestSetup();
-      const newMetadataHashes = [
-        'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJ1',
-        'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJ2',
-        'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJ3',
-        'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJ4',
-        'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJ5',
-        'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJ6',
-      ];
-      const amountToMint = [1, 2, 1, 7, 1, 2];
-      const signature = await generateRevealSignature(
-        user.address,
-        unrevealedtokenId,
-        amountToMint,
-        newMetadataHashes,
-        [
-          revealHashA,
-          revealHashB,
-          revealHashC,
-          revealHashD,
-          revealHashE,
-          revealHashF,
-        ]
-      );
-
-      const result = await revealAsset(
-        signature,
-        unrevealedtokenId,
-        amountToMint,
-        newMetadataHashes,
-        [
-          revealHashA,
-          revealHashB,
-          revealHashC,
-          revealHashD,
-          revealHashE,
-          revealHashF,
-        ]
-      );
-      expect(result.events[7].event).to.equal('AssetRevealMint');
-      expect(result.events[7].args['newTokenIds'].length).to.equal(6);
-    });
-    it('Should allow instant reveal when authorized by the backend', async function () {
-      const {
-        user,
-        generateBurnAndRevealSignature,
-        instantReveal,
-        unrevealedtokenId,
-      } = await runRevealTestSetup();
-      const newMetadataHash = [
-        'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJF',
-      ];
-      const amounts = [1];
-
-      const signature = await generateBurnAndRevealSignature(
-        user.address,
-        unrevealedtokenId,
-        amounts,
-        newMetadataHash,
-        [revealHashA]
-      );
-
-      const result = await instantReveal(
-        signature,
-        unrevealedtokenId,
-        amounts[0],
-        amounts,
-        newMetadataHash,
-        [revealHashA]
-      );
-      expect(result.events[4].event).to.equal('AssetRevealMint');
-    });
-    it('Should not allow minting with invalid signature', async function () {
-      const {revealAsset, unrevealedtokenId} = await runRevealTestSetup();
-      const newMetadataHashes = [
-        'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJF',
-      ];
-      const amounts = [1];
-      await expect(
-        revealAsset(
-          '0x1556a70d76cc452ae54e83bb167a9041f0d062d000fa0dcb42593f77c544f6471643d14dbd6a6edc658f4b16699a585181a08dba4f6d16a9273e0e2cbed622da1b',
-          // TODO: write down how is this a bad sig here so it's clear
+  describe('Reveal Minting', function () {
+    describe('Signature generation and validation', function () {
+      it('Should not allow minting with invalid amount', async function () {
+        const {
+          user,
+          generateRevealSignature,
+          unrevealedtokenId,
+          AssetRevealContract,
+        } = await runRevealTestSetup();
+        const newMetadataHashes = [
+          'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJF',
+        ];
+        const amounts = [1];
+        const signature = await generateRevealSignature(
+          user.address,
           unrevealedtokenId,
           amounts,
           newMetadataHashes,
           [revealHashA]
-        )
-      ).to.be.revertedWith('Invalid revealMint signature');
-    });
-    it('Should not allow minting with invalid prevTokenId', async function () {
-      const {
-        user,
-        generateRevealSignature,
-        unrevealedtokenId,
-        AssetRevealContract,
-      } = await runRevealTestSetup();
-      const newMetadataHashes = [
-        'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJF',
-      ];
-      const amounts = [1];
-      const signature = await generateRevealSignature(
-        user.address,
-        unrevealedtokenId,
-        amounts,
-        newMetadataHashes,
-        [revealHashA]
-      );
-
-      await expect(
-        AssetRevealContract.revealMint(
-          signature,
-          123, // invalid
-          amounts,
-          newMetadataHashes,
-          [revealHashA]
-        )
-      ).to.be.revertedWith('Invalid revealMint signature');
-    });
-    it('Should not allow minting with invalid amount', async function () {
-      const {
-        user,
-        generateRevealSignature,
-        unrevealedtokenId,
-        AssetRevealContract,
-      } = await runRevealTestSetup();
-      const newMetadataHashes = [
-        'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJF',
-      ];
-      const amounts = [1];
-      const signature = await generateRevealSignature(
-        user.address,
-        unrevealedtokenId,
-        amounts,
-        newMetadataHashes,
-        [revealHashA]
-      );
-
-      await expect(
-        AssetRevealContract.revealMint(
-          signature,
-          unrevealedtokenId,
-          [123], // invalid
-          newMetadataHashes,
-          [revealHashA]
-        )
-      ).to.be.revertedWith('Invalid revealMint signature');
-    });
-    it('Should not allow minting with invalid metadataHashes', async function () {
-      const {
-        user,
-        generateRevealSignature,
-        unrevealedtokenId,
-        AssetRevealContract,
-      } = await runRevealTestSetup();
-      const newMetadataHashes = [
-        'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJF',
-      ];
-      const amounts = [1];
-      const signature = await generateRevealSignature(
-        user.address,
-        unrevealedtokenId,
-        amounts,
-        newMetadataHashes,
-        [revealHashA]
-      );
-
-      await expect(
-        AssetRevealContract.revealMint(
-          signature,
-          unrevealedtokenId,
-          amounts,
-          ['QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJE'], // invalid
-          [revealHashA]
-        )
-      ).to.be.revertedWith('Invalid revealMint signature');
-    });
-    it('Should not allow using the same signature twice', async function () {
-      const {
-        user,
-        generateRevealSignature,
-        revealAsset,
-        unrevealedtokenId,
-        AssetRevealContract,
-      } = await runRevealTestSetup();
-      const newMetadataHashes = [
-        'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJF',
-      ];
-      const amounts = [1];
-      const signature = await generateRevealSignature(
-        user.address,
-        unrevealedtokenId,
-        amounts,
-        newMetadataHashes,
-        [revealHashA]
-      );
-
-      await revealAsset(
-        signature,
-        unrevealedtokenId,
-        amounts,
-        newMetadataHashes,
-        [revealHashA]
-      );
-
-      await expect(
-        AssetRevealContract.revealMint(
-          signature,
+        );
+        await expect(
+          AssetRevealContract.revealMint(
+            signature,
+            unrevealedtokenId,
+            [123], // invalid
+            newMetadataHashes,
+            [revealHashA]
+          )
+        ).to.be.revertedWith('AssetReveal: Invalid revealMint signature');
+      });
+      it('Should not allow minting with invalid recipient', async function () {
+        const {revealAsset, unrevealedtokenId, generateRevealSignature} =
+          await runRevealTestSetup();
+        const newMetadataHashes = [
+          'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJF',
+        ];
+        const amounts = [1];
+        const incorrectSignature = await generateRevealSignature(
+          '0x0000000000000000000000000000000000000000', // invalid
           unrevealedtokenId,
           amounts,
           newMetadataHashes,
           [revealHashA]
-        )
-      ).to.be.revertedWith('Invalid revealMint signature'); // TODO: check this is correct and not 'Invalid revealHash'
+        );
+
+        await expect(
+          revealAsset(
+            incorrectSignature,
+            unrevealedtokenId,
+            amounts,
+            newMetadataHashes,
+            [revealHashA]
+          )
+        ).to.be.revertedWith('AssetReveal: Invalid revealMint signature');
+      });
+      it('Should not allow minting with invalid prevTokenId', async function () {
+        const {
+          user,
+          generateRevealSignature,
+          unrevealedtokenId,
+          AssetRevealContract,
+        } = await runRevealTestSetup();
+        const newMetadataHashes = [
+          'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJF',
+        ];
+        const amounts = [1];
+        const signature = await generateRevealSignature(
+          user.address,
+          unrevealedtokenId,
+          amounts,
+          newMetadataHashes,
+          [revealHashA]
+        );
+
+        await expect(
+          AssetRevealContract.revealMint(
+            signature,
+            123, // invalid
+            amounts,
+            newMetadataHashes,
+            [revealHashA]
+          )
+        ).to.be.revertedWith('AssetReveal: Invalid revealMint signature');
+      });
+      it('Should not allow minting with invalid metadataHashes', async function () {
+        const {user, generateRevealSignature, unrevealedtokenId, revealAsset} =
+          await runRevealTestSetup();
+        const newMetadataHashes = [
+          'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJF',
+        ];
+        const amounts = [1];
+        const signature = await generateRevealSignature(
+          user.address,
+          unrevealedtokenId,
+          amounts,
+          newMetadataHashes,
+          [revealHashA]
+        );
+
+        await expect(
+          revealAsset(
+            signature,
+            unrevealedtokenId,
+            amounts,
+            ['QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJE'], // invalid
+            [revealHashA]
+          )
+        ).to.be.revertedWith('AssetReveal: Invalid revealMint signature');
+      });
+    });
+    describe('Single reveal mint', function () {
+      describe('Success', function () {
+        it('Should allow minting with valid signature', async function () {
+          const {
+            user,
+            unrevealedtokenId,
+            generateRevealSignature,
+            revealAsset,
+            AssetContract,
+          } = await runRevealTestSetup();
+          const newMetadataHashes = [
+            'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJF',
+          ];
+          const amounts = [1];
+
+          const signature = await generateRevealSignature(
+            user.address, // revealer
+            unrevealedtokenId, // prevTokenId
+            amounts,
+            newMetadataHashes,
+            [revealHashA]
+          );
+          const result = await revealAsset(
+            signature,
+            unrevealedtokenId,
+            amounts,
+            newMetadataHashes,
+            [revealHashA]
+          );
+          expect(result.events[2].event).to.equal('AssetRevealMint');
+          const newTokenId = result.events[2].args.newTokenIds[0];
+          const balance = await AssetContract.balanceOf(
+            user.address,
+            newTokenId
+          );
+          expect(balance.toString()).to.equal('1');
+        });
+        it('Should allow minting when multiple copies revealed to the same metadata hash', async function () {
+          const {
+            user,
+            unrevealedtokenId,
+            AssetContract,
+            revealAsset,
+            generateRevealSignature,
+          } = await runRevealTestSetup();
+          const newMetadataHashes = [
+            'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJF',
+          ];
+          const amounts = [2];
+          const signature = await generateRevealSignature(
+            user.address,
+            unrevealedtokenId,
+            amounts,
+            newMetadataHashes,
+            [revealHashA]
+          );
+          const result = await revealAsset(
+            signature,
+            unrevealedtokenId,
+            amounts,
+            newMetadataHashes,
+            [revealHashA]
+          );
+          expect(result.events[2].event).to.equal('AssetRevealMint');
+          expect(result.events[2].args['newTokenIds'].length).to.equal(1);
+          const newTokenId = result.events[2].args.newTokenIds[0];
+          const balance = await AssetContract.balanceOf(
+            user.address,
+            newTokenId
+          );
+          expect(balance.toString()).to.equal('2');
+        });
+        it('should increase the tokens supply for tokens with same metadata hash', async function () {
+          const {
+            user,
+            unrevealedtokenId,
+            generateRevealSignature,
+            revealAsset,
+            AssetContract,
+          } = await runRevealTestSetup();
+          const newMetadataHashes = [
+            'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJF',
+          ];
+          const amounts = [1];
+          const signature = await generateRevealSignature(
+            user.address,
+            unrevealedtokenId,
+            amounts,
+            newMetadataHashes,
+            [revealHashA]
+          );
+          const result = await revealAsset(
+            signature,
+            unrevealedtokenId,
+            amounts,
+            newMetadataHashes,
+            [revealHashA]
+          );
+          const newTokenId = result.events[2].args.newTokenIds[0];
+          const balance = await AssetContract.balanceOf(
+            user.address,
+            newTokenId
+          );
+          expect(balance.toString()).to.equal('1');
+          const signature2 = await generateRevealSignature(
+            user.address,
+            unrevealedtokenId,
+            amounts,
+            newMetadataHashes,
+            [revealHashB]
+          );
+          await revealAsset(
+            signature2,
+            unrevealedtokenId,
+            amounts,
+            newMetadataHashes,
+            [revealHashB]
+          );
+          const balance2 = await AssetContract.balanceOf(
+            user.address,
+            newTokenId
+          );
+          expect(balance2.toString()).to.equal('2');
+        });
+        it('Should allow revealing multiple copies at the same time', async function () {
+          const {
+            user,
+            generateRevealSignature,
+            revealAsset,
+            unrevealedtokenId,
+          } = await runRevealTestSetup();
+          const newMetadataHashes = [
+            'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJ1',
+            'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJ2',
+            'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJ3',
+            'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJ4',
+            'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJ5',
+            'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJ6',
+          ];
+          const amountToMint = [1, 2, 1, 7, 1, 2];
+          const signature = await generateRevealSignature(
+            user.address,
+            unrevealedtokenId,
+            amountToMint,
+            newMetadataHashes,
+            [
+              revealHashA,
+              revealHashB,
+              revealHashC,
+              revealHashD,
+              revealHashE,
+              revealHashF,
+            ]
+          );
+
+          const result = await revealAsset(
+            signature,
+            unrevealedtokenId,
+            amountToMint,
+            newMetadataHashes,
+            [
+              revealHashA,
+              revealHashB,
+              revealHashC,
+              revealHashD,
+              revealHashE,
+              revealHashF,
+            ]
+          );
+          expect(result.events[7].event).to.equal('AssetRevealMint');
+          expect(result.events[7].args['newTokenIds'].length).to.equal(6);
+        });
+      });
+      describe('Revert', function () {
+        it('Should revert if amounts array is not the same length as metadataHashes array', async function () {
+          const {
+            user,
+            generateRevealSignature,
+            revealAsset,
+            unrevealedtokenId,
+          } = await runRevealTestSetup();
+
+          const newMetadataHashes = [
+            'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcf',
+            'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcg',
+          ];
+
+          const amounts = [1, 2, 3];
+
+          const signature = await generateRevealSignature(
+            user.address,
+            unrevealedtokenId,
+            amounts,
+            newMetadataHashes,
+            [revealHashA, revealHashB]
+          );
+
+          await expect(
+            revealAsset(
+              signature,
+              unrevealedtokenId,
+              amounts,
+              newMetadataHashes,
+              [revealHashA, revealHashB]
+            )
+          ).to.be.revertedWith('AssetReveal: Invalid amounts length');
+        });
+        it('Should revert if amounts array is not the same length as revealHashes array', async function () {
+          const {
+            user,
+            generateRevealSignature,
+            revealAsset,
+            unrevealedtokenId,
+          } = await runRevealTestSetup();
+
+          const newMetadataHashes = [
+            'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcf',
+            'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcg',
+          ];
+
+          const amounts = [1, 2];
+
+          const signature = await generateRevealSignature(
+            user.address,
+            unrevealedtokenId,
+            amounts,
+            newMetadataHashes,
+            [revealHashA, revealHashB, revealHashC]
+          );
+
+          await expect(
+            revealAsset(
+              signature,
+              unrevealedtokenId,
+              amounts,
+              newMetadataHashes,
+              [revealHashA, revealHashB, revealHashC]
+            )
+          ).to.be.revertedWith('AssetReveal: Invalid revealHashes length');
+        });
+        it('Should not allow using the same signature twice', async function () {
+          const {
+            user,
+            generateRevealSignature,
+            revealAsset,
+            unrevealedtokenId,
+          } = await runRevealTestSetup();
+          const newMetadataHashes = [
+            'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJF',
+          ];
+          const amounts = [1];
+          const signature = await generateRevealSignature(
+            user.address,
+            unrevealedtokenId,
+            amounts,
+            newMetadataHashes,
+            [revealHashA]
+          );
+
+          await expect(
+            revealAsset(
+              signature,
+              unrevealedtokenId,
+              amounts,
+              newMetadataHashes,
+              [revealHashA]
+            )
+          ).not.to.be.reverted;
+
+          await expect(
+            revealAsset(
+              signature,
+              unrevealedtokenId,
+              amounts,
+              newMetadataHashes,
+              [revealHashA]
+            )
+          ).to.be.revertedWith('AssetReveal: RevealHash already used');
+        });
+      });
+      describe('Events', function () {
+        // TODO
+      });
+    });
+    describe('Batch reveal mint', function () {
+      describe('Success', function () {
+        it('Should allow batch reveal minting with valid signatures', async function () {
+          const {
+            user,
+            revealAssetBatch,
+            generateBatchRevealSignature,
+            unrevealedtokenId,
+            unrevealedtokenId2,
+          } = await runRevealTestSetup();
+          const newMetadataHashes1 = [
+            'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJF',
+          ];
+          const newMetadataHashes2 = [
+            'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJZ',
+          ];
+          const amounts1 = [1];
+          const amounts2 = [1];
+
+          const signature = await generateBatchRevealSignature(
+            user.address,
+            [unrevealedtokenId, unrevealedtokenId2],
+            [amounts1, amounts2],
+            [newMetadataHashes1, newMetadataHashes2],
+            [[revealHashA], [revealHashB]]
+          );
+
+          const result = await revealAssetBatch(
+            signature,
+            [unrevealedtokenId, unrevealedtokenId2],
+            [amounts1, amounts2],
+            [newMetadataHashes1, newMetadataHashes2],
+            [[revealHashA], [revealHashB]]
+          );
+
+          // expect two events with name AssetsRevealed
+          expect(result.events[2].event).to.equal('AssetRevealMint');
+          expect(result.events[5].event).to.equal('AssetRevealMint');
+        });
+        it("should allow batch reveal of the same token's copies", async function () {
+          const {
+            user,
+            revealAssetBatch,
+            generateBatchRevealSignature,
+            unrevealedtokenId,
+            AssetContract,
+          } = await runRevealTestSetup();
+          const newMetadataHashes1 = [
+            'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcf',
+            'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcg',
+          ];
+          const newMetadataHashes2 = [
+            'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcg',
+            'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXch',
+          ];
+          const amounts1 = [1, 2];
+
+          const signature = await generateBatchRevealSignature(
+            user.address,
+            [unrevealedtokenId, unrevealedtokenId],
+            [amounts1, amounts1],
+            [newMetadataHashes1, newMetadataHashes2],
+            [
+              [revealHashA, revealHashB],
+              [revealHashC, revealHashD],
+            ]
+          );
+
+          const result = await revealAssetBatch(
+            signature,
+            [unrevealedtokenId, unrevealedtokenId],
+            [amounts1, amounts1],
+            [newMetadataHashes1, newMetadataHashes2],
+            [
+              [revealHashA, revealHashB],
+              [revealHashC, revealHashD],
+            ]
+          );
+
+          // three tokens should be minted with amounts 1, 3,2
+          expect(result.events[3].event).to.equal('AssetRevealMint');
+          expect(result.events[3].args['newTokenIds'].length).to.equal(2);
+
+          expect(result.events[6].event).to.equal('AssetRevealMint');
+          expect(result.events[6].args['newTokenIds'].length).to.equal(2);
+
+          const allNewTokenIds = [
+            ...result.events[3].args['newTokenIds'],
+            ...result.events[6].args['newTokenIds'],
+          ];
+
+          // deduplicate, deep equality
+          const deduplicated = allNewTokenIds.filter(
+            (v, i, a) => a.findIndex((t) => t.eq(v)) === i
+          );
+
+          expect(deduplicated.length).to.equal(3);
+          // check balances
+          const balance1 = await AssetContract.balanceOf(
+            user.address,
+            deduplicated[0]
+          );
+
+          const balance2 = await AssetContract.balanceOf(
+            user.address,
+            deduplicated[1]
+          );
+
+          const balance3 = await AssetContract.balanceOf(
+            user.address,
+            deduplicated[2]
+          );
+
+          expect(balance1.toString()).to.equal('1');
+          expect(balance2.toString()).to.equal('3');
+          expect(balance3.toString()).to.equal('2');
+        });
+      });
+      describe('Revert', function () {
+        it('Should revert if ids array and amounts array are not the same length', async function () {
+          const {
+            user,
+            generateBatchRevealSignature,
+            revealAssetBatch,
+            unrevealedtokenId,
+            unrevealedtokenId2,
+          } = await runRevealTestSetup();
+          const newMetadataHashes1 = ['QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcf'];
+          const newMetadataHashes2 = ['QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcg'];
+          const amounts1 = [1];
+          const amounts2 = [1, 2];
+          const amounts3 = [1, 2];
+
+          const signature = await generateBatchRevealSignature(
+            user.address,
+            [unrevealedtokenId, unrevealedtokenId2],
+            [amounts1, amounts2, amounts3],
+            [newMetadataHashes1, newMetadataHashes2],
+            [[revealHashA], [revealHashB]]
+          );
+
+          await expect(
+            revealAssetBatch(
+              signature,
+              [unrevealedtokenId, unrevealedtokenId2],
+              [amounts1, amounts2, amounts3],
+              [newMetadataHashes1, newMetadataHashes2],
+              [[revealHashA], [revealHashB]]
+            )
+          ).to.be.revertedWith('AssetReveal: Invalid amounts length');
+        });
+        it('Should revert if ids array and metadataHashes array are not the same length', async function () {
+          const {
+            user,
+            generateBatchRevealSignature,
+            revealAssetBatch,
+            unrevealedtokenId,
+            unrevealedtokenId2,
+          } = await runRevealTestSetup();
+          const newMetadataHashes1 = ['QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcf'];
+          const amounts1 = [1];
+          const amounts2 = [1];
+
+          const signature = await generateBatchRevealSignature(
+            user.address,
+            [unrevealedtokenId, unrevealedtokenId2],
+            [amounts1, amounts2],
+            [newMetadataHashes1],
+            [[revealHashA], [revealHashB]]
+          );
+
+          await expect(
+            revealAssetBatch(
+              signature,
+              [unrevealedtokenId, unrevealedtokenId2],
+              [amounts1, amounts2],
+              [newMetadataHashes1],
+              [[revealHashA], [revealHashB]]
+            )
+          ).to.be.revertedWith('AssetReveal: Invalid metadataHashes length');
+        });
+        it('Should revert if ids array and revealHashes array are not the same length', async function () {
+          const {
+            user,
+            generateBatchRevealSignature,
+            revealAssetBatch,
+            unrevealedtokenId,
+            unrevealedtokenId2,
+          } = await runRevealTestSetup();
+          const newMetadataHashes1 = ['QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcf'];
+          const newMetadataHashes2 = ['QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcg'];
+          const amounts1 = [1];
+          const amounts2 = [1];
+
+          const signature = await generateBatchRevealSignature(
+            user.address,
+            [unrevealedtokenId, unrevealedtokenId2],
+            [amounts1, amounts2],
+            [newMetadataHashes1, newMetadataHashes2],
+            [[revealHashA]]
+          );
+
+          await expect(
+            revealAssetBatch(
+              signature,
+              [unrevealedtokenId, unrevealedtokenId2],
+              [amounts1, amounts2],
+              [newMetadataHashes1, newMetadataHashes2],
+              [[revealHashA]]
+            )
+          ).to.be.revertedWith('AssetReveal: Invalid revealHashes length');
+        });
+        it('should not allow using the same signature twice', async function () {
+          const {
+            user,
+            generateBatchRevealSignature,
+            revealAssetBatch,
+            unrevealedtokenId,
+            unrevealedtokenId2,
+          } = await runRevealTestSetup();
+          const newMetadataHashes1 = ['QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcf'];
+          const newMetadataHashes2 = ['QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcg'];
+          const amounts1 = [1];
+          const amounts2 = [1];
+
+          const signature = await generateBatchRevealSignature(
+            user.address,
+            [unrevealedtokenId, unrevealedtokenId2],
+            [amounts1, amounts2],
+            [newMetadataHashes1, newMetadataHashes2],
+            [[revealHashA], [revealHashB]]
+          );
+
+          await expect(
+            revealAssetBatch(
+              signature,
+              [unrevealedtokenId, unrevealedtokenId2],
+              [amounts1, amounts2],
+              [newMetadataHashes1, newMetadataHashes2],
+              [[revealHashA], [revealHashB]]
+            )
+          ).not.to.be.reverted;
+
+          await expect(
+            revealAssetBatch(
+              signature,
+              [unrevealedtokenId, unrevealedtokenId2],
+              [amounts1, amounts2],
+              [newMetadataHashes1, newMetadataHashes2],
+              [[revealHashA], [revealHashB]]
+            )
+          ).to.be.revertedWith('AssetReveal: RevealHash already used');
+        });
+      });
+      describe('Events', function () {
+        // TODO
+      });
+    });
+    describe('Burn and reveal mint', function () {
+      describe('Success', function () {
+        it('Should allow instant reveal when authorized by the backend', async function () {
+          const {
+            user,
+            generateBurnAndRevealSignature,
+            instantReveal,
+            unrevealedtokenId,
+          } = await runRevealTestSetup();
+          const newMetadataHash = [
+            'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJF',
+          ];
+          const amounts = [1];
+
+          const signature = await generateBurnAndRevealSignature(
+            user.address,
+            unrevealedtokenId,
+            amounts,
+            newMetadataHash,
+            [revealHashA]
+          );
+
+          const result = await instantReveal(
+            signature,
+            unrevealedtokenId,
+            amounts[0],
+            amounts,
+            newMetadataHash,
+            [revealHashA]
+          );
+          expect(result.events[3].event).to.equal('AssetRevealMint');
+        });
+      });
+      describe('Revert', function () {
+        // TODO all below
+        it("should revert if amounts array isn't the same length as metadataHashes array", async function () {});
+        it("should revert if amounts array isn't the same length as revealHashes array", async function () {});
+      });
+      describe('Events', function () {
+        it("Should emit AssetRevealBurn event with correct data when burning and revealing a single token's copy", async function () {});
+        it('Should emit AssetRevealMint event with correct data when burning and revealing a single token', async function () {});
+      });
     });
   });
 });

--- a/packages/asset/test/AssetReveal.test.ts
+++ b/packages/asset/test/AssetReveal.test.ts
@@ -2,6 +2,7 @@ import {expect} from 'chai';
 import {formatBytes32String} from 'ethers/lib/utils';
 import {runRevealTestSetup} from './fixtures/assetRevealFixtures';
 import {ethers} from 'hardhat';
+import {Event} from 'ethers';
 
 const revealHashA = formatBytes32String('revealHashA');
 const revealHashB = formatBytes32String('revealHashB');
@@ -1136,7 +1137,7 @@ describe('AssetReveal', function () {
           );
 
           const revealEvents = result.events.filter(
-            (event: any) => event.event === 'AssetRevealMint'
+            (event: Event) => event.event === 'AssetRevealMint'
           );
           expect(revealEvents.length).to.equal(2);
         });
@@ -1169,7 +1170,7 @@ describe('AssetReveal', function () {
             [[revealHashA], [revealHashB]]
           );
           const revealEvents = result.events.filter(
-            (event: any) => event.event === 'AssetRevealMint'
+            (event: Event) => event.event === 'AssetRevealMint'
           );
           const args1 = revealEvents[0].args;
           const args2 = revealEvents[1].args;
@@ -1219,7 +1220,7 @@ describe('AssetReveal', function () {
             [revealHashA]
           );
           const revealMintEvent = result.events.filter(
-            (event: any) => event.event === 'AssetRevealMint'
+            (event: Event) => event.event === 'AssetRevealMint'
           )[0];
           expect(revealMintEvent).to.not.be.undefined;
         });
@@ -1318,7 +1319,7 @@ describe('AssetReveal', function () {
             [revealHashA]
           );
           const burnEvent = result.events.filter(
-            (event: any) => event.event === 'AssetRevealBurn'
+            (event: Event) => event.event === 'AssetRevealBurn'
           )[0];
           expect(burnEvent.args['revealer']).to.equal(user.address);
           expect(burnEvent.args['unrevealedTokenId']).to.equal(
@@ -1355,7 +1356,7 @@ describe('AssetReveal', function () {
             [revealHashA]
           );
           const revealMintEvent = result.events.filter(
-            (event: any) => event.event === 'AssetRevealMint'
+            (event: Event) => event.event === 'AssetRevealMint'
           )[0];
           expect(revealMintEvent.args['recipient']).to.equal(user.address);
           expect(revealMintEvent.args['unrevealedTokenId']).to.equal(

--- a/packages/asset/test/fixtures/assetRevealFixtures.ts
+++ b/packages/asset/test/fixtures/assetRevealFixtures.ts
@@ -46,6 +46,13 @@ export async function runRevealTestSetup() {
 
   await AssetContract.deployed();
 
+  // deploy wrapped TokenIdUtils contract
+  const TokenIdUtilsFactory = await ethers.getContractFactory(
+    'TokenIdUtilsWrapped'
+  );
+  const TokenIdUtilsContract = await TokenIdUtilsFactory.deploy();
+  await TokenIdUtilsContract.deployed();
+
   const CatalystFactory = await ethers.getContractFactory('Catalyst');
   const CatalystContract = await upgrades.deployProxy(
     CatalystFactory,
@@ -273,6 +280,7 @@ export async function runRevealTestSetup() {
     AssetRevealContract,
     AssetRevealContractAsUser,
     AssetRevealContractAsAdmin,
+    TokenIdUtilsContract,
     AssetContract,
     AuthValidatorContract,
     trustedForwarder,

--- a/packages/asset/test/fixtures/assetRevealFixtures.ts
+++ b/packages/asset/test/fixtures/assetRevealFixtures.ts
@@ -84,6 +84,7 @@ export async function runRevealTestSetup() {
       AssetContract.address,
       AuthValidatorContract.address,
       trustedForwarder.address,
+      assetAdmin.address,
     ],
     {
       initializer: 'initialize',
@@ -279,5 +280,6 @@ export async function runRevealTestSetup() {
     unrevealedtokenId2,
     revealedtokenId,
     user,
+    assetAdmin,
   };
 }

--- a/packages/asset/test/fixtures/assetRevealFixtures.ts
+++ b/packages/asset/test/fixtures/assetRevealFixtures.ts
@@ -79,6 +79,10 @@ export async function runRevealTestSetup() {
     backendAuthWallet.address
   );
 
+  const MockAssetReveal = await ethers.getContractFactory('MockAssetReveal');
+  const MockAssetRevealContract = await MockAssetReveal.deploy();
+  await MockAssetRevealContract.deployed();
+
   // END DEPLOY DEPENDENCIES
 
   const AssetRevealFactory = await ethers.getContractFactory('AssetReveal');
@@ -112,6 +116,7 @@ export async function runRevealTestSetup() {
   // add mock minter as minter
   const MinterRole = await AssetContract.MINTER_ROLE();
   const BurnerRole = await AssetContract.BURNER_ROLE();
+  const AdminRole = await AssetContract.DEFAULT_ADMIN_ROLE();
   await AssetContractAsAdmin.grantRole(MinterRole, MockMinterContract.address);
 
   // add AssetReveal contracts as both MINTER and BURNER for Asset contract
@@ -280,6 +285,7 @@ export async function runRevealTestSetup() {
     AssetRevealContract,
     AssetRevealContractAsUser,
     AssetRevealContractAsAdmin,
+    MockAssetRevealContract,
     TokenIdUtilsContract,
     AssetContract,
     AuthValidatorContract,
@@ -287,6 +293,7 @@ export async function runRevealTestSetup() {
     unrevealedtokenId,
     unrevealedtokenId2,
     revealedtokenId,
+    AdminRole,
     user,
     assetAdmin,
   };

--- a/packages/asset/test/utils/revealSignature.ts
+++ b/packages/asset/test/utils/revealSignature.ts
@@ -1,5 +1,6 @@
 import hre from 'hardhat';
 import {Contract, Wallet} from 'ethers';
+import {SignerWithAddress} from '@nomiclabs/hardhat-ethers/signers';
 
 async function burnAndRevealSignature(
   recipient: string,
@@ -8,7 +9,7 @@ async function burnAndRevealSignature(
   metadataHashes: string[],
   revealHashes: string[],
   contract: Contract,
-  signer: Wallet
+  signer: SignerWithAddress
 ): Promise<string> {
   const AssetRevealContract = contract;
   const data = {
@@ -50,7 +51,7 @@ async function batchRevealSignature(
   metadataHashes: string[][],
   revealHashes: string[][],
   contract: Contract,
-  signer: Wallet
+  signer: SignerWithAddress
 ): Promise<string> {
   const AssetRevealContract = contract;
   const data = {
@@ -93,7 +94,7 @@ async function revealSignature(
   metadataHashes: string[],
   revealHashes: string[],
   contract: Contract,
-  signer: Wallet
+  signer: SignerWithAddress
 ): Promise<string> {
   const AssetRevealContract = contract;
   const data = {

--- a/packages/asset/test/utils/revealSignature.ts
+++ b/packages/asset/test/utils/revealSignature.ts
@@ -1,5 +1,5 @@
 import hre from 'hardhat';
-import {Contract, Wallet} from 'ethers';
+import {Contract} from 'ethers';
 import {SignerWithAddress} from '@nomiclabs/hardhat-ethers/signers';
 
 async function burnAndRevealSignature(

--- a/packages/deploy/deploy/400_asset/404_deploy_asset_reveal.ts
+++ b/packages/deploy/deploy/400_asset/404_deploy_asset_reveal.ts
@@ -4,7 +4,7 @@ import {DeployFunction} from 'hardhat-deploy/types';
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const {deployments, getNamedAccounts} = hre;
   const {deploy} = deployments;
-  const {deployer, upgradeAdmin} = await getNamedAccounts();
+  const {deployer, upgradeAdmin, assetAdmin} = await getNamedAccounts();
 
   const AssetContract = await deployments.get('Asset');
   const AuthValidatorContract = await deployments.get('AssetAuthValidator');
@@ -13,8 +13,6 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const version = '1.0';
 
   const TRUSTED_FORWARDER = await deployments.get('TRUSTED_FORWARDER_V2');
-
-  // TODO: who is DEFAULT_ADMIN ?
 
   await deploy('AssetReveal', {
     from: deployer,
@@ -31,6 +29,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
           AssetContract.address,
           AuthValidatorContract.address,
           TRUSTED_FORWARDER.address,
+          assetAdmin,
         ],
       },
       upgradeIndex: 0,


### PR DESCRIPTION
## Improve tests for AssetReveal

The PR updates the AssetReveal implementation by applying more tests and covering a few todos pointed out by @atkinsonholly.

The changes involve:

- Tested all events, reverts and covered more scenarios
- Add admin role to AssetReveal
- Add new `AssetRevealBatchBurn` event when burning a batch of tokens rather than emitting multiple burn events
- Update the revert messages 
- Add batch burning function
- Add the ability to change trusted forwarder




