### PR TITLE
Update catalyst tiers and adding new ones

### DIFF
--- a/packages/asset/contracts/Catalyst.sol
+++ b/packages/asset/contracts/Catalyst.sol
@@ -55,7 +55,7 @@ contract Catalyst is
     bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
     bytes32 public constant BURNER_ROLE = keccak256("BURNER_ROLE");
 
-    uint256 public tokenCount;
+    uint256 public highestTierIndex;
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -63,7 +63,7 @@ contract Catalyst is
     }
 
     modifier onlyValidId(uint256 tokenId) {
-        require(tokenId > 0 && tokenId <= tokenCount, "Catalyst: invalid catalyst id");
+        require(tokenId > 0 && tokenId <= highestTierIndex, "Catalyst: invalid catalyst id");
         _;
     }
 
@@ -104,7 +104,7 @@ contract Catalyst is
         for (uint256 i = 0; i < _catalystIpfsCID.length; i++) {
             require(bytes(_catalystIpfsCID[i]).length != 0, "Catalyst: CID can't be empty");
             _setURI(i, _catalystIpfsCID[i]);
-            unchecked {tokenCount++;}
+            highestTierIndex = i;
         }
     }
 
@@ -130,7 +130,7 @@ contract Catalyst is
         uint256[] memory amounts
     ) external onlyRole(MINTER_ROLE) {
         for (uint256 i = 0; i < ids.length; i++) {
-            require(ids[i] > 0 && ids[i] <= tokenCount, "INVALID_CATALYST_ID");
+            require(ids[i] > 0 && ids[i] <= highestTierIndex, "Catalyst: invalid catalyst id");
         }
         _mintBatch(to, ids, amounts, "");
     }
@@ -160,14 +160,12 @@ contract Catalyst is
     }
 
     /// @notice Add a new catalyst type, limited to DEFAULT_ADMIN_ROLE only
-    /// @param catalystId The catalyst id to add
     /// @param ipfsCID The royalty bps for the catalyst
-    function addNewCatalystType(uint256 catalystId, string memory ipfsCID) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        require(catalystId > tokenCount, "Catalyst: invalid catalyst id");
+    function addNewCatalystType(string memory ipfsCID) external onlyRole(DEFAULT_ADMIN_ROLE) {
         require(bytes(ipfsCID).length != 0, "Catalyst: CID can't be empty");
-        tokenCount++;
-        ERC1155URIStorageUpgradeable._setURI(catalystId, ipfsCID);
-        emit NewCatalystTypeAdded(catalystId);
+        uint256 newCatId = ++highestTierIndex;
+        ERC1155URIStorageUpgradeable._setURI(newCatId, ipfsCID);
+        emit NewCatalystTypeAdded(newCatId);
     }
 
     /// @notice Set a new trusted forwarder address, limited to DEFAULT_ADMIN_ROLE only

--- a/packages/asset/contracts/interfaces/ICatalyst.sol
+++ b/packages/asset/contracts/interfaces/ICatalyst.sol
@@ -49,9 +49,8 @@ interface ICatalyst {
     ) external;
 
     /// @notice Add a new catalyst type, limited to DEFAULT_ADMIN_ROLE only
-    /// @param catalystId The catalyst id to add
     /// @param ipfsCID The royalty bps for the catalyst
-    function addNewCatalystType(uint256 catalystId, string memory ipfsCID) external;
+    function addNewCatalystType(string memory ipfsCID) external;
 
     /// @notice Set a new URI for specific tokenid
     /// @param tokenId The token id to set URI for

--- a/packages/asset/test/Catalyst.test.ts
+++ b/packages/asset/test/Catalyst.test.ts
@@ -6,7 +6,7 @@ import {CATALYST_BASE_URI, CATALYST_IPFS_CID_PER_TIER} from '../data/constants';
 const catalystArray = [0, 1, 2, 3, 4, 5, 6];
 const zeroAddress = '0x0000000000000000000000000000000000000000';
 
