### PR TITLE
Fix/improve erc2771handler

### DIFF
--- a/packages/asset/contracts/Asset.sol
+++ b/packages/asset/contracts/Asset.sol
@@ -22,8 +22,7 @@ import {
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {IERC1155} from "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
 import {
-    ERC2771HandlerUpgradeable,
-    ERC2771HandlerAbstract
+    ERC2771HandlerUpgradeable
 } from "@sandbox-smart-contracts/dependency-metatx/contracts/ERC2771HandlerUpgradeable.sol";
 import {
     MultiRoyaltyDistributor
@@ -212,20 +211,20 @@ contract Asset is
         internal
         view
         virtual
-        override(ContextUpgradeable, ERC2771HandlerAbstract)
+        override(ContextUpgradeable, ERC2771HandlerUpgradeable)
         returns (address sender)
     {
-        return ERC2771HandlerAbstract._msgSender();
+        return ERC2771HandlerUpgradeable._msgSender();
     }
 
     function _msgData()
         internal
         view
         virtual
-        override(ContextUpgradeable, ERC2771HandlerAbstract)
+        override(ContextUpgradeable, ERC2771HandlerUpgradeable)
         returns (bytes calldata)
     {
-        return ERC2771HandlerAbstract._msgData();
+        return ERC2771HandlerUpgradeable._msgData();
     }
 
     function _beforeTokenTransfer(

--- a/packages/asset/contracts/AssetCreate.sol
+++ b/packages/asset/contracts/AssetCreate.sol
@@ -10,8 +10,7 @@ import {
 import {TokenIdUtils} from "./libraries/TokenIdUtils.sol";
 import {AuthSuperValidator} from "./AuthSuperValidator.sol";
 import {
-    ERC2771HandlerUpgradeable,
-    ERC2771HandlerAbstract
+    ERC2771HandlerUpgradeable
 } from "@sandbox-smart-contracts/dependency-metatx/contracts/ERC2771HandlerUpgradeable.sol";
 import {IAsset} from "./interfaces/IAsset.sol";
 import {ICatalyst} from "./interfaces/ICatalyst.sol";
@@ -272,19 +271,19 @@ contract AssetCreate is
         internal
         view
         virtual
-        override(ContextUpgradeable, ERC2771HandlerAbstract)
+        override(ContextUpgradeable, ERC2771HandlerUpgradeable)
         returns (address sender)
     {
-        return ERC2771HandlerAbstract._msgSender();
+        return ERC2771HandlerUpgradeable._msgSender();
     }
 
     function _msgData()
         internal
         view
         virtual
-        override(ContextUpgradeable, ERC2771HandlerAbstract)
+        override(ContextUpgradeable, ERC2771HandlerUpgradeable)
         returns (bytes calldata)
     {
-        return ERC2771HandlerAbstract._msgData();
+        return ERC2771HandlerUpgradeable._msgData();
     }
 }

--- a/packages/asset/contracts/AssetReveal.sol
+++ b/packages/asset/contracts/AssetReveal.sol
@@ -10,8 +10,7 @@ import {
 import {TokenIdUtils} from "./libraries/TokenIdUtils.sol";
 import {AuthSuperValidator} from "./AuthSuperValidator.sol";
 import {
-    ERC2771HandlerUpgradeable,
-    ERC2771HandlerAbstract
+    ERC2771HandlerUpgradeable
 } from "@sandbox-smart-contracts/dependency-metatx/contracts/ERC2771HandlerUpgradeable.sol";
 import {IAsset} from "./interfaces/IAsset.sol";
 import {IAssetReveal} from "./interfaces/IAssetReveal.sol";
@@ -412,19 +411,19 @@ contract AssetReveal is
         internal
         view
         virtual
-        override(ContextUpgradeable, ERC2771HandlerAbstract)
+        override(ContextUpgradeable, ERC2771HandlerUpgradeable)
         returns (address sender)
     {
-        return ERC2771HandlerAbstract._msgSender();
+        return ERC2771HandlerUpgradeable._msgSender();
     }
 
     function _msgData()
         internal
         view
         virtual
-        override(ContextUpgradeable, ERC2771HandlerAbstract)
+        override(ContextUpgradeable, ERC2771HandlerUpgradeable)
         returns (bytes calldata)
     {
-        return ERC2771HandlerAbstract._msgData();
+        return ERC2771HandlerUpgradeable._msgData();
     }
 }

--- a/packages/asset/contracts/Catalyst.sol
+++ b/packages/asset/contracts/Catalyst.sol
@@ -32,8 +32,7 @@ import {
 } from "@sandbox-smart-contracts/dependency-royalty-management/contracts/interfaces/IRoyaltyManager.sol";
 import {IERC2981Upgradeable} from "@openzeppelin/contracts-upgradeable/interfaces/IERC2981Upgradeable.sol";
 import {
-    ERC2771HandlerUpgradeable,
-    ERC2771HandlerAbstract
+    ERC2771HandlerUpgradeable
 } from "@sandbox-smart-contracts/dependency-metatx/contracts/ERC2771HandlerUpgradeable.sol";
 import {ICatalyst} from "./interfaces/ICatalyst.sol";
 
@@ -211,8 +210,14 @@ contract Catalyst is
     }
 
     /// @dev Needed for meta transactions (see EIP-2771)
-    function _msgSender() internal view virtual override(ContextUpgradeable, ERC2771HandlerAbstract) returns (address) {
-        return ERC2771HandlerAbstract._msgSender();
+    function _msgSender()
+        internal
+        view
+        virtual
+        override(ContextUpgradeable, ERC2771HandlerUpgradeable)
+        returns (address)
+    {
+        return ERC2771HandlerUpgradeable._msgSender();
     }
 
     /// @dev Needed for meta transactions (see EIP-2771)
@@ -220,10 +225,10 @@ contract Catalyst is
         internal
         view
         virtual
-        override(ContextUpgradeable, ERC2771HandlerAbstract)
+        override(ContextUpgradeable, ERC2771HandlerUpgradeable)
         returns (bytes calldata)
     {
-        return ERC2771HandlerAbstract._msgData();
+        return ERC2771HandlerUpgradeable._msgData();
     }
 
     /// @notice Transfers `value` tokens of type `id` from  `from` to `to`  (with safety call).

--- a/packages/dependency-metatx/contracts/ERC2771Handler.sol
+++ b/packages/dependency-metatx/contracts/ERC2771Handler.sol
@@ -44,4 +44,16 @@ contract ERC2771Handler is ERC2771HandlerAbstract {
     function _isTrustedForwarder(address forwarder) internal view virtual override returns (bool) {
         return forwarder == _trustedForwarder;
     }
+
+    /// @notice if the call is from the trusted forwarder the sender is extracted from calldata, msg.sender otherwise
+    /// @return sender the calculated address of the sender
+    function _msgSender() internal view virtual override returns (address sender) {
+        return super._msgSender();
+    }
+
+    /// @notice if the call is from the trusted forwarder the sender is removed from calldata
+    /// @return the calldata without the sender
+    function _msgData() internal view virtual override returns (bytes calldata) {
+        return super._msgData();
+    }
 }

--- a/packages/dependency-metatx/contracts/ERC2771HandlerUpgradeable.sol
+++ b/packages/dependency-metatx/contracts/ERC2771HandlerUpgradeable.sol
@@ -52,5 +52,17 @@ contract ERC2771HandlerUpgradeable is Initializable, ERC2771HandlerAbstract {
         return forwarder == _trustedForwarder;
     }
 
+    /// @notice if the call is from the trusted forwarder the sender is extracted from calldata, msg.sender otherwise
+    /// @return sender the calculated address of the sender
+    function _msgSender() internal view virtual override returns (address sender) {
+        return super._msgSender();
+    }
+
+    /// @notice if the call is from the trusted forwarder the sender is removed from calldata
+    /// @return the calldata without the sender
+    function _msgData() internal view virtual override returns (bytes calldata) {
+        return super._msgData();
+    }
+
     uint256[49] private __gap;
 }

--- a/packages/dependency-royalty-management/contracts/RoyaltySplitter.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltySplitter.sol
@@ -16,9 +16,7 @@ import {
     IERC165,
     Recipient
 } from "@manifoldxyz/royalty-registry-solidity/contracts/overrides/IRoyaltySplitter.sol";
-import {
-    ERC2771HandlerAbstract
-} from "@sandbox-smart-contracts/dependency-metatx/contracts/ERC2771HandlerUpgradeable.sol";
+import {ERC2771HandlerAbstract} from "@sandbox-smart-contracts/dependency-metatx/contracts/ERC2771HandlerAbstract.sol";
 import {IRoyaltyManager} from "./interfaces/IRoyaltyManager.sol";
 import {IERC20Approve} from "./interfaces/IERC20Approve.sol";
 


### PR DESCRIPTION
## Description
add _msgSender and _msgData to the handler so the abstract class doesn't need to be imported if not used.
