### PR TITLE
Asset reveal todo tests

### DIFF
--- a/packages/asset/contracts/Catalyst.sol
+++ b/packages/asset/contracts/Catalyst.sol
@@ -287,8 +287,6 @@ contract Catalyst is
         returns (bool)
     {
         return
-            ERC1155Upgradeable.supportsInterface(interfaceId) ||
-            AccessControlUpgradeable.supportsInterface(interfaceId) ||
             super.supportsInterface(interfaceId);
     }
 

--- a/packages/asset/contracts/Catalyst.sol
+++ b/packages/asset/contracts/Catalyst.sol
@@ -286,7 +286,10 @@ contract Catalyst is
         override(ERC1155Upgradeable, AccessControlUpgradeable, RoyaltyDistributor)
         returns (bool)
     {
-        return super.supportsInterface(interfaceId);
+        return
+            ERC1155Upgradeable.supportsInterface(interfaceId) ||
+            AccessControlUpgradeable.supportsInterface(interfaceId) ||
+            super.supportsInterface(interfaceId);
     }
 
     /// @notice This function is used to register Catalyst contract on the Operator Filterer Registry of Opensea.can only be called by admin.

--- a/packages/asset/contracts/Catalyst.sol
+++ b/packages/asset/contracts/Catalyst.sol
@@ -286,8 +286,7 @@ contract Catalyst is
         override(ERC1155Upgradeable, AccessControlUpgradeable, RoyaltyDistributor)
         returns (bool)
     {
-        return
-            super.supportsInterface(interfaceId);
+        return super.supportsInterface(interfaceId);
     }
 
     /// @notice This function is used to register Catalyst contract on the Operator Filterer Registry of Opensea.can only be called by admin.

--- a/packages/asset/test/Asset.test.ts
+++ b/packages/asset/test/Asset.test.ts
@@ -2,6 +2,16 @@ import {expect} from 'chai';
 import {ethers, upgrades} from 'hardhat';
 import {runAssetSetup} from './fixtures/asset/assetFixture';
 import {setupOperatorFilter} from './fixtures/operatorFilterFixture';