-describe.only('Catalyst (/packages/asset/contracts/Catalyst.sol)', function () {
+describe('Catalyst (/packages/asset/contracts/Catalyst.sol)', function () {
   describe('Contract setup', function () {
     it('Should deploy correctly', async function () {
       const {

--- a/packages/asset/test/Catalyst.test.ts
+++ b/packages/asset/test/Catalyst.test.ts
@@ -265,7 +265,25 @@ describe('Catalyst (/packages/asset/contracts/Catalyst.sol)', function () {
       await catalystAsAdmin.addNewCatalystType('0x01');
       expect(await catalystAsAdmin.uri(7)).to.be.equal('ipfs://0x01');
     });
-
+    it('correctly increases highest tier index on adding new catalyst', async function () {
+      const {catalystAsAdmin} = await runCatalystSetup();
+      expect(await catalystAsAdmin.highestTierIndex()).to.be.equal(6);
+      await catalystAsAdmin.addNewCatalystType('0x01');
+      expect(await catalystAsAdmin.highestTierIndex()).to.be.equal(7);
+    });
+    it('emits NewCatalystTypeAdded event on adding new catalyst with id one higher than the previous highest tier', async function () {
+      const {catalystAsAdmin} = await runCatalystSetup();
+      expect(await catalystAsAdmin.highestTierIndex()).to.be.equal(6);
+      await expect(catalystAsAdmin.addNewCatalystType('0x01'))
+        .to.emit(catalystAsAdmin, 'NewCatalystTypeAdded')
+        .withArgs(7);
+    });
+    it('sets the URI for newly created catalyst tier correctly', async function () {
+      const {catalystAsAdmin} = await runCatalystSetup();
+      expect(await catalystAsAdmin.highestTierIndex()).to.be.equal(6);
+      await catalystAsAdmin.addNewCatalystType('0x01');
+      expect(await catalystAsAdmin.uri(7)).to.be.equal('ipfs://0x01');
+    });
     it('only Admin can add new catalyst', async function () {
       const {catalyst, user1, catalystAdminRole} = await runCatalystSetup();
 

--- a/packages/asset/test/Catalyst.test.ts
+++ b/packages/asset/test/Catalyst.test.ts
@@ -6,7 +6,7 @@ import {CATALYST_BASE_URI, CATALYST_IPFS_CID_PER_TIER} from '../data/constants';
 const catalystArray = [0, 1, 2, 3, 4, 5, 6];
 const zeroAddress = '0x0000000000000000000000000000000000000000';
 
-describe('Catalyst (/packages/asset/contracts/Catalyst.sol)', function () {
+describe.only('Catalyst (/packages/asset/contracts/Catalyst.sol)', function () {
   describe('Contract setup', function () {
     it('Should deploy correctly', async function () {
       const {
@@ -26,7 +26,7 @@ describe('Catalyst (/packages/asset/contracts/Catalyst.sol)', function () {
       expect(
         await catalyst.hasRole(minterRole, catalystMinter.address)
       ).to.be.equals(true);
-      expect(await catalyst.tokenCount()).to.be.equals(6);
+      expect(await catalyst.highestTierIndex()).to.be.equals(6);
       expect(catalyst.address).to.be.properAddress;
     });
     it("base uri can't be empty in initialization", async function () {
@@ -262,7 +262,7 @@ describe('Catalyst (/packages/asset/contracts/Catalyst.sol)', function () {
     });
     it('Admin can add new catalyst', async function () {
       const {catalystAsAdmin} = await runCatalystSetup();
-      await catalystAsAdmin.addNewCatalystType(7, '0x01');
+      await catalystAsAdmin.addNewCatalystType('0x01');
       expect(await catalystAsAdmin.uri(7)).to.be.equal('ipfs://0x01');
     });
 
@@ -270,7 +270,7 @@ describe('Catalyst (/packages/asset/contracts/Catalyst.sol)', function () {
       const {catalyst, user1, catalystAdminRole} = await runCatalystSetup();
 
       await expect(
-        catalyst.connect(user1).addNewCatalystType(7, '0x01')
+        catalyst.connect(user1).addNewCatalystType('0x01')
       ).to.be.revertedWith(
         `AccessControl: account ${user1.address.toLocaleLowerCase()} is missing role ${catalystAdminRole}`
       );
@@ -333,17 +333,11 @@ describe('Catalyst (/packages/asset/contracts/Catalyst.sol)', function () {
         `AccessControl: account ${user1.address.toLocaleLowerCase()} is missing role ${catalystAdminRole}`
       );
     });
-    it('cant add invalid token id', async function () {
-      const {catalystAsAdmin} = await runCatalystSetup();
-      await expect(
-        catalystAsAdmin.addNewCatalystType(0, '0x01')
-      ).to.be.revertedWith('Catalyst: invalid catalyst id');
-    });
     it('cant add invalid token uri', async function () {
       const {catalystAsAdmin} = await runCatalystSetup();
-      await expect(
-        catalystAsAdmin.addNewCatalystType(9, '')
-      ).to.be.revertedWith("Catalyst: CID can't be empty");
+      await expect(catalystAsAdmin.addNewCatalystType('')).to.be.revertedWith(
+        "Catalyst: CID can't be empty"
+      );
     });
     it('cant set invalid trusted forwarder', async function () {
       const {catalystAsAdmin} = await runCatalystSetup();
@@ -395,7 +389,7 @@ describe('Catalyst (/packages/asset/contracts/Catalyst.sol)', function () {
       const {catalyst, user1, catalystAsMinter} = await runCatalystSetup();
       const catalystId = [];
       const catalystAmount = [];
-      for (let i = 0; i < catalystArray.length; i++) {
+      for (let i = 1; i < catalystArray.length; i++) {
         catalystId.push(catalystArray[i]);
         catalystAmount.push(catalystArray[i] * 2);
       }
@@ -404,7 +398,7 @@ describe('Catalyst (/packages/asset/contracts/Catalyst.sol)', function () {
         catalystId,
         catalystAmount
       );
-      for (let i = 0; i < catalystArray.length; i++) {
+      for (let i = 1; i < catalystArray.length; i++) {
         expect(
           await catalyst.balanceOf(user1.address, catalystArray[i])
         ).to.be.equal(catalystArray[i] * 2);
@@ -419,7 +413,7 @@ describe('Catalyst (/packages/asset/contracts/Catalyst.sol)', function () {
   describe('Total Supply', function () {
     it('Total Supply increase on minting', async function () {
       const {catalyst, user1, catalystAsMinter} = await runCatalystSetup();
-      for (let i = 0; i < catalystArray.length; i++) {
+      for (let i = 1; i < catalystArray.length; i++) {
         expect(await catalyst.totalSupply(catalystArray[i])).to.equal(0);
         await catalystAsMinter.mint(user1.address, catalystArray[i], 2);
         expect(await catalyst.totalSupply(catalystArray[i])).to.be.equal(2);
@@ -429,7 +423,7 @@ describe('Catalyst (/packages/asset/contracts/Catalyst.sol)', function () {
       const {catalyst, user1, catalystAsMinter} = await runCatalystSetup();
       const catalystId = [];
       const catalystAmount = [];
-      for (let i = 0; i < catalystArray.length; i++) {
+      for (let i = 1; i < catalystArray.length; i++) {
         catalystId.push(catalystArray[i]);
         catalystAmount.push(catalystArray[i] * 2);
       }
@@ -438,7 +432,7 @@ describe('Catalyst (/packages/asset/contracts/Catalyst.sol)', function () {
         catalystId,
         catalystAmount
       );
-      for (let i = 0; i < catalystArray.length; i++) {
+      for (let i = 1; i < catalystArray.length; i++) {
         expect(await catalyst.totalSupply(catalystArray[i])).to.equal(
           catalystArray[i] * 2
         );
@@ -448,18 +442,21 @@ describe('Catalyst (/packages/asset/contracts/Catalyst.sol)', function () {
       const {catalyst, user1, catalystAsBurner, catalystAsMinter} =
         await runCatalystSetup();
       const catalystAmount = [];
-      for (let i = 0; i < catalystArray.length; i++) {
+      const catalystId = [];
+      for (let i = 1; i < catalystArray.length; i++) {
         expect(await catalyst.totalSupply(catalystArray[i])).to.be.equal(0);
         catalystAmount.push(catalystArray[i] * 2);
+        catalystId.push(catalystArray[i]);
       }
+
       await catalystAsMinter.mintBatch(
         user1.address,
-        catalystArray,
+        catalystId,
         catalystAmount
       );
-      for (let i = 0; i < catalystArray.length; i++) {
+      for (let i = 1; i < catalystArray.length; i++) {
         expect(await catalyst.totalSupply(catalystArray[i])).to.equal(
-          catalystAmount[i]
+          catalystArray[i] * 2
         );
 
         await catalystAsBurner.burnFrom(user1.address, catalystArray[i], 2);
@@ -471,12 +468,12 @@ describe('Catalyst (/packages/asset/contracts/Catalyst.sol)', function () {
     it('Total Supply decrease on batch burning', async function () {
       const {catalyst, user1, catalystAsMinter, catalystAsBurner} =
         await runCatalystSetup();
-      for (let i = 0; i < catalystArray.length; i++) {
+      for (let i = 1; i < catalystArray.length; i++) {
         expect(await catalyst.totalSupply(catalystArray[i])).to.equal(0);
       }
       const catalystId = [];
       let catalystAmount = [];
-      for (let i = 0; i < catalystArray.length; i++) {
+      for (let i = 1; i < catalystArray.length; i++) {
         catalystId.push(catalystArray[i]);
         catalystAmount.push(catalystArray[i] * 2);
       }
@@ -485,14 +482,14 @@ describe('Catalyst (/packages/asset/contracts/Catalyst.sol)', function () {
         catalystId,
         catalystAmount
       );
-      for (let i = 0; i < catalystArray.length; i++) {
+      for (let i = 1; i < catalystArray.length; i++) {
         expect(await catalyst.totalSupply(catalystArray[i])).to.equal(
           catalystArray[i] * 2
         );
       }
       catalystAmount = [];
 
-      for (let i = 0; i < catalystArray.length; i++) {
+      for (let i = 1; i < catalystArray.length; i++) {
         catalystAmount.push(1);
       }
 
@@ -501,7 +498,7 @@ describe('Catalyst (/packages/asset/contracts/Catalyst.sol)', function () {
         catalystId,
         catalystAmount
       );
-      for (let i = 0; i < catalystArray.length; i++) {
+      for (let i = 1; i < catalystArray.length; i++) {
         expect(await catalyst.totalSupply(catalystArray[i])).to.equal(
           catalystArray[i] * 2 - 1
         );


### PR DESCRIPTION
## Description

Changed to Catalyst that were required after adding TSB Exclusive tier 0.

- No longer require an id to be passed when creating new cat tiers.
- Cat tier will be automatically incremented
- Rename `tokenCount` => `highestTierIndex` to be clearer on the meaning of the variable
- Update tests
- Update interface
