### PR TITLE
Add pausable extension to asset reveal and asset create

### DIFF
--- a/packages/asset/contracts/AssetCreate.sol
+++ b/packages/asset/contracts/AssetCreate.sol
@@ -72,6 +72,7 @@ contract AssetCreate is
         __ERC2771Handler_init(_forwarder);
         __EIP712_init(_name, _version);
         __AccessControl_init();
+        __Pausable_init();
         _grantRole(DEFAULT_ADMIN_ROLE, _defaultAdmin);
     }
 

--- a/packages/asset/contracts/AssetReveal.sol
+++ b/packages/asset/contracts/AssetReveal.sol
@@ -77,6 +77,8 @@ contract AssetReveal is
         authValidator = AuthSuperValidator(_authValidator);
         __ERC2771Handler_init(_forwarder);
         __EIP712_init(_name, _version);
+        __AccessControl_init();
+        __Pausable_init();
         _grantRole(DEFAULT_ADMIN_ROLE, _defaultAdmin);
     }
 

--- a/packages/asset/contracts/AssetReveal.sol
+++ b/packages/asset/contracts/AssetReveal.sol
@@ -7,6 +7,7 @@ import {
     AccessControlUpgradeable,
     ContextUpgradeable
 } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
 import {TokenIdUtils} from "./libraries/TokenIdUtils.sol";
 import {AuthSuperValidator} from "./AuthSuperValidator.sol";
 import {
@@ -23,7 +24,8 @@ contract AssetReveal is
     Initializable,
     AccessControlUpgradeable,
     ERC2771HandlerUpgradeable,
-    EIP712Upgradeable
+    EIP712Upgradeable,
+    PausableUpgradeable
 {
     using TokenIdUtils for uint256;
     IAsset private assetContract;
@@ -38,6 +40,8 @@ contract AssetReveal is
 
     // allowance list for tier to be revealed in a single transaction
     mapping(uint8 => bool) internal tierInstantRevealAllowed;
+
+    bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
 
     bytes32 public constant REVEAL_TYPEHASH =
         keccak256(
@@ -80,7 +84,7 @@ contract AssetReveal is
     /// @dev the reveal mechanism works through burning the asset and minting a new one with updated tokenId
     /// @param tokenId the tokenId of id idasset to reveal
     /// @param amount the amount of tokens to reveal
-    function revealBurn(uint256 tokenId, uint256 amount) external {
+    function revealBurn(uint256 tokenId, uint256 amount) external whenNotPaused {
         _burnAsset(tokenId, amount);
         emit AssetRevealBurn(_msgSender(), tokenId, amount);
     }
@@ -89,7 +93,7 @@ contract AssetReveal is
     /// @dev Can be used to burn multiple copies of the same token id, each copy will be revealed separately
     /// @param tokenIds the tokenIds of the assets to burn
     /// @param amounts the amounts of the assets to burn
-    function revealBatchBurn(uint256[] calldata tokenIds, uint256[] calldata amounts) external {
+    function revealBatchBurn(uint256[] calldata tokenIds, uint256[] calldata amounts) external whenNotPaused {
         _burnAssetBatch(tokenIds, amounts);
         emit AssetRevealBatchBurn(_msgSender(), tokenIds, amounts);
     }
@@ -107,7 +111,7 @@ contract AssetReveal is
         uint256[] calldata amounts,
         string[] calldata metadataHashes,
         bytes32[] calldata revealHashes
-    ) external {
+    ) external whenNotPaused {
         require(amounts.length == metadataHashes.length, "AssetReveal: Invalid amounts length");
         require(amounts.length == revealHashes.length, "AssetReveal: Invalid revealHashes length");
         require(
@@ -134,7 +138,7 @@ contract AssetReveal is
         uint256[][] calldata amounts,
         string[][] calldata metadataHashes,
         bytes32[][] calldata revealHashes
-    ) external {
+    ) external whenNotPaused {
         require(prevTokenIds.length == amounts.length, "AssetReveal: Invalid amounts length");
         require(amounts.length == metadataHashes.length, "AssetReveal: Invalid metadataHashes length");
         require(prevTokenIds.length == revealHashes.length, "AssetReveal: Invalid revealHashes length");
@@ -167,7 +171,7 @@ contract AssetReveal is
         uint256[] calldata amounts,
         string[] calldata metadataHashes,
         bytes32[] calldata revealHashes
-    ) external {
+    ) external whenNotPaused {
         require(amounts.length == metadataHashes.length, "AssetReveal: Invalid amounts length");
         require(amounts.length == revealHashes.length, "AssetReveal: Invalid revealHashes length");
         uint8 tier = prevTokenId.getTier();
@@ -416,6 +420,16 @@ contract AssetReveal is
     /// @return Whether instant reveal is allowed for the given tier
     function getTierInstantRevealAllowed(uint8 tier) external view returns (bool) {
         return tierInstantRevealAllowed[tier];
+    }
+
+    /// @notice Pause the contracts mint and burn functions
+    function pause() external onlyRole(PAUSER_ROLE) {
+        _pause();
+    }
+
+    /// @notice Unpause the contracts mint and burn functions
+    function unpause() external onlyRole(PAUSER_ROLE) {
+        _unpause();
     }
 
     /// @notice Set a new trusted forwarder address, limited to DEFAULT_ADMIN_ROLE only

--- a/packages/asset/docs/AssetCreate.md
+++ b/packages/asset/docs/AssetCreate.md
@@ -6,6 +6,7 @@ This document serves as comprehensive documentation for the AssetCreate contract
 
 1. **DEFAULT_ADMIN_ROLE**: The role with broad administrative permissions, including setting URIs and changing the trusted forwarder.
 2. **SPECIAL_MINTER_ROLE**: The special minter role with permission to create special assets like TSB exclusive tokens.
+3. **PAUSER_ROLE**: The role with permission to pause the contract.
 
 ## Public Variables
 

--- a/packages/asset/docs/AssetReveal.md
+++ b/packages/asset/docs/AssetReveal.md
@@ -4,7 +4,8 @@ This is a solidity contract designed for managing the revealing of assets linked
 
 ## Roles in the Contract
 
-1. **Admin**: This role has broad administrative permissions, including the ability to set the trusted forwarder.
+1. **DEFAULT_ADMIN_ROLE**: This role has broad administrative permissions, including the ability to set the trusted forwarder.
+2. **PAUSER_ROLE**: The role with permission to pause the contract.
 
 ## Public Variables
 

--- a/packages/asset/test/AssetReveal.test.ts
+++ b/packages/asset/test/AssetReveal.test.ts
@@ -195,6 +195,133 @@ describe('AssetReveal (/packages/asset/contracts/AssetReveal.sol)', function () 
       await MockAssetRevealContract.msgData();
     });
   });
+  describe('Pause/Unpause', function () {
+    it('should allow pauser to pause the contract', async function () {
+      const {AssetRevealContractAsAdmin} = await runRevealTestSetup();
+      await AssetRevealContractAsAdmin.pause();
+      expect(await AssetRevealContractAsAdmin.paused()).to.be.true;
+    });
+    it('should not allow non pauser to pause the contract', async function () {
+      const {AssetRevealContractAsUser, user, PauserRole} =
+        await runRevealTestSetup();
+      await expect(AssetRevealContractAsUser.pause()).to.be.revertedWith(
+        `AccessControl: account ${user.address.toLowerCase()} is missing role ${PauserRole}`
+      );
+    });
+    it('should allow pauser to unpause the contract', async function () {
+      const {AssetRevealContractAsAdmin} = await runRevealTestSetup();
+      await AssetRevealContractAsAdmin.pause();
+      await AssetRevealContractAsAdmin.unpause();
+      expect(await AssetRevealContractAsAdmin.paused()).to.be.false;
+    });
+    it('should not allow non pauser to unpause the contract', async function () {
+      const {AssetRevealContractAsUser, user, PauserRole} =
+        await runRevealTestSetup();
+      await expect(AssetRevealContractAsUser.unpause()).to.be.revertedWith(
+        `AccessControl: account ${user.address.toLowerCase()} is missing role ${PauserRole}`
+      );
+    });
+    it('should not allow revealBurn to be called when paused', async function () {
+      const {
+        AssetRevealContractAsAdmin,
+        AssetRevealContractAsUser,
+        unrevealedtokenId,
+      } = await runRevealTestSetup();
+      await AssetRevealContractAsAdmin.pause();
+      await expect(
+        AssetRevealContractAsUser.revealBurn(unrevealedtokenId, 1)
+      ).to.be.revertedWith('Pausable: paused');
+    });
+    it('should not allow revealMint to be called when paused', async function () {
+      const {
+        unrevealedtokenId,
+        user,
+        generateRevealSignature,
+        pause,
+        revealAsset,
+      } = await runRevealTestSetup();
+      const newMetadataHashes = [
+        'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJF',
+      ];
+      const amounts = [1];
+      const signature = await generateRevealSignature(
+        user.address, // revealer
+        unrevealedtokenId, // prevTokenId
+        amounts,
+        newMetadataHashes,
+        [revealHashA]
+      );
+      await pause();
+      await expect(
+        revealAsset(signature, unrevealedtokenId, amounts, newMetadataHashes, [
+          revealHashA,
+        ])
+      ).to.be.revertedWith('Pausable: paused');
+    });
+    it('should not allow revealBatchMint to be called when paused', async function () {
+      const {
+        unrevealedtokenId,
+        user,
+        generateRevealSignature,
+        pause,
+        revealAsset,
+      } = await runRevealTestSetup();
+      const newMetadataHashes = [
+        'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJF',
+      ];
+      const amounts = [1];
+      const signature = await generateRevealSignature(
+        user.address, // revealer
+        unrevealedtokenId, // prevTokenId
+        amounts,
+        newMetadataHashes,
+        [revealHashA]
+      );
+      await pause();
+      await expect(
+        revealAsset(signature, unrevealedtokenId, amounts, newMetadataHashes, [
+          revealHashA,
+        ])
+      ).to.be.revertedWith('Pausable: paused');
+    });
+    it('should not allow revealBatchBurn to be called when paused', async function () {
+      const {
+        unrevealedtokenId,
+        user,
+        generateRevealSignature,
+        pause,
+        revealAsset,
+      } = await runRevealTestSetup();
+      const newMetadataHashes = [
+        'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJF',
+      ];
+      const amounts = [1];
+      const signature = await generateRevealSignature(
+        user.address, // revealer
+        unrevealedtokenId, // prevTokenId
+        amounts,
+        newMetadataHashes,
+        [revealHashA]
+      );
+      await pause();
+      await expect(
+        revealAsset(signature, unrevealedtokenId, amounts, newMetadataHashes, [
+          revealHashA,
+        ])
+      ).to.be.revertedWith('Pausable: paused');
+    });
+    it('should not allow burnAndReveal to be called when paused', async function () {
+      const {
+        AssetRevealContractAsAdmin,
+        AssetRevealContractAsUser,
+        unrevealedtokenId,
+      } = await runRevealTestSetup();
+      await AssetRevealContractAsAdmin.pause();
+      await expect(
+        AssetRevealContractAsUser.burnAndReveal(unrevealedtokenId, 1)
+      ).to.be.revertedWith('Pausable: paused');
+    });
+  });
   describe('Burning', function () {
     describe('Single burn', function () {
       describe('Success', function () {

--- a/packages/asset/test/AssetReveal.test.ts
+++ b/packages/asset/test/AssetReveal.test.ts
@@ -195,7 +195,7 @@ describe('AssetReveal (/packages/asset/contracts/AssetReveal.sol)', function () 
       await MockAssetRevealContract.msgData();
     });
   });
-  describe.only('Pause/Unpause', function () {
+  describe('Pause/Unpause', function () {
     it('should allow pauser to pause the contract', async function () {
       const {AssetRevealContractAsAdmin} = await runRevealTestSetup();
       await AssetRevealContractAsAdmin.pause();

--- a/packages/asset/test/AssetReveal.test.ts
+++ b/packages/asset/test/AssetReveal.test.ts
@@ -195,7 +195,7 @@ describe('AssetReveal (/packages/asset/contracts/AssetReveal.sol)', function () 
       await MockAssetRevealContract.msgData();
     });
   });
-  describe('Pause/Unpause', function () {
+  describe.only('Pause/Unpause', function () {
     it('should allow pauser to pause the contract', async function () {
       const {AssetRevealContractAsAdmin} = await runRevealTestSetup();
       await AssetRevealContractAsAdmin.pause();
@@ -313,12 +313,34 @@ describe('AssetReveal (/packages/asset/contracts/AssetReveal.sol)', function () 
     it('should not allow burnAndReveal to be called when paused', async function () {
       const {
         AssetRevealContractAsAdmin,
-        AssetRevealContractAsUser,
         unrevealedtokenId,
+        instantReveal,
+        generateBurnAndRevealSignature,
+        user,
       } = await runRevealTestSetup();
       await AssetRevealContractAsAdmin.pause();
+      const newMetadataHash = [
+        'QmZvGR5JNtSjSgSL9sD8V3LpSTHYXcfc9gy3CqptuoETJF',
+      ];
+      const amounts = [1];
+
+      const signature = await generateBurnAndRevealSignature(
+        user.address,
+        unrevealedtokenId,
+        amounts,
+        newMetadataHash,
+        [revealHashA]
+      );
+
       await expect(
-        AssetRevealContractAsUser.burnAndReveal(unrevealedtokenId, 1)
+        instantReveal(
+          signature,
+          unrevealedtokenId,
+          amounts[0],
+          amounts,
+          newMetadataHash,
+          [revealHashA]
+        )
       ).to.be.revertedWith('Pausable: paused');
     });
   });

--- a/packages/asset/test/fixtures/asset/assetCreateFixtures.ts
+++ b/packages/asset/test/fixtures/asset/assetCreateFixtures.ts
@@ -174,6 +174,9 @@ export async function runCreateTestSetup() {
 
   const AssetCreateContractAsAdmin = AssetCreateContract.connect(assetAdmin);
   const SpecialMinterRole = await AssetCreateContract.SPECIAL_MINTER_ROLE();
+
+  const PauserRole = await AssetCreateContract.PAUSER_ROLE();
+  await AssetCreateContractAsAdmin.grantRole(PauserRole, assetAdmin.address);
   // END SETUP ROLES
 
   // HELPER FUNCTIONS
@@ -286,6 +289,15 @@ export async function runCreateTestSetup() {
     );
     return signature;
   };
+
+  const pause = async () => {
+    await AssetCreateContractAsAdmin.pause();
+  };
+
+  const unpause = async () => {
+    await AssetCreateContractAsAdmin.unpause();
+  };
+
   // END HELPER FUNCTIONS
 
   return {
@@ -296,6 +308,7 @@ export async function runCreateTestSetup() {
     additionalMetadataHash: 'QmZEhV6rMsZfNyAmNKrWuN965xaidZ8r5nd2XkZq9yZ95L',
     user,
     AdminRole,
+    PauserRole,
     trustedForwarder,
     otherWallet,
     AssetContract,
@@ -313,5 +326,7 @@ export async function runCreateTestSetup() {
     generateSingleMintSignature,
     generateMultipleMintSignature,
     getCreatorNonce,
+    pause,
+    unpause,
   };
 }

--- a/packages/asset/test/fixtures/asset/assetRevealFixtures.ts
+++ b/packages/asset/test/fixtures/asset/assetRevealFixtures.ts
@@ -182,8 +182,8 @@ export async function runRevealTestSetup() {
   await AssetContractAsAdmin.grantRole(BurnerRole, AssetRevealContract.address);
 
   // set admin as pauser
-  const PauserRole = await AssetContract.PAUSER_ROLE();
-  await AssetContractAsAdmin.grantRole(PauserRole, assetAdmin.address);
+  const PauserRole = await AssetRevealContract.PAUSER_ROLE();
+  await AssetRevealContractAsAdmin.grantRole(PauserRole, assetAdmin.address);
   // END SET UP ROLES
 
   // SET TIER 5 AS ALLOWED FOR INSTANT REVEAl

--- a/packages/asset/test/fixtures/asset/assetRevealFixtures.ts
+++ b/packages/asset/test/fixtures/asset/assetRevealFixtures.ts
@@ -180,6 +180,10 @@ export async function runRevealTestSetup() {
   // add AssetReveal contracts as both MINTER and BURNER for Asset contract
   await AssetContractAsAdmin.grantRole(MinterRole, AssetRevealContract.address);
   await AssetContractAsAdmin.grantRole(BurnerRole, AssetRevealContract.address);
+
+  // set admin as pauser
+  const PauserRole = await AssetContract.PAUSER_ROLE();
+  await AssetContractAsAdmin.grantRole(PauserRole, assetAdmin.address);
   // END SET UP ROLES
 
   // SET TIER 5 AS ALLOWED FOR INSTANT REVEAl
@@ -342,6 +346,15 @@ export async function runRevealTestSetup() {
     );
     return signature;
   };
+
+  const pause = async () => {
+    await AssetRevealContractAsAdmin.pause();
+  };
+
+  const unpause = async () => {
+    await AssetRevealContractAsAdmin.unpause();
+  };
+
   // END HELPER FUNCTIONS
 
   return {
@@ -351,6 +364,8 @@ export async function runRevealTestSetup() {
     revealAsset,
     revealAssetBatch,
     instantReveal,
+    pause,
+    unpause,
     AssetRevealContract,
     AssetRevealContractAsUser,
     AssetRevealContractAsAdmin,
@@ -363,6 +378,7 @@ export async function runRevealTestSetup() {
     unrevealedtokenId2,
     revealedtokenId,
     AdminRole,
+    PauserRole,
     user,
     assetAdmin,
   };

--- a/packages/deploy/hardhat.config.ts
+++ b/packages/deploy/hardhat.config.ts
@@ -62,6 +62,7 @@ const namedAccounts = {
   mintingFeeCollector: 'sandAdmin', // will receiver the fee from Asset minting
   sandBeneficiary: 'sandAdmin', // will be the owner of all initial SAND
   assetAdmin: 'sandAdmin', // can add super operator and change admin to Asset
+  assetPauser: 'sandAdmin', // can pause AssetCreate and AssetReveal
   assetMinterAdmin: 'sandAdmin', // can set metaTxProcessors & types
   assetBouncerAdmin: 'sandAdmin', // setup the contract allowed to mint Assets
   sandSaleAdmin: 'sandAdmin', // can pause the sandSale and withdraw SAND

--- a/packages/deploy/test/asset/AssetCreate.test.ts
+++ b/packages/deploy/test/asset/AssetCreate.test.ts
@@ -3,7 +3,8 @@ import {deployments} from 'hardhat';
 
 const setupTest = deployments.createFixture(
   async ({deployments, getNamedAccounts, ethers}) => {
-    const {assetAdmin, backendAuthWallet} = await getNamedAccounts();
+    const {assetAdmin, backendAuthWallet, assetPauser} =
+      await getNamedAccounts();
     await deployments.fixture();
     const Asset = await deployments.get('Asset');
     const AssetContract = await ethers.getContractAt('Asset', Asset.address);
@@ -32,6 +33,7 @@ const setupTest = deployments.createFixture(
       AuthSuperValidatorContract,
       assetAdmin,
       backendAuthWallet,
+      assetPauser,
     };
   }
 );
@@ -91,6 +93,12 @@ describe('Asset Create', function () {
       expect(
         await AuthSuperValidatorContract.getSigner(AssetCreateContract.address)
       ).to.be.equal(backendAuthWallet);
+    });
+    it('Pauser role is granted to assetPauser', async function () {
+      const {AssetCreateContract, assetPauser} = await setupTest();
+      const pauserRole = await AssetCreateContract.PAUSER_ROLE();
+      expect(await AssetCreateContract.hasRole(pauserRole, assetPauser)).to.be
+        .true;
     });
   });
   describe('EIP712', function () {

--- a/packages/deploy/test/asset/AssetReveal.test.ts
+++ b/packages/deploy/test/asset/AssetReveal.test.ts
@@ -3,7 +3,8 @@ import {deployments} from 'hardhat';
 
 const setupTest = deployments.createFixture(
   async ({deployments, getNamedAccounts, ethers}) => {
-    const {assetAdmin, backendAuthWallet} = await getNamedAccounts();
+    const {assetAdmin, backendAuthWallet, assetPauser} =
+      await getNamedAccounts();
     await deployments.fixture('Asset');
     const Asset = await deployments.get('Asset');
     const AssetContract = await ethers.getContractAt('Asset', Asset.address);
@@ -32,6 +33,7 @@ const setupTest = deployments.createFixture(
       AuthSuperValidatorContract,
       assetAdmin,
       backendAuthWallet,
+      assetPauser,
     };
   }
 );
@@ -78,6 +80,12 @@ describe('Asset Reveal', function () {
       expect(
         await AuthSuperValidatorContract.getSigner(AssetRevealContract.address)
       ).to.be.equal(backendAuthWallet);
+    });
+    it('Pauser role is granted to assetPauser', async function () {
+      const {AssetRevealContract, assetPauser} = await setupTest();
+      const pauserRole = await AssetRevealContract.PAUSER_ROLE();
+      expect(await AssetRevealContract.hasRole(pauserRole, assetPauser)).to.be
+        .true;
     });
   });
   describe('EIP712', function () {


### PR DESCRIPTION
## Description

- Add PausableUpgradeable extension to AssetCreate and AssetReveal
- Add new role `PAUSER_ROLE` to both of the above contract
- Add tests to make sure the functions specified are blocked when the contract is paused
- Added deployment setup for the pauser role
- Added deployment tests
