### PR TITLE
refactor: Asset royalty interfaces refactored to move getRecipients

### DIFF
--- a/packages/asset/test/Asset.test.ts
+++ b/packages/asset/test/Asset.test.ts
@@ -847,6 +847,10 @@ describe('Base Asset Contract (/packages/asset/contracts/Asset.sol)', function (
       const {AssetContract} = await runAssetSetup();
       expect(await AssetContract.supportsInterface('0x4f07bc84')).to.be.true;
     });
+    it('should support IRoyaltyMultiRecipients', async function () {
+      const {AssetContract} = await runAssetSetup();
+      expect(await AssetContract.supportsInterface('0xfd90e897')).to.be.true;
+    });
   });
   describe('Token util', function () {
     it('should return correct creator from asset for a token', async function () {

--- a/packages/asset/test/Asset.test.ts
+++ b/packages/asset/test/Asset.test.ts
@@ -839,13 +839,13 @@ describe('Base Asset Contract (/packages/asset/contracts/Asset.sol)', function (
       const {AssetContract} = await runAssetSetup();
       expect(await AssetContract.supportsInterface('0x572b6c05')).to.be.true;
     });
-    it('should support RoyaltyUGC', async function () {
+    it('should support IRoyaltyUGC', async function () {
       const {AssetContract} = await runAssetSetup();
       expect(await AssetContract.supportsInterface('0xa30b4db9')).to.be.true;
     });
-    it('should support RoyaltyMultiDistributor', async function () {
+    it('should support IRoyaltyMultiDistributor', async function () {
       const {AssetContract} = await runAssetSetup();
-      expect(await AssetContract.supportsInterface('0xb2975413')).to.be.true;
+      expect(await AssetContract.supportsInterface('0x4f07bc84')).to.be.true;
     });
   });
   describe('Token util', function () {

--- a/packages/dependency-royalty-management/contracts/MultiRoyaltyDistributor.sol
+++ b/packages/dependency-royalty-management/contracts/MultiRoyaltyDistributor.sol
@@ -4,11 +4,8 @@ pragma solidity ^0.8.0;
 import {ERC165Upgradeable} from "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol";
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
-
-import {
-    IEIP2981MultiReceiverRoyaltyOverride
-} from "@manifoldxyz/royalty-registry-solidity/contracts/overrides/IMultiReceiverRoyaltyOverride.sol";
 import {IMultiRoyaltyDistributor} from "./interfaces/IMultiRoyaltyDistributor.sol";
+import {IMultiRoyaltyRecipients} from "./interfaces/IMultiRoyaltyRecipients.sol";
 import {
     IRoyaltySplitter,
     IERC165
@@ -20,7 +17,12 @@ import {IRoyaltyManager, Recipient} from "./interfaces/IRoyaltyManager.sol";
 /// @author The Sandbox
 /// @dev  The MultiRoyaltyDistributer contract implements the ERC-2981 and ERC-165 interfaces for a royalty payment system. This payment system can be used to pay royalties to multiple recipients through splitters.
 /// @dev  This contract calls to the Royalties manager contract to deploy RoyaltySplitter for a creator to slip its royalty between the creator and Sandbox and use it for every token minted by that creator.
-abstract contract MultiRoyaltyDistributor is IEIP2981, IMultiRoyaltyDistributor, ERC165Upgradeable {
+abstract contract MultiRoyaltyDistributor is
+    IEIP2981,
+    IMultiRoyaltyDistributor,
+    IMultiRoyaltyRecipients,
+    ERC165Upgradeable
+{
     uint16 internal constant TOTAL_BASIS_POINTS = 10000;
     uint16 public _defaultRoyaltyBPS;
     address payable public _defaultRoyaltyReceiver;
@@ -51,7 +53,6 @@ abstract contract MultiRoyaltyDistributor is IEIP2981, IMultiRoyaltyDistributor,
     {
         return
             interfaceId == type(IEIP2981).interfaceId ||
-            interfaceId == type(IEIP2981MultiReceiverRoyaltyOverride).interfaceId ||
             interfaceId == type(IMultiRoyaltyDistributor).interfaceId ||
             super.supportsInterface(interfaceId);
     }

--- a/packages/dependency-royalty-management/contracts/MultiRoyaltyDistributor.sol
+++ b/packages/dependency-royalty-management/contracts/MultiRoyaltyDistributor.sol
@@ -5,7 +5,6 @@ import {ERC165Upgradeable} from "@openzeppelin/contracts-upgradeable/utils/intro
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
 import {IMultiRoyaltyDistributor} from "./interfaces/IMultiRoyaltyDistributor.sol";
-import {IMultiRoyaltyRecipients} from "./interfaces/IMultiRoyaltyRecipients.sol";
 import {
     IRoyaltySplitter,
     IERC165
@@ -17,12 +16,7 @@ import {IRoyaltyManager, Recipient} from "./interfaces/IRoyaltyManager.sol";
 /// @author The Sandbox
 /// @dev  The MultiRoyaltyDistributer contract implements the ERC-2981 and ERC-165 interfaces for a royalty payment system. This payment system can be used to pay royalties to multiple recipients through splitters.
 /// @dev  This contract calls to the Royalties manager contract to deploy RoyaltySplitter for a creator to slip its royalty between the creator and Sandbox and use it for every token minted by that creator.
-abstract contract MultiRoyaltyDistributor is
-    IEIP2981,
-    IMultiRoyaltyDistributor,
-    IMultiRoyaltyRecipients,
-    ERC165Upgradeable
-{
+abstract contract MultiRoyaltyDistributor is IEIP2981, IMultiRoyaltyDistributor, ERC165Upgradeable {
     uint16 internal constant TOTAL_BASIS_POINTS = 10000;
     uint16 public _defaultRoyaltyBPS;
     address payable public _defaultRoyaltyReceiver;

--- a/packages/dependency-royalty-management/contracts/MultiRoyaltyDistributor.sol
+++ b/packages/dependency-royalty-management/contracts/MultiRoyaltyDistributor.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 import {ERC165Upgradeable} from "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol";
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
-import {IMultiRoyaltyDistributor} from "./interfaces/IMultiRoyaltyDistributor.sol";
+import {IMultiRoyaltyDistributor, IMultiRoyaltyRecipients} from "./interfaces/IMultiRoyaltyDistributor.sol";
 import {
     IRoyaltySplitter,
     IERC165

--- a/packages/dependency-royalty-management/contracts/MultiRoyaltyDistributor.sol
+++ b/packages/dependency-royalty-management/contracts/MultiRoyaltyDistributor.sol
@@ -54,6 +54,7 @@ abstract contract MultiRoyaltyDistributor is
         return
             interfaceId == type(IEIP2981).interfaceId ||
             interfaceId == type(IMultiRoyaltyDistributor).interfaceId ||
+            interfaceId == type(IMultiRoyaltyRecipients).interfaceId ||
             super.supportsInterface(interfaceId);
     }
 

--- a/packages/dependency-royalty-management/contracts/interfaces/IMultiRoyaltyDistributor.sol
+++ b/packages/dependency-royalty-management/contracts/interfaces/IMultiRoyaltyDistributor.sol
@@ -46,16 +46,17 @@ interface IMultiRoyaltyDistributor is IERC165 {
     function getDefaultRoyalty() external view returns (uint16 bps, Recipient[] memory);
 
     /**
-     * @dev Set a default royalty e.  Will be used if no token specific configuration is set
+     * @dev Set a default royalty.  Will be used if no token specific configuration is set
      */
     function setDefaultRoyaltyBps(uint16 bps) external;
 
+    /**
+     * @dev Set a default royalty receiver.  Will be used if no token specific configuration is set
+     */
     function setDefaultRoyaltyReceiver(address payable defaultReceiver) external;
 
     /**
      * @dev Helper function to get all splits contracts
      */
     function getAllSplits() external view returns (address payable[] memory);
-
-    function getRecipients(uint256 tokenId) external view returns (Recipient[] memory);
 }

--- a/packages/dependency-royalty-management/contracts/interfaces/IMultiRoyaltyDistributor.sol
+++ b/packages/dependency-royalty-management/contracts/interfaces/IMultiRoyaltyDistributor.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.0;
 
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {IMultiRoyaltyRecipients} from "./IMultiRoyaltyRecipients.sol";
 import {
     IRoyaltySplitter,
     Recipient
@@ -10,7 +11,7 @@ import {
 /**
  * Multi-receiver EIP2981 reference override implementation
  */
-interface IMultiRoyaltyDistributor is IERC165 {
+interface IMultiRoyaltyDistributor is IERC165, IMultiRoyaltyRecipients {
     event TokenRoyaltyRemoved(uint256 tokenId);
     event TokenRoyaltySet(uint256 tokenId, uint16 royaltyBPS, address recipient);
     event DefaultRoyaltyBpsSet(uint16 royaltyBPS);

--- a/packages/dependency-royalty-management/contracts/interfaces/IMultiRoyaltyRecipients.sol
+++ b/packages/dependency-royalty-management/contracts/interfaces/IMultiRoyaltyRecipients.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {Recipient} from "@manifoldxyz/royalty-registry-solidity/contracts/overrides/IRoyaltySplitter.sol";
+
+/**
+ * Multi-receiver EIP2981 reference override implementation
+ */
+interface IMultiRoyaltyRecipients is IERC165 {
+    /**
+     * @dev Helper function to get all recipients
+     */
+    function getRecipients(uint256 tokenId) external view returns (Recipient[] memory);
+}


### PR DESCRIPTION
Interface refactor to move getRecipients out of IMultiRoyaltyDistributor into its own interface that is inherited by our custom override, MultiRoyaltyDistributor