### PR TITLE
Mint special should only be able to mint tier 0

### DIFF
--- a/packages/asset/contracts/AssetCreate.sol
+++ b/packages/asset/contracts/AssetCreate.sol
@@ -151,6 +151,7 @@ contract AssetCreate is IAssetCreate, Initializable, ERC2771Handler, EIP712Upgra
         string calldata metadataHash,
         address creator
     ) external onlyRole(SPECIAL_MINTER_ROLE) {
+        require(tier == 0, "AssetCreate: Special assets must be tier 0");
         require(
             authValidator.verify(
                 signature,


### PR DESCRIPTION
## Description

Previously we allowed the special mint function to mint any tier level asset by TSB's special minter without burning catalysts.
That was not correct according to the guidelines and would not be appreciated by the user base.

- Add restriction so that only tier 0 assets (TSB Exclusive) can be minted without catalysts by TSB.
- Add/update test cases.