+import {
+  AccessControlInterfaceId,
+  ERC1155InterfaceId,
+  ERC1155MetadataURIInterfaceId,
+  ERC165InterfaceId,
+  ERC2981InterfaceId,
+  RoyaltyMultiDistributorInterfaceId,
+  RoyaltyMultiRecipientsInterfaceId,
+  RoyaltyUGCInterfaceId,
+} from './utils/interfaceIds';
 const zeroAddress = '0x0000000000000000000000000000000000000000';
 
 describe('Base Asset Contract (/packages/asset/contracts/Asset.sol)', function () {
@@ -821,31 +831,48 @@ describe('Base Asset Contract (/packages/asset/contracts/Asset.sol)', function (
   describe('Interface support', function () {
     it('should support ERC165', async function () {
       const {AssetContract} = await runAssetSetup();
-      expect(await AssetContract.supportsInterface('0x01ffc9a7')).to.be.true;
+      expect(await AssetContract.supportsInterface(ERC165InterfaceId)).to.be
+        .true;
     });
     it('should support ERC1155', async function () {
       const {AssetContract} = await runAssetSetup();
-      expect(await AssetContract.supportsInterface('0xd9b67a26')).to.be.true;
+      expect(await AssetContract.supportsInterface(ERC1155InterfaceId)).to.be
+        .true;
     });
     it('should support ERC1155MetadataURI', async function () {
       const {AssetContract} = await runAssetSetup();
-      expect(await AssetContract.supportsInterface('0x0e89341c')).to.be.true;
+      expect(
+        await AssetContract.supportsInterface(ERC1155MetadataURIInterfaceId)
+      ).to.be.true;
     });
     it('should support AccessControlUpgradeable', async function () {
       const {AssetContract} = await runAssetSetup();
-      expect(await AssetContract.supportsInterface('0x7965db0b')).to.be.true;
+      expect(await AssetContract.supportsInterface(AccessControlInterfaceId)).to
+        .be.true;
     });
     it('should support IRoyaltyUGC', async function () {
       const {AssetContract} = await runAssetSetup();
-      expect(await AssetContract.supportsInterface('0xa30b4db9')).to.be.true;
+      expect(await AssetContract.supportsInterface(RoyaltyUGCInterfaceId)).to.be
+        .true;
     });
     it('should support IRoyaltyMultiDistributor', async function () {
       const {AssetContract} = await runAssetSetup();
-      expect(await AssetContract.supportsInterface('0x667873ce')).to.be.true;
+      expect(
+        await AssetContract.supportsInterface(
+          RoyaltyMultiDistributorInterfaceId
+        )
+      ).to.be.true;
     });
     it('should support IRoyaltyMultiRecipients', async function () {
       const {AssetContract} = await runAssetSetup();
-      expect(await AssetContract.supportsInterface('0xfd90e897')).to.be.true;
+      expect(
+        await AssetContract.supportsInterface(RoyaltyMultiRecipientsInterfaceId)
+      ).to.be.true;
+    });
+    it('should support IERC2981', async function () {
+      const {AssetContract} = await runAssetSetup();
+      expect(await AssetContract.supportsInterface(ERC2981InterfaceId)).to.be
+        .true;
     });
   });
   describe('Token util', function () {

--- a/packages/asset/test/Catalyst.test.ts
+++ b/packages/asset/test/Catalyst.test.ts
@@ -36,7 +36,7 @@ describe('Catalyst (/packages/asset/contracts/Catalyst.sol)', function () {
       expect(await catalyst.highestTierIndex()).to.be.equals(6);
       expect(catalyst.address).to.be.properAddress;
     });
-    describe.only('Interface support', function () {
+    describe('Interface support', function () {
       it('should support ERC165', async function () {
         const {catalyst} = await runCatalystSetup();
         expect(await catalyst.supportsInterface(ERC165InterfaceId)).to.be.true;

--- a/packages/asset/test/Catalyst.test.ts
+++ b/packages/asset/test/Catalyst.test.ts
@@ -3,6 +3,13 @@ import {setupOperatorFilter} from './fixtures/operatorFilterFixture';
 import {ethers, upgrades} from 'hardhat';
 import {runCatalystSetup} from './fixtures/catalyst/catalystFixture';
 import {CATALYST_BASE_URI, CATALYST_IPFS_CID_PER_TIER} from '../data/constants';
+import {
+  AccessControlInterfaceId,
+  ERC1155InterfaceId,
+  ERC1155MetadataURIInterfaceId,
+  ERC165InterfaceId,
+  ERC2981InterfaceId,
+} from './utils/interfaceIds';
 const catalystArray = [0, 1, 2, 3, 4, 5, 6];
 const zeroAddress = '0x0000000000000000000000000000000000000000';
 
@@ -29,10 +36,28 @@ describe('Catalyst (/packages/asset/contracts/Catalyst.sol)', function () {
       expect(await catalyst.highestTierIndex()).to.be.equals(6);
       expect(catalyst.address).to.be.properAddress;
     });
-    describe('Interface support', function () {
-      it('should support ERC2981Upgradeable', async function () {
+    describe.only('Interface support', function () {
+      it('should support ERC165', async function () {
         const {catalyst} = await runCatalystSetup();
-        expect(await catalyst.supportsInterface('0x2a55205a')).to.be.true;
+        expect(await catalyst.supportsInterface(ERC165InterfaceId)).to.be.true;
+      });
+      it('should support ERC1155', async function () {
+        const {catalyst} = await runCatalystSetup();
+        expect(await catalyst.supportsInterface(ERC1155InterfaceId)).to.be.true;
+      });
+      it('should support ERC1155MetadataURI', async function () {
+        const {catalyst} = await runCatalystSetup();
+        expect(await catalyst.supportsInterface(ERC1155MetadataURIInterfaceId))
+          .to.be.true;
+      });
+      it('should support AccessControl', async function () {
+        const {catalyst} = await runCatalystSetup();
+        expect(await catalyst.supportsInterface(AccessControlInterfaceId)).to.be
+          .true;
+      });
+      it('should support IERC2981', async function () {
+        const {catalyst} = await runCatalystSetup();
+        expect(await catalyst.supportsInterface(ERC2981InterfaceId)).to.be.true;
       });
     });
     it("base uri can't be empty in initialization", async function () {

--- a/packages/asset/test/fixtures/asset/assetRevealFixtures.ts
+++ b/packages/asset/test/fixtures/asset/assetRevealFixtures.ts
@@ -1,4 +1,5 @@
 import {ethers, upgrades} from 'hardhat';
+import {Event} from 'ethers';
 import {
   batchRevealSignature,
   burnAndRevealSignature,
@@ -191,8 +192,9 @@ export async function runRevealTestSetup() {
     'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJA' // metadata hash
   );
   const unRevResult = await unRevMintTx.wait();
-  // TODO: this is brittle and should be modified to search for the relevant event name
-  const unrevealedtokenId = unRevResult.events[5].args.tokenId.toString();
+  const unrevealedtokenId = unRevResult.events
+    .find((e: Event) => e.event === 'Minted')
+    .args.tokenId.toString();
 
   // mint a tier 5 asset with 10 copies
   const unRevMintTx2 = await MockMinterContract.mintAsset(
@@ -204,8 +206,9 @@ export async function runRevealTestSetup() {
   );
   const unRevResult2 = await unRevMintTx2.wait();
 
-  // TODO: this is brittle and should be modified to search for the relevant event name
-  const unrevealedtokenId2 = unRevResult2.events[3].args.tokenId.toString();
+  const unrevealedtokenId2 = unRevResult2.events
+    .find((e: Event) => e.event === 'Minted')
+    .args.tokenId.toString();
 
   // mint a revealed version, tier 5 asset with 10 copies
   const revMintTx = await MockMinterContract.mintAsset(
@@ -216,8 +219,10 @@ export async function runRevealTestSetup() {
     'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJC'
   );
   const revResult = await revMintTx.wait();
-  // TODO: this is brittle and should be modified to search for the relevant event name
-  const revealedtokenId = revResult.events[3].args.tokenId.toString();
+
+  const revealedtokenId = revResult.events
+    .find((e: Event) => e.event === 'Minted')
+    .args.tokenId.toString();
 
   // END SETUP USER WITH MINTED ASSETS
 

--- a/packages/asset/test/utils/interfaceIds.ts
+++ b/packages/asset/test/utils/interfaceIds.ts
@@ -1,0 +1,8 @@
+export const ERC165InterfaceId = '0x01ffc9a7';
+export const ERC1155InterfaceId = '0xd9b67a26';
+export const ERC1155MetadataURIInterfaceId = '0x0e89341c';
+export const AccessControlInterfaceId = '0x7965db0b';
+export const ERC2981InterfaceId = '0x2a55205a';
+export const RoyaltyUGCInterfaceId = '0xa30b4db9';
+export const RoyaltyMultiDistributorInterfaceId = '0x667873ce';
+export const RoyaltyMultiRecipientsInterfaceId = '0x2e1a7d4d';

--- a/packages/asset/test/utils/interfaceIds.ts
+++ b/packages/asset/test/utils/interfaceIds.ts
@@ -5,4 +5,4 @@ export const AccessControlInterfaceId = '0x7965db0b';
 export const ERC2981InterfaceId = '0x2a55205a';
 export const RoyaltyUGCInterfaceId = '0xa30b4db9';
 export const RoyaltyMultiDistributorInterfaceId = '0x667873ce';
-export const RoyaltyMultiRecipientsInterfaceId = '0x2e1a7d4d';
+export const RoyaltyMultiRecipientsInterfaceId = '0xfd90e897';

--- a/packages/dependency-royalty-management/contracts/RoyaltyDistributor.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltyDistributor.sol
@@ -3,10 +3,7 @@ pragma solidity ^0.8.0;
 
 import {IERC2981Upgradeable} from "@openzeppelin/contracts-upgradeable/interfaces/IERC2981Upgradeable.sol";
 import {IRoyaltyManager} from "./interfaces/IRoyaltyManager.sol";
-import {
-    ERC165Upgradeable,
-    IERC165Upgradeable
-} from "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol";
+import {ERC165Upgradeable, IERC165Upgradeable} from "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol";
 
 contract RoyaltyDistributor is IERC2981Upgradeable, ERC165Upgradeable {
     uint16 internal constant TOTAL_BASIS_POINTS = 10000;
@@ -22,7 +19,7 @@ contract RoyaltyDistributor is IERC2981Upgradeable, ERC165Upgradeable {
     /// @return receiver the receiver of royalty
     /// @return royaltyAmount the amount of royalty
     function royaltyInfo(
-        uint256, /*_tokenId */
+        uint256 /*_tokenId */,
         uint256 _salePrice
     ) external view returns (address receiver, uint256 royaltyAmount) {
         uint16 royaltyBps;
@@ -34,7 +31,9 @@ contract RoyaltyDistributor is IERC2981Upgradeable, ERC165Upgradeable {
     /// @notice Query if a contract implements interface `id`.
     /// @param interfaceId the interface identifier, as specified in ERC-165.
     /// @return `true` if the contract implements `id`.
-    function supportsInterface(bytes4 interfaceId) public view virtual override(ERC165Upgradeable, IERC165Upgradeable) returns (bool) {
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override(ERC165Upgradeable, IERC165Upgradeable) returns (bool) {
         return interfaceId == type(IERC2981Upgradeable).interfaceId || super.supportsInterface(interfaceId);
     }
 }

--- a/packages/dependency-royalty-management/contracts/RoyaltyDistributor.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltyDistributor.sol
@@ -3,7 +3,10 @@ pragma solidity ^0.8.0;
 
 import {IERC2981Upgradeable} from "@openzeppelin/contracts-upgradeable/interfaces/IERC2981Upgradeable.sol";
 import {IRoyaltyManager} from "./interfaces/IRoyaltyManager.sol";
-import {ERC165Upgradeable, IERC165Upgradeable} from "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol";
+import {
+    ERC165Upgradeable,
+    IERC165Upgradeable
+} from "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol";
 
 contract RoyaltyDistributor is IERC2981Upgradeable, ERC165Upgradeable {
     uint16 internal constant TOTAL_BASIS_POINTS = 10000;
@@ -19,7 +22,7 @@ contract RoyaltyDistributor is IERC2981Upgradeable, ERC165Upgradeable {
     /// @return receiver the receiver of royalty
     /// @return royaltyAmount the amount of royalty
     function royaltyInfo(
-        uint256 /*_tokenId */,
+        uint256, /*_tokenId */
         uint256 _salePrice
     ) external view returns (address receiver, uint256 royaltyAmount) {
         uint16 royaltyBps;
@@ -31,9 +34,13 @@ contract RoyaltyDistributor is IERC2981Upgradeable, ERC165Upgradeable {
     /// @notice Query if a contract implements interface `id`.
     /// @param interfaceId the interface identifier, as specified in ERC-165.
     /// @return `true` if the contract implements `id`.
-    function supportsInterface(
-        bytes4 interfaceId
-    ) public view virtual override(ERC165Upgradeable, IERC165Upgradeable) returns (bool) {
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(ERC165Upgradeable, IERC165Upgradeable)
+        returns (bool)
+    {
         return interfaceId == type(IERC2981Upgradeable).interfaceId || super.supportsInterface(interfaceId);
     }
 }

--- a/packages/dependency-royalty-management/contracts/RoyaltyDistributor.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltyDistributor.sol
@@ -3,8 +3,12 @@ pragma solidity ^0.8.0;
 
 import {IERC2981Upgradeable} from "@openzeppelin/contracts-upgradeable/interfaces/IERC2981Upgradeable.sol";
 import {IRoyaltyManager} from "./interfaces/IRoyaltyManager.sol";
+import {
+    ERC165Upgradeable,
+    IERC165Upgradeable
+} from "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol";
 
-contract RoyaltyDistributor is IERC2981Upgradeable {
+contract RoyaltyDistributor is IERC2981Upgradeable, ERC165Upgradeable {
     uint16 internal constant TOTAL_BASIS_POINTS = 10000;
     IRoyaltyManager public royaltyManager;
 
@@ -30,7 +34,7 @@ contract RoyaltyDistributor is IERC2981Upgradeable {
     /// @notice Query if a contract implements interface `id`.
     /// @param interfaceId the interface identifier, as specified in ERC-165.
     /// @return `true` if the contract implements `id`.
-    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
-        return interfaceId == type(IERC2981Upgradeable).interfaceId;
+    function supportsInterface(bytes4 interfaceId) public view virtual override(ERC165Upgradeable, IERC165Upgradeable) returns (bool) {
+        return interfaceId == type(IERC2981Upgradeable).interfaceId || super.supportsInterface(interfaceId);
     }
 }


### PR DESCRIPTION
## Description

- Use `.find` method when looking for a particular event in assetFixture
- Move interfaceIds to common utils file so we can manage them easier
- Fix `supportsInterface` function in `Catalyst.sol` to return expected values
- Update tests for Asset and Catalyst that check interface support