### PR TITLE
prepare the asset branch for the new solhint version

### DIFF
--- a/packages/asset/.solhint.json
+++ b/packages/asset/.solhint.json
@@ -8,14 +8,9 @@
         "endOfLine": "auto"
       }
     ],
-    "code-complexity": ["error", 7],
+    "custom-errors": "off",
     "compiler-version": ["error", "^0.8.0"],
-    "const-name-snakecase": "off",
-    "func-name-mixedcase": "off",
-    "constructor-syntax": "error",
     "func-visibility": ["error", {"ignoreConstructors": true}],
-    "not-rely-on-time": "off",
-    "no-inline-assembly": "off",
     "reason-string": ["warn", {"maxLength": 64}]
   }
 }

--- a/packages/asset/contracts/Asset.sol
+++ b/packages/asset/contracts/Asset.sol
@@ -3,24 +3,19 @@ pragma solidity 0.8.18;
 
 import {
     AccessControlUpgradeable,
-    ContextUpgradeable,
-    IAccessControlUpgradeable,
-    IERC165Upgradeable
+    ContextUpgradeable
 } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import {
     ERC1155BurnableUpgradeable,
-    ERC1155Upgradeable,
-    IERC1155Upgradeable
+    ERC1155Upgradeable
 } from "@openzeppelin/contracts-upgradeable/token/ERC1155/extensions/ERC1155BurnableUpgradeable.sol";
 import {
     ERC1155SupplyUpgradeable
 } from "@openzeppelin/contracts-upgradeable/token/ERC1155/extensions/ERC1155SupplyUpgradeable.sol";
 import {
-    ERC1155URIStorageUpgradeable,
-    IERC1155MetadataURIUpgradeable
+    ERC1155URIStorageUpgradeable
 } from "@openzeppelin/contracts-upgradeable/token/ERC1155/extensions/ERC1155URIStorageUpgradeable.sol";
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import {IERC1155} from "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
 import {
     ERC2771HandlerUpgradeable
 } from "@sandbox-smart-contracts/dependency-metatx/contracts/ERC2771HandlerUpgradeable.sol";

--- a/packages/asset/contracts/Catalyst.sol
+++ b/packages/asset/contracts/Catalyst.sol
@@ -15,10 +15,6 @@ import {
 import {
     ERC1155URIStorageUpgradeable
 } from "@openzeppelin/contracts-upgradeable/token/ERC1155/extensions/ERC1155URIStorageUpgradeable.sol";
-import {
-    IERC165Upgradeable,
-    ERC2981Upgradeable
-} from "@openzeppelin/contracts-upgradeable/token/common/ERC2981Upgradeable.sol";
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {
     OperatorFiltererUpgradeable,
@@ -27,10 +23,6 @@ import {
 import {
     RoyaltyDistributor
 } from "@sandbox-smart-contracts/dependency-royalty-management/contracts/RoyaltyDistributor.sol";
-import {
-    IRoyaltyManager
-} from "@sandbox-smart-contracts/dependency-royalty-management/contracts/interfaces/IRoyaltyManager.sol";
-import {IERC2981Upgradeable} from "@openzeppelin/contracts-upgradeable/interfaces/IERC2981Upgradeable.sol";
 import {
     ERC2771HandlerUpgradeable
 } from "@sandbox-smart-contracts/dependency-metatx/contracts/ERC2771HandlerUpgradeable.sol";

--- a/packages/dependency-operator-filter/.solhint.json
+++ b/packages/dependency-operator-filter/.solhint.json
@@ -8,14 +8,9 @@
         "endOfLine": "auto"
       }
     ],
-    "code-complexity": ["error", 7],
+    "custom-errors": "off",
     "compiler-version": ["error", "^0.8.0"],
-    "const-name-snakecase": "off",
-    "func-name-mixedcase": "off",
-    "constructor-syntax": "error",
     "func-visibility": ["error", {"ignoreConstructors": true}],
-    "not-rely-on-time": "off",
-    "no-inline-assembly": "off",
     "reason-string": ["warn", {"maxLength": 64}]
   }
 }

