### PR TITLE
Moderation

### DIFF
--- a/packages/asset/contracts/Asset.sol
+++ b/packages/asset/contracts/Asset.sol
@@ -148,11 +148,7 @@ contract Asset is
     /// @dev The metadata hash should be the IPFS CIDv1 base32 encoded hash
     /// @param tokenId The token id to set URI for
     /// @param metadata The new URI for asset's metadata
-    function setTokenURI(uint256 tokenId, string memory metadata) external {
-        require(
-            hasRole(MODERATOR_ROLE, _msgSender()) || hasRole(DEFAULT_ADMIN_ROLE, _msgSender()),
-            "Asset: must have moderator or admin role to set token URI"
-        );
+    function setTokenURI(uint256 tokenId, string memory metadata) external onlyRole(MODERATOR_ROLE) {
         _setURI(tokenId, metadata);
     }
 
@@ -179,7 +175,6 @@ contract Asset is
     }
 
     function _setMetadataHash(uint256 tokenId, string memory metadataHash) internal {
-        require(hasRole(MINTER_ROLE, _msgSender()), "Asset: must have minter or admin role to mint");
         if (hashUsed[metadataHash] != 0) {
             require(hashUsed[metadataHash] == tokenId, "Asset: not allowed to reuse metadata hash");
         } else {

--- a/packages/asset/contracts/Asset.sol
+++ b/packages/asset/contracts/Asset.sol
@@ -46,6 +46,7 @@ contract Asset is
 
     bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
     bytes32 public constant BURNER_ROLE = keccak256("BURNER_ROLE");
+    bytes32 public constant MODERATOR_ROLE = keccak256("MODERATOR_ROLE");
 
     // mapping of ipfs metadata token hash to token id
     mapping(string => uint256) public hashUsed;
@@ -147,8 +148,11 @@ contract Asset is
     /// @dev The metadata hash should be the IPFS CIDv1 base32 encoded hash
     /// @param tokenId The token id to set URI for
     /// @param metadata The new URI for asset's metadata
-    function setTokenURI(uint256 tokenId, string memory metadata) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        _setMetadataHash(tokenId, metadata);
+    function setTokenURI(uint256 tokenId, string memory metadata) external {
+        require(
+            hasRole(MODERATOR_ROLE, _msgSender()) || hasRole(DEFAULT_ADMIN_ROLE, _msgSender()),
+            "Asset: must have moderator or admin role to set token URI"
+        );
         _setURI(tokenId, metadata);
     }
 
@@ -175,10 +179,7 @@ contract Asset is
     }
 
     function _setMetadataHash(uint256 tokenId, string memory metadataHash) internal {
-        require(
-            hasRole(MINTER_ROLE, _msgSender()) || hasRole(DEFAULT_ADMIN_ROLE, _msgSender()),
-            "Asset: must have minter or admin role to mint"
-        );
+        require(hasRole(MINTER_ROLE, _msgSender()), "Asset: must have minter or admin role to mint");
         if (hashUsed[metadataHash] != 0) {
             require(hashUsed[metadataHash] == tokenId, "Asset: not allowed to reuse metadata hash");
         } else {

--- a/packages/asset/docs/Asset.md
+++ b/packages/asset/docs/Asset.md
@@ -7,12 +7,14 @@ This is the base Asset L2 contract that serves as an upgradeable, burnable ERC11
 1. **Minter**: This role can create new tokens using the `mint` or `mintBatch` functions.
 2. **Burner**: This role can destroy tokens using the `burnFrom` or `burnBatchFrom` functions.
 3. **Admin**: This role has broad administrative permissions including the ability to set URIs and change the trusted forwarder.
+4. **Moderator**: This role has the ability to set URIs.
 
 ## Public Variables
 
 1. `MINTER_ROLE` - A bytes32 value representing the role that can mint new tokens.
 2. `BURNER_ROLE` - A bytes32 value representing the role that can burn tokens.
-3. `hashUsed` - A mapping from string metadata hashes to uint256 token IDs.
+3. `MODERATOR_ROLE` - A bytes32 value representing the role that can set URIs.
+4. `hashUsed` - A mapping from string metadata hashes to uint256 token IDs.
 
 ## Functions
 

--- a/packages/asset/docs/Asset.md
+++ b/packages/asset/docs/Asset.md
@@ -118,7 +118,7 @@ Parameters:
 function setTokenURI(uint256 tokenId, string memory metadata) external
 ```
 
-Sets a new URI for a specific token, only available to DEFAULT_ADMIN_ROLE or MODERATOR_ROLE.
+Sets a new URI for a specific token, only available to MODERATOR_ROLE.
 
 Parameters:
 

--- a/packages/asset/docs/Asset.md
+++ b/packages/asset/docs/Asset.md
@@ -113,10 +113,10 @@ Parameters:
 ### setTokenURI
 
 ```solidity
-function setTokenURI(uint256 tokenId, string memory metadata) external onlyRole(DEFAULT_ADMIN_ROLE)
+function setTokenURI(uint256 tokenId, string memory metadata) external
 ```
 
-Sets a new URI for a specific token.
+Sets a new URI for a specific token, only available to DEFAULT_ADMIN_ROLE or MODERATOR_ROLE.
 
 Parameters:
 

--- a/packages/asset/test/Asset.test.ts
+++ b/packages/asset/test/Asset.test.ts
@@ -173,18 +173,13 @@ describe('Base Asset Contract (/packages/asset/contracts/Asset.sol)', function (
       expect(newTokenURI).to.be.equal(baseURI + metadataHashes[1]);
     });
     it('Should not allow unauthorized accounts to change token URI', async function () {
-      const {
-        AssetContractAsMinter,
-        minter,
-        mintOne,
-        metadataHashes,
-        defaultAdminRole,
-      } = await runAssetSetup();
+      const {AssetContractAsMinter, mintOne, metadataHashes} =
+        await runAssetSetup();
       const {tokenId} = await mintOne();
       await expect(
         AssetContractAsMinter.setTokenURI(tokenId, metadataHashes[1])
       ).to.be.revertedWith(
-        `AccessControl: account ${minter.address.toLowerCase()} is missing role ${defaultAdminRole}`
+        'Asset: must have moderator or admin role to set token URI'
       );
     });
   });

--- a/packages/asset/test/Asset.test.ts
+++ b/packages/asset/test/Asset.test.ts
@@ -135,21 +135,6 @@ describe('Base Asset Contract (/packages/asset/contracts/Asset.sol)', function (
       const tokenURI = await AssetContract.uri(tokenId);
       expect(tokenURI).to.be.equal(baseURI + metadataHashes[0]);
     });
-    it('Should allow DEFAULT_ADMIN to change token URI', async function () {
-      const {
-        AssetContract,
-        AssetContractAsAdmin,
-        mintOne,
-        metadataHashes,
-        baseURI,
-      } = await runAssetSetup();
-      const {tokenId} = await mintOne();
-      const tokenURI = await AssetContract.uri(tokenId);
-      expect(tokenURI).to.be.equal(baseURI + metadataHashes[0]);
-      await AssetContractAsAdmin.setTokenURI(tokenId, metadataHashes[1]);
-      const newTokenURI = await AssetContract.uri(tokenId);
-      expect(newTokenURI).to.be.equal(baseURI + metadataHashes[1]);
-    });
     it('Should allow MODERATOR_ROLE to change token URI', async function () {
       const {
         AssetContract,
@@ -173,13 +158,15 @@ describe('Base Asset Contract (/packages/asset/contracts/Asset.sol)', function (
       expect(newTokenURI).to.be.equal(baseURI + metadataHashes[1]);
     });
     it('Should not allow unauthorized accounts to change token URI', async function () {
-      const {AssetContractAsMinter, mintOne, metadataHashes} =
+      const {AssetContractAsMinter, mintOne, metadataHashes, minter} =
         await runAssetSetup();
       const {tokenId} = await mintOne();
       await expect(
         AssetContractAsMinter.setTokenURI(tokenId, metadataHashes[1])
       ).to.be.revertedWith(
-        'Asset: must have moderator or admin role to set token URI'
+        `AccessControl: account ${minter.address.toLowerCase()} is missing role ${ethers.utils.id(
+          'MODERATOR_ROLE'
+        )}`
       );
     });
   });


### PR DESCRIPTION
## Description

Add the possibility to moderate metadata by a `Moderator`. Using `setTokenURI ` no longer verifies if a specific metadata hash has already been assigned to another tokenId allowing moderators to set the same metadata hash for all tokens that should be moderated.

- Add new moderator role that can update URIs
- Update documentation
- Add test for moderator role

[Link to Jira Issue](https://internal-jira.atlassian.net/browse/AL2-111)