--- a/packages/dependency-operator-filter/contracts/OperatorFilterSubscription.sol
+++ b/packages/dependency-operator-filter/contracts/OperatorFilterSubscription.sol
@@ -10,6 +10,7 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 contract OperatorFilterSubscription is Ownable {
     address public constant DEFAULT_SUBSCRIPTION = address(0x3cc6CddA760b79bAfa08dF41ECFA224f810dCeB6);
 
+    // solhint-disable-next-line const-name-snakecase
     IOperatorFilterRegistry public constant operatorFilterRegistry =
         IOperatorFilterRegistry(0x000000000000AAeB6D7670E522A718067333cd4E);
 

--- a/packages/dependency-operator-filter/contracts/OperatorFiltererUpgradeable.sol
+++ b/packages/dependency-operator-filter/contracts/OperatorFiltererUpgradeable.sol
@@ -11,6 +11,7 @@ import {ContextUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/Cont
 abstract contract OperatorFiltererUpgradeable is Initializable, ContextUpgradeable {
     IOperatorFilterRegistry public operatorFilterRegistry;
 
+    // solhint-disable-next-line func-name-mixedcase
     function __OperatorFilterer_init(address subscriptionOrRegistrantToCopy, bool subscribe) internal onlyInitializing {
         operatorFilterRegistry = IOperatorFilterRegistry(0x000000000000AAeB6D7670E522A718067333cd4E); // Address of the operator filterer registry
         // If an inheriting token contract is deployed to a network without the registry deployed, the modifier

--- a/packages/dependency-royalty-management/.solhint.json
+++ b/packages/dependency-royalty-management/.solhint.json
@@ -8,14 +8,9 @@
         "endOfLine": "auto"
       }
     ],
-    "code-complexity": ["error", 7],
+    "custom-errors": "off",
     "compiler-version": ["error", "^0.8.0"],
-    "const-name-snakecase": "off",
-    "func-name-mixedcase": "off",
-    "constructor-syntax": "error",
     "func-visibility": ["error", {"ignoreConstructors": true}],
-    "not-rely-on-time": "off",
-    "no-inline-assembly": "off",
     "reason-string": ["warn", {"maxLength": 64}]
   }
 }

--- a/packages/dependency-royalty-management/contracts/MultiRoyaltyDistributor.sol
+++ b/packages/dependency-royalty-management/contracts/MultiRoyaltyDistributor.sol
@@ -2,8 +2,6 @@
 pragma solidity ^0.8.0;
 
 import {ERC165Upgradeable} from "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol";
-import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
-import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
 import {IMultiRoyaltyDistributor, IMultiRoyaltyRecipients} from "./interfaces/IMultiRoyaltyDistributor.sol";
 import {
     IRoyaltySplitter,
@@ -23,6 +21,7 @@ abstract contract MultiRoyaltyDistributor is IEIP2981, IMultiRoyaltyDistributor,
     mapping(uint256 => address payable) public _tokenRoyaltiesSplitter;
     uint256[] private _tokensWithRoyalties;
 
+    // solhint-disable-next-line func-name-mixedcase
     function __MultiRoyaltyDistributor_init(address _royaltyManager) internal {
         royaltyManager = _royaltyManager;
     }

--- a/packages/dependency-royalty-management/contracts/RoyaltyDistributor.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltyDistributor.sol
@@ -12,6 +12,7 @@ contract RoyaltyDistributor is IERC2981Upgradeable, ERC165Upgradeable {
     uint16 internal constant TOTAL_BASIS_POINTS = 10000;
     IRoyaltyManager public royaltyManager;
 
+    // solhint-disable-next-line func-name-mixedcase
     function __RoyaltyDistributor_init(address _royaltyManager) internal {
         royaltyManager = IRoyaltyManager(_royaltyManager);
     }

--- a/packages/dependency-royalty-management/contracts/RoyaltyManager.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltyManager.sol
@@ -2,12 +2,8 @@
 pragma solidity ^0.8.0;
 
 import {AccessControlUpgradeable} from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
-import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {IRoyaltyManager} from "./interfaces/IRoyaltyManager.sol";
-import {
-    IRoyaltySplitter,
-    Recipient
-} from "@manifoldxyz/royalty-registry-solidity/contracts/overrides/IRoyaltySplitter.sol";
+import {Recipient} from "@manifoldxyz/royalty-registry-solidity/contracts/overrides/IRoyaltySplitter.sol";
 import {RoyaltySplitter} from "./RoyaltySplitter.sol";
 import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
 

--- a/packages/dependency-royalty-management/contracts/interfaces/IMultiRoyaltyDistributor.sol
+++ b/packages/dependency-royalty-management/contracts/interfaces/IMultiRoyaltyDistributor.sol
@@ -3,10 +3,7 @@ pragma solidity ^0.8.0;
 
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {IMultiRoyaltyRecipients} from "./IMultiRoyaltyRecipients.sol";
-import {
-    IRoyaltySplitter,
-    Recipient
-} from "@manifoldxyz/royalty-registry-solidity/contracts/overrides/IRoyaltySplitter.sol";
+import {Recipient} from "@manifoldxyz/royalty-registry-solidity/contracts/overrides/IRoyaltySplitter.sol";
 
 /**
  * Multi-receiver EIP2981 reference override implementation


### PR DESCRIPTION
## Description
Changes to prepare for the new solhint version. 
The spirit of this PR is to avoid code changes. 
There is a change that wasn't done but may be useful: it is desirable to limit the reason-string to 32 bytes to avoid unnecessary gas consumption ( removing `"reason-string": ["warn", {"maxLength": 64}]` from solhint conf), shortening the strings and fixing the related unit tests.