### PR TITLE
Catalyst audit: N-05 _disableInitializers() Not Called in Multiple Initializable Contract Constructors

### DIFF
--- a/packages/asset/contracts/Asset.sol
+++ b/packages/asset/contracts/Asset.sol
@@ -336,7 +336,7 @@ contract Asset is
         return TokenIdUtils.isBridged(tokenId);
     }
 
-    /// @notice This function is used to register Asset contract on the Operator Filterer Registry of Opensea.can only be called by admin.
+    /// @notice This function is used to register Asset contract on the Operator Filterer Registry of OpenSea.can only be called by admin.
     /// @dev used to register contract and subscribe to the subscriptionOrRegistrantToCopy's black list.
     /// @param subscriptionOrRegistrantToCopy registration address of the list to subscribe.
     /// @param subscribe bool to signify subscription "true"" or to copy the list "false".

--- a/packages/asset/contracts/Catalyst.sol
+++ b/packages/asset/contracts/Catalyst.sol
@@ -77,7 +77,7 @@ contract Catalyst is
         address _defaultMinter,
         string[] memory _catalystIpfsCID,
         address _royaltyManager
-    ) public initializer {
+    ) external initializer {
         require(bytes(_baseUri).length != 0, "Catalyst: base uri can't be empty");
         require(_trustedForwarder != address(0), "Catalyst: trusted forwarder can't be zero");
         require(_subscription != address(0), "Catalyst: subscription can't be zero");

--- a/packages/asset/contracts/Catalyst.sol
+++ b/packages/asset/contracts/Catalyst.sol
@@ -30,7 +30,7 @@ import {ICatalyst} from "./interfaces/ICatalyst.sol";
 
 /// @title Catalyst
 /// @author The Sandbox
-/// @notice THis contract manages catalysts which are used to mint new assets.
+/// @notice This contract manages catalysts which are used to mint new assets.
 /// @dev An ERC1155 contract that manages catalysts, extends multiple OpenZeppelin contracts to
 /// provide a variety of features including, AccessControl, URIStorage, Burnable and more.
 /// The contract includes support for meta transactions.
@@ -235,7 +235,7 @@ contract Catalyst is
     /// @param to address to which the token will be transfered.
     /// @param id the token type transfered.
     /// @param value amount of token transfered.
-    /// @param data aditional data accompanying the transfer.
+    /// @param data additional data accompanying the transfer.
     function safeTransferFrom(
         address from,
         address to,
@@ -252,7 +252,7 @@ contract Catalyst is
     /// @param to address to which the token will be transfered.
     /// @param ids ids of each token type transfered.
     /// @param values amount of each token type transfered.
-    /// @param data aditional data accompanying the transfer.
+    /// @param data additional data accompanying the transfer.
     function safeBatchTransferFrom(
         address from,
         address to,
@@ -293,7 +293,7 @@ contract Catalyst is
         return super.supportsInterface(interfaceId);
     }
 
-    /// @notice This function is used to register Catalyst contract on the Operator Filterer Registry of Opensea.can only be called by admin.
+    /// @notice This function is used to register Catalyst contract on the Operator Filterer Registry of Opensea. Can only be called by admin.
     /// @dev used to register contract and subscribe to the subscriptionOrRegistrantToCopy's black list.
     /// @param subscriptionOrRegistrantToCopy registration address of the list to subscribe.
     /// @param subscribe bool to signify subscription "true"" or to copy the list "false".

--- a/packages/asset/contracts/Catalyst.sol
+++ b/packages/asset/contracts/Catalyst.sol
@@ -293,7 +293,7 @@ contract Catalyst is
         return super.supportsInterface(interfaceId);
     }
 
-    /// @notice This function is used to register Catalyst contract on the Operator Filterer Registry of Opensea. Can only be called by admin.
+    /// @notice This function is used to register Catalyst contract on the Operator Filterer Registry of OpenSea. Can only be called by admin.
     /// @dev used to register contract and subscribe to the subscriptionOrRegistrantToCopy's black list.
     /// @param subscriptionOrRegistrantToCopy registration address of the list to subscribe.
     /// @param subscribe bool to signify subscription "true"" or to copy the list "false".

--- a/packages/asset/docs/Asset.md
+++ b/packages/asset/docs/Asset.md
@@ -176,6 +176,7 @@ Sets a new trusted forwarder for meta-transactions.
 Parameters:
 
 - `trustedForwarder` - The new trusted forwarder.
+
 ### setTokenRoyalties
 
 ```solidity
@@ -183,7 +184,7 @@ function setTokenRoyalties(
         uint256 tokenId,
         address payable recipient,
         address creator
-) external override onlyRole(DEFAULT_ADMIN_ROLE) 
+) external override onlyRole(DEFAULT_ADMIN_ROLE)
 ```
 
 Sets token royalty i.e. the creator splitter address as EIP2981 royalty recipient. deploys a splitter if there is none deployed for a creator. Only admin can call it.
@@ -254,7 +255,6 @@ Parameters:
 
 - `tokenId` - the id of the token.
 
-
 ### isBridged
 
 ```solidity
@@ -275,7 +275,7 @@ function registerAndSubscribe(address subscriptionOrRegistrantToCopy, bool subsc
     onlyRole(DEFAULT_ADMIN_ROLE)
 ```
 
-Used to register and subscribe on the operator filter registry of Opensea
+Used to register and subscribe on the operator filter registry of OpenSea
 
 Parameters:
 
@@ -286,7 +286,7 @@ Parameters:
 
 ```solidity
 function setOperatorRegistry(address registry) external onlyRole(DEFAULT_ADMIN_ROLE)
-```fu
+```
 
 Used to the address of the operator filter registry
 

--- a/packages/dependency-operator-filter/contracts/OperatorFilterRegistrant.md
+++ b/packages/dependency-operator-filter/contracts/OperatorFilterRegistrant.md
@@ -1,19 +1,20 @@
-# OperatorFilterRegistry 
-Opensea in an attempt to regularize market places and creator earnings deployed a registry(https://github.com/ProjectOpenSea/operator-filter-registry) and asked NFT token contract to add filter logic(https://github.com/ProjectOpenSea/operator-filter-registry/blob/main/src/OperatorFilterer.sol). 
+# OperatorFilterRegistry
 
-These filter has two modifier 
-1st : onlyAllowedOperator 
+OpenSea in an attempt to regularize market places and creator earnings deployed a registry(https://github.com/ProjectOpenSea/operator-filter-registry) and asked NFT token contract to add filter logic(https://github.com/ProjectOpenSea/operator-filter-registry/blob/main/src/OperatorFilterer.sol).
+
+These filter has two modifier
+1st : onlyAllowedOperator
 2nd : onlyAllowedOperatorApproval
 
-These modifiers are added to to the transfer functions(onlyAllowedOperator) and approval function(onlyAllowedOperatorApproval) such that the when not an owner tried to transfer a Token(ex: Marketplace) or owner approves an operator(ex : Marketplace) they would be filtered on the OperatorFilterRegistry. 
+These modifiers are added to to the transfer functions(onlyAllowedOperator) and approval function(onlyAllowedOperatorApproval) such that the when not an owner tried to transfer a Token(ex: Marketplace) or owner approves an operator(ex : Marketplace) they would be filtered on the OperatorFilterRegistry.
 
 If the operator or the token transfer is not approved by the registry the transaction would be reverted.
 
-On OperatorFilterRegistry a contract owner or the contract can register and maintain there own blacklist or subscribe to other blacklists but that blacklist should contain the default marketplaces blacklisted by Opensea. 
+On OperatorFilterRegistry a contract owner or the contract can register and maintain there own blacklist or subscribe to other blacklists but that blacklist should contain the default marketplaces blacklisted by OpenSea.
 
-# OperatorFiltererRegistrant  
+# OperatorFiltererRegistrant
 
-The OperatorFiltererRegistrant contract is made to be registered on the OperatorFilterRegistry and copy the default blacklist of the openSea. This contract would then be subscribed by the contract such as AssetERC721 and AssetERC1155.
+The OperatorFiltererRegistrant contract is made to be registered on the OperatorFilterRegistry and copy the default blacklist of the OpenSea. This contract would then be subscribed by the contract such as AssetERC721 and AssetERC1155.
 
 The OperatorFiltererRegistrant would be the subscription for our token contracts on a layer(layer-1 : Ethereum , layer-2: Polygon), such that when a address is added or removed from OperatorFiltererRegistrant's blacklist it would be come in affect for each contact which subscribe to the OperatorFiltererRegistrant's blacklist.
 
@@ -21,7 +22,7 @@ The OperatorFiltererRegistrant would be the subscription for our token contracts
 
 The OperatorFiltererRegistrant is so that sandbox will have a common blacklist that would be utilized by every Token contract on a layer. This would create a single list that would be subscribed by each contract to provide uniformity to which market places sandbox wants to blacklist. This would also provide a focal point to remove and add market places such that it would be applicable to every contract that subscribe to it.
 
-# Implementation 
+# Implementation
 
 We didn't use the npm package as its solidity pragma(solidity version) doesn't match the one we have for our Asset contracts and updating our solidity version for Assets would have been to time consuming.
 

--- a/packages/dependency-operator-filter/contracts/OperatorFilterSubscription.sol
+++ b/packages/dependency-operator-filter/contracts/OperatorFilterSubscription.sol
@@ -15,7 +15,7 @@ contract OperatorFilterSubscription is Ownable {
         IOperatorFilterRegistry(0x000000000000AAeB6D7670E522A718067333cd4E);
 
     constructor() Ownable() {
-        // Subscribe and copy the entries of the Default subscription list of open sea.
+        // Subscribe and copy the entries of the Default subscription list of OpenSea.
         if (address(OPERATOR_FILTER_REGISTRY).code.length > 0) {
             OPERATOR_FILTER_REGISTRY.registerAndCopyEntries(address(this), DEFAULT_SUBSCRIPTION);
         }

--- a/packages/dependency-operator-filter/contracts/OperatorFilterSubscription.sol
+++ b/packages/dependency-operator-filter/contracts/OperatorFilterSubscription.sol
@@ -8,7 +8,7 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 /// @author The Sandbox
 /// @notice This contract is meant to register and copy the default subscription of the OpenSea for the operator filter and our Token contract are supposed to subscribe to this contract on openSea operator filter registry
 contract OperatorFilterSubscription is Ownable {
-    address public constant DEFAULT_SUBSCRIPTION = address(0x3cc6CddA760b79bAfa08dF41ECFA224f810dCeB6);
+    address public constant DEFAULT_SUBSCRIPTION = 0x3cc6CddA760b79bAfa08dF41ECFA224f810dCeB6;
 
     // solhint-disable-next-line const-name-snakecase
     IOperatorFilterRegistry public constant OPERATOR_FILTER_REGISTRY =

--- a/packages/dependency-operator-filter/contracts/OperatorFilterSubscription.sol
+++ b/packages/dependency-operator-filter/contracts/OperatorFilterSubscription.sol
@@ -6,7 +6,7 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 /// @title OperatorFilterSubription
 /// @author The Sandbox
-/// @notice This contract is meant to register and copy the default subscription of the OpenSea for the operator filter and our Token contract are supposed to subscribe to this contract on openSea operator filter registry
+/// @notice This contract is meant to register and copy the default subscription of the OpenSea for the operator filter and our Token contract are supposed to subscribe to this contract on OpenSea operator filter registry
 contract OperatorFilterSubscription is Ownable {
     address public constant DEFAULT_SUBSCRIPTION = 0x3cc6CddA760b79bAfa08dF41ECFA224f810dCeB6;
 

--- a/packages/dependency-operator-filter/contracts/OperatorFiltererUpgradeable.sol
+++ b/packages/dependency-operator-filter/contracts/OperatorFiltererUpgradeable.sol
@@ -6,7 +6,7 @@ import {IOperatorFilterRegistry} from "./interfaces/IOperatorFilterRegistry.sol"
 import {ContextUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol";
 
 ///@title OperatorFiltererUpgradeable
-///@author The SandBox
+///@author The Sandbox
 ///@notice This contract would subscribe or copy or just to the subscription provided or just register to default subscription list. The operator filter registry's address could be set using a setter which could be implemented in inheriting contract
 abstract contract OperatorFiltererUpgradeable is Initializable, ContextUpgradeable {
     event OperatorFilterRegistrySet(address indexed registry);

--- a/packages/dependency-operator-filter/contracts/OperatorFiltererUpgradeable.sol
+++ b/packages/dependency-operator-filter/contracts/OperatorFiltererUpgradeable.sol
@@ -7,7 +7,7 @@ import {ContextUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/Cont
 
 ///@title OperatorFiltererUpgradeable
 ///@author The SandBox
-///@notice This contract would subscibe or copy or just to the subscription provided or just register to default subscription list. The operator filter registry's addess could be set using a setter which could be implemented in inherting contract
+///@notice This contract would subscribe or copy or just to the subscription provided or just register to default subscription list. The operator filter registry's address could be set using a setter which could be implemented in inheriting contract
 abstract contract OperatorFiltererUpgradeable is Initializable, ContextUpgradeable {
     event OperatorFilterRegistrySet(address indexed registry);
 

--- a/packages/dependency-operator-filter/contracts/interfaces/IOperatorFilterRegistry.sol
+++ b/packages/dependency-operator-filter/contracts/interfaces/IOperatorFilterRegistry.sol
@@ -6,7 +6,7 @@ pragma solidity ^0.8.0;
 interface IOperatorFilterRegistry {
     ///@notice Returns true if operator is not filtered for a given token, either by address or codeHash. Also returns
     ///        true if supplied registrant address is not registered.
-    function isOperatorAllowed(address registrant, address operator) external view returns (bool);
+    function isOperatorAllowed(address registrant, address operator) external view returns (bool isAllowed);
 
     ///@notice Registers an address with the registry. May be called by address itself or by EIP-173 owner.
     function register(address registrant) external;
@@ -66,46 +66,44 @@ interface IOperatorFilterRegistry {
 
     ///@notice Get the set of addresses subscribed to a given registrant.
     ///        Note that order is not guaranteed as updates are made.
-
-    function subscribers(address registrant) external returns (address[] memory);
+    function subscribers(address registrant) external returns (address[] memory subscribersList);
 
     ///@notice Get the subscriber at a given index in the set of addresses subscribed to a given registrant.
     ///        Note that order is not guaranteed as updates are made.
-    function subscriberAt(address registrant, uint256 index) external returns (address);
+    function subscriberAt(address registrant, uint256 index) external returns (address subscriberAddress);
 
     ///@notice Copy filtered operators and codeHashes from a different registrantToCopy to addr.
-
     function copyEntriesOf(address registrant, address registrantToCopy) external;
 
     ///@notice Returns true if operator is filtered by a given address or its subscription.
-    function isOperatorFiltered(address registrant, address operator) external returns (bool);
+    function isOperatorFiltered(address registrant, address operator) external returns (bool isFiltered);
 
     ///@notice Returns true if the hash of an address's code is filtered by a given address or its subscription.
-    function isCodeHashOfFiltered(address registrant, address operatorWithCode) external returns (bool);
+    function isCodeHashOfFiltered(address registrant, address operatorWithCode) external returns (bool isFiltered);
 
     ///@notice Returns true if a codeHash is filtered by a given address or its subscription.
-    function isCodeHashFiltered(address registrant, bytes32 codeHash) external returns (bool);
+    function isCodeHashFiltered(address registrant, bytes32 codeHash) external returns (bool isFiltered);
 
     ///@notice Returns a list of filtered operators for a given address or its subscription.
-    function filteredOperators(address addr) external returns (address[] memory);
+    function filteredOperators(address addr) external returns (address[] memory operatorList);
 
     ///@notice Returns the set of filtered codeHashes for a given address or its subscription.
     ///        Note that order is not guaranteed as updates are made.
-    function filteredCodeHashes(address addr) external returns (bytes32[] memory);
+    function filteredCodeHashes(address addr) external returns (bytes32[] memory codeHashList);
 
     ///@notice Returns the filtered operator at the given index of the set of filtered operators for a given address or
     ///        its subscription.
     ///        Note that order is not guaranteed as updates are made.
-    function filteredOperatorAt(address registrant, uint256 index) external returns (address);
+    function filteredOperatorAt(address registrant, uint256 index) external returns (address operator);
 
     ///@notice Returns the filtered codeHash at the given index of the list of filtered codeHashes for a given address or
     ///        its subscription.
     ///        Note that order is not guaranteed as updates are made.
-    function filteredCodeHashAt(address registrant, uint256 index) external returns (bytes32);
+    function filteredCodeHashAt(address registrant, uint256 index) external returns (bytes32 codeHash);
 
     ///@notice Returns true if an address has registered
-    function isRegistered(address addr) external returns (bool);
+    function isRegistered(address addr) external returns (bool registered);
 
     ///@dev Convenience method to compute the code hash of an arbitrary contract
-    function codeHashOf(address addr) external returns (bytes32);
+    function codeHashOf(address addr) external returns (bytes32 codeHash);
 }

--- a/packages/dependency-operator-filter/contracts/mock/MockOperatorFilterRegistry.sol
+++ b/packages/dependency-operator-filter/contracts/mock/MockOperatorFilterRegistry.sol
@@ -11,7 +11,7 @@ import {
 
 /**
  * @title  MockOperatorFilterRegistry
- * @notice Made based on the OperatorFilterRegistry of openSea at https://github.com/ProjectOpenSea/operator-filter-registry/blob/main/src/OperatorFilterRegistry.sol
+ * @notice Made based on the OperatorFilterRegistry of OpenSea at https://github.com/ProjectOpenSea/operator-filter-registry/blob/main/src/OperatorFilterRegistry.sol
  * @notice This contracts allows tokens or token owners to register specific addresses or codeHashes that may be
  * *       restricted according to the isOperatorAllowed function.
  */

--- a/packages/dependency-royalty-management/contracts/MultiRoyaltyDistributor.sol
+++ b/packages/dependency-royalty-management/contracts/MultiRoyaltyDistributor.sol
@@ -3,10 +3,7 @@ pragma solidity ^0.8.0;
 
 import {ERC165Upgradeable} from "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol";
 import {IMultiRoyaltyDistributor, IMultiRoyaltyRecipients} from "./interfaces/IMultiRoyaltyDistributor.sol";
-import {
-    IRoyaltySplitter,
-    IERC165
-} from "@manifoldxyz/royalty-registry-solidity/contracts/overrides/IRoyaltySplitter.sol";
+import {IRoyaltySplitter, IERC165} from "@manifoldxyz/royalty-registry-solidity/contracts/overrides/IRoyaltySplitter.sol";
 import {IEIP2981} from "@manifoldxyz/royalty-registry-solidity/contracts/specs/IEIP2981.sol";
 import {IRoyaltyManager, Recipient} from "./interfaces/IRoyaltyManager.sol";
 
@@ -30,13 +27,9 @@ abstract contract MultiRoyaltyDistributor is IEIP2981, IMultiRoyaltyDistributor,
     /// @notice Query if a contract implements interface `id`.
     /// @param interfaceId the interface identifier, as specified in ERC-165.
     /// @return isSupported `true` if the contract implements `id`.
-    function supportsInterface(bytes4 interfaceId)
-        public
-        view
-        virtual
-        override(ERC165Upgradeable, IERC165)
-        returns (bool isSupported)
-    {
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override(ERC165Upgradeable, IERC165) returns (bool isSupported) {
         return
             interfaceId == type(IEIP2981).interfaceId ||
             interfaceId == type(IMultiRoyaltyDistributor).interfaceId ||
@@ -49,11 +42,7 @@ abstract contract MultiRoyaltyDistributor is IEIP2981, IMultiRoyaltyDistributor,
     /// @param tokenId id of token
     /// @param recipient royalty recipient
     /// @param creator of the token
-    function _setTokenRoyalties(
-        uint256 tokenId,
-        address payable recipient,
-        address creator
-    ) internal {
+    function _setTokenRoyalties(uint256 tokenId, address payable recipient, address creator) internal {
         address payable creatorSplitterAddress = IRoyaltyManager(royaltyManager).deploySplitter(creator, recipient);
 
         if (_tokenRoyaltiesSplitter[tokenId] != address(0)) {
@@ -71,14 +60,12 @@ abstract contract MultiRoyaltyDistributor is IEIP2981, IMultiRoyaltyDistributor,
     /// @param value the amount on which the royalty is calculated
     /// @return receiver address the royalty receiver
     /// @return royaltyAmount value the EIP2981 royalty
-    function royaltyInfo(uint256 tokenId, uint256 value)
-        public
-        view
-        override
-        returns (address receiver, uint256 royaltyAmount)
-    {
-        (address payable _defaultRoyaltyReceiver, uint16 _defaultRoyaltyBPS) =
-            IRoyaltyManager(royaltyManager).getRoyaltyInfo();
+    function royaltyInfo(
+        uint256 tokenId,
+        uint256 value
+    ) public view override returns (address receiver, uint256 royaltyAmount) {
+        (address payable _defaultRoyaltyReceiver, uint16 _defaultRoyaltyBPS) = IRoyaltyManager(royaltyManager)
+            .getRoyaltyInfo();
         if (_tokenRoyaltiesSplitter[tokenId] != address(0)) {
             return (_tokenRoyaltiesSplitter[tokenId], (value * _defaultRoyaltyBPS) / TOTAL_BASIS_POINTS);
         }

--- a/packages/dependency-royalty-management/contracts/MultiRoyaltyDistributor.sol
+++ b/packages/dependency-royalty-management/contracts/MultiRoyaltyDistributor.sol
@@ -36,11 +36,10 @@ abstract contract MultiRoyaltyDistributor is IEIP2981, IMultiRoyaltyDistributor,
         override(ERC165Upgradeable, IERC165)
         returns (bool isSupported)
     {
-        return
-            interfaceId == type(IEIP2981).interfaceId ||
+        isSupported = (interfaceId == type(IEIP2981).interfaceId ||
             interfaceId == type(IMultiRoyaltyDistributor).interfaceId ||
             interfaceId == type(IMultiRoyaltyRecipients).interfaceId ||
-            super.supportsInterface(interfaceId);
+            super.supportsInterface(interfaceId));
     }
 
     /// @notice sets token royalty
@@ -79,12 +78,17 @@ abstract contract MultiRoyaltyDistributor is IEIP2981, IMultiRoyaltyDistributor,
         (address payable _defaultRoyaltyReceiver, uint16 _defaultRoyaltyBPS) =
             IRoyaltyManager(royaltyManager).getRoyaltyInfo();
         if (_tokenRoyaltiesSplitter[tokenId] != address(0)) {
-            return (_tokenRoyaltiesSplitter[tokenId], (value * _defaultRoyaltyBPS) / TOTAL_BASIS_POINTS);
+            (receiver, royaltyAmount) = (
+                _tokenRoyaltiesSplitter[tokenId],
+                (value * _defaultRoyaltyBPS) / TOTAL_BASIS_POINTS
+            );
+            return (receiver, royaltyAmount);
         }
         if (_defaultRoyaltyReceiver != address(0) && _defaultRoyaltyBPS != 0) {
-            return (_defaultRoyaltyReceiver, (value * _defaultRoyaltyBPS) / TOTAL_BASIS_POINTS);
+            (receiver, royaltyAmount) = (_defaultRoyaltyReceiver, (value * _defaultRoyaltyBPS) / TOTAL_BASIS_POINTS);
+            return (receiver, royaltyAmount);
         }
-        return (address(0), 0);
+        return (receiver, royaltyAmount);
     }
 
     /// @notice returns the EIP-2981 royalty receiver for each token (i.e. splitters) including the default royalty receiver.
@@ -134,13 +138,13 @@ abstract contract MultiRoyaltyDistributor is IEIP2981, IMultiRoyaltyDistributor,
     /// @param tokenId is the token id for which royalty splitter should be returned.
     /// @return splitterAddress address of royalty splitter for the token
     function getTokenRoyaltiesSplitter(uint256 tokenId) external view returns (address payable splitterAddress) {
-        return _tokenRoyaltiesSplitter[tokenId];
+        splitterAddress = _tokenRoyaltiesSplitter[tokenId];
     }
 
     /// @notice returns the address of royalty manager.
     /// @return managerAddress address of royalty manager.
     function getRoyaltyManager() external view returns (address managerAddress) {
-        return royaltyManager;
+        managerAddress = royaltyManager;
     }
 
     /// @notice set royalty manager address

--- a/packages/dependency-royalty-management/contracts/MultiRoyaltyDistributor.sol
+++ b/packages/dependency-royalty-management/contracts/MultiRoyaltyDistributor.sol
@@ -37,11 +37,10 @@ abstract contract MultiRoyaltyDistributor is IEIP2981, IMultiRoyaltyDistributor,
         override(ERC165Upgradeable, IERC165)
         returns (bool isSupported)
     {
-        return
-            interfaceId == type(IEIP2981).interfaceId ||
+        isSupported = (interfaceId == type(IEIP2981).interfaceId ||
             interfaceId == type(IMultiRoyaltyDistributor).interfaceId ||
             interfaceId == type(IMultiRoyaltyRecipients).interfaceId ||
-            super.supportsInterface(interfaceId);
+            super.supportsInterface(interfaceId));
     }
 
     /// @notice sets token royalty
@@ -80,12 +79,17 @@ abstract contract MultiRoyaltyDistributor is IEIP2981, IMultiRoyaltyDistributor,
         (address payable _defaultRoyaltyReceiver, uint16 _defaultRoyaltyBPS) =
             IRoyaltyManager(royaltyManager).getRoyaltyInfo();
         if (_tokenRoyaltiesSplitter[tokenId] != address(0)) {
-            return (_tokenRoyaltiesSplitter[tokenId], (value * _defaultRoyaltyBPS) / TOTAL_BASIS_POINTS);
+            (receiver, royaltyAmount) = (
+                _tokenRoyaltiesSplitter[tokenId],
+                (value * _defaultRoyaltyBPS) / TOTAL_BASIS_POINTS
+            );
+            return (receiver, royaltyAmount);
         }
         if (_defaultRoyaltyReceiver != address(0) && _defaultRoyaltyBPS != 0) {
-            return (_defaultRoyaltyReceiver, (value * _defaultRoyaltyBPS) / TOTAL_BASIS_POINTS);
+            (receiver, royaltyAmount) = (_defaultRoyaltyReceiver, (value * _defaultRoyaltyBPS) / TOTAL_BASIS_POINTS);
+            return (receiver, royaltyAmount);
         }
-        return (address(0), 0);
+        return (receiver, royaltyAmount);
     }
 
     /// @notice returns the EIP-2981 royalty receiver for each token (i.e. splitters) including the default royalty receiver.
@@ -135,13 +139,13 @@ abstract contract MultiRoyaltyDistributor is IEIP2981, IMultiRoyaltyDistributor,
     /// @param tokenId is the token id for which royalty splitter should be returned.
     /// @return splitterAddress address of royalty splitter for the token
     function getTokenRoyaltiesSplitter(uint256 tokenId) external view returns (address payable splitterAddress) {
-        return _tokenRoyaltiesSplitter[tokenId];
+        splitterAddress = _tokenRoyaltiesSplitter[tokenId];
     }
 
     /// @notice returns the address of royalty manager.
     /// @return managerAddress address of royalty manager.
     function getRoyaltyManager() external view returns (address managerAddress) {
-        return royaltyManager;
+        managerAddress = royaltyManager;
     }
 
     /// @notice set royalty manager address

--- a/packages/dependency-royalty-management/contracts/MultiRoyaltyDistributor.sol
+++ b/packages/dependency-royalty-management/contracts/MultiRoyaltyDistributor.sol
@@ -37,10 +37,11 @@ abstract contract MultiRoyaltyDistributor is IEIP2981, IMultiRoyaltyDistributor,
         override(ERC165Upgradeable, IERC165)
         returns (bool isSupported)
     {
-        isSupported = (interfaceId == type(IEIP2981).interfaceId ||
+        return
+            interfaceId == type(IEIP2981).interfaceId ||
             interfaceId == type(IMultiRoyaltyDistributor).interfaceId ||
             interfaceId == type(IMultiRoyaltyRecipients).interfaceId ||
-            super.supportsInterface(interfaceId));
+            super.supportsInterface(interfaceId);
     }
 
     /// @notice sets token royalty
@@ -79,17 +80,12 @@ abstract contract MultiRoyaltyDistributor is IEIP2981, IMultiRoyaltyDistributor,
         (address payable _defaultRoyaltyReceiver, uint16 _defaultRoyaltyBPS) =
             IRoyaltyManager(royaltyManager).getRoyaltyInfo();
         if (_tokenRoyaltiesSplitter[tokenId] != address(0)) {
-            (receiver, royaltyAmount) = (
-                _tokenRoyaltiesSplitter[tokenId],
-                (value * _defaultRoyaltyBPS) / TOTAL_BASIS_POINTS
-            );
-            return (receiver, royaltyAmount);
+            return (_tokenRoyaltiesSplitter[tokenId], (value * _defaultRoyaltyBPS) / TOTAL_BASIS_POINTS);
         }
         if (_defaultRoyaltyReceiver != address(0) && _defaultRoyaltyBPS != 0) {
-            (receiver, royaltyAmount) = (_defaultRoyaltyReceiver, (value * _defaultRoyaltyBPS) / TOTAL_BASIS_POINTS);
-            return (receiver, royaltyAmount);
+            return (_defaultRoyaltyReceiver, (value * _defaultRoyaltyBPS) / TOTAL_BASIS_POINTS);
         }
-        return (receiver, royaltyAmount);
+        return (address(0), 0);
     }
 
     /// @notice returns the EIP-2981 royalty receiver for each token (i.e. splitters) including the default royalty receiver.
@@ -139,13 +135,13 @@ abstract contract MultiRoyaltyDistributor is IEIP2981, IMultiRoyaltyDistributor,
     /// @param tokenId is the token id for which royalty splitter should be returned.
     /// @return splitterAddress address of royalty splitter for the token
     function getTokenRoyaltiesSplitter(uint256 tokenId) external view returns (address payable splitterAddress) {
-        splitterAddress = _tokenRoyaltiesSplitter[tokenId];
+        return _tokenRoyaltiesSplitter[tokenId];
     }
 
     /// @notice returns the address of royalty manager.
     /// @return managerAddress address of royalty manager.
     function getRoyaltyManager() external view returns (address managerAddress) {
-        managerAddress = royaltyManager;
+        return royaltyManager;
     }
 
     /// @notice set royalty manager address

--- a/packages/dependency-royalty-management/contracts/MultiRoyaltyDistributor.sol
+++ b/packages/dependency-royalty-management/contracts/MultiRoyaltyDistributor.sol
@@ -10,10 +10,10 @@ import {
 import {IEIP2981} from "@manifoldxyz/royalty-registry-solidity/contracts/specs/IEIP2981.sol";
 import {IRoyaltyManager, Recipient} from "./interfaces/IRoyaltyManager.sol";
 
-/// @title MultiRoyaltyDistributer
+/// @title MultiRoyaltyDistributor
 /// @author The Sandbox
-/// @dev  The MultiRoyaltyDistributer contract implements the ERC-2981 and ERC-165 interfaces for a royalty payment system. This payment system can be used to pay royalties to multiple recipients through splitters.
-/// @dev  This contract calls to the Royalties manager contract to deploy RoyaltySplitter for a creator to slip its royalty between the creator and Sandbox and use it for every token minted by that creator.
+/// @dev  The MultiRoyaltyDistributor contract implements the ERC-2981 and ERC-165 interfaces for a royalty payment system. This payment system can be used to pay royalties to multiple recipients through splitters.
+/// @dev  This contract calls to the Royalties manager contract to deploy RoyaltySplitter for a creator to split its royalty between the creator and Sandbox and use it for every token minted by that creator.
 abstract contract MultiRoyaltyDistributor is IEIP2981, IMultiRoyaltyDistributor, ERC165Upgradeable {
     uint16 internal constant TOTAL_BASIS_POINTS = 10000;
     address private royaltyManager;

--- a/packages/dependency-royalty-management/contracts/MultiRoyaltyDistributor.sol
+++ b/packages/dependency-royalty-management/contracts/MultiRoyaltyDistributor.sol
@@ -26,9 +26,9 @@ abstract contract MultiRoyaltyDistributor is IEIP2981, IMultiRoyaltyDistributor,
         _setRoyaltyManager(_royaltyManager);
     }
 
-    /// @notice EIP 165 interface function
-    /// @dev used to check the interface implemented
-    /// @param interfaceId to be checked for implementation
+    /// @notice Query if a contract implements interface `id`.
+    /// @param interfaceId the interface identifier, as specified in ERC-165.
+    /// @return `true` if the contract implements `id`.
     function supportsInterface(bytes4 interfaceId)
         public
         view
@@ -46,6 +46,7 @@ abstract contract MultiRoyaltyDistributor is IEIP2981, IMultiRoyaltyDistributor,
     /// @notice sets token royalty
     /// @dev deploys a splitter if a creator doesn't have one
     /// @param tokenId id of token
+    /// @param recipient royalty recipient
     /// @param creator of the token
     function _setTokenRoyalties(
         uint256 tokenId,

--- a/packages/dependency-royalty-management/contracts/MultiRoyaltyDistributor.sol
+++ b/packages/dependency-royalty-management/contracts/MultiRoyaltyDistributor.sol
@@ -24,6 +24,7 @@ abstract contract MultiRoyaltyDistributor is IEIP2981, IMultiRoyaltyDistributor,
     // solhint-disable-next-line func-name-mixedcase
     function __MultiRoyaltyDistributor_init(address _royaltyManager) internal onlyInitializing {
         _setRoyaltyManager(_royaltyManager);
+        __ERC165_init_unchained();
     }
 
     /// @notice Query if a contract implements interface `id`.

--- a/packages/dependency-royalty-management/contracts/MultiRoyaltyDistributor.sol
+++ b/packages/dependency-royalty-management/contracts/MultiRoyaltyDistributor.sol
@@ -36,10 +36,11 @@ abstract contract MultiRoyaltyDistributor is IEIP2981, IMultiRoyaltyDistributor,
         override(ERC165Upgradeable, IERC165)
         returns (bool isSupported)
     {
-        isSupported = (interfaceId == type(IEIP2981).interfaceId ||
+        return
+            interfaceId == type(IEIP2981).interfaceId ||
             interfaceId == type(IMultiRoyaltyDistributor).interfaceId ||
             interfaceId == type(IMultiRoyaltyRecipients).interfaceId ||
-            super.supportsInterface(interfaceId));
+            super.supportsInterface(interfaceId);
     }
 
     /// @notice sets token royalty
@@ -78,17 +79,12 @@ abstract contract MultiRoyaltyDistributor is IEIP2981, IMultiRoyaltyDistributor,
         (address payable _defaultRoyaltyReceiver, uint16 _defaultRoyaltyBPS) =
             IRoyaltyManager(royaltyManager).getRoyaltyInfo();
         if (_tokenRoyaltiesSplitter[tokenId] != address(0)) {
-            (receiver, royaltyAmount) = (
-                _tokenRoyaltiesSplitter[tokenId],
-                (value * _defaultRoyaltyBPS) / TOTAL_BASIS_POINTS
-            );
-            return (receiver, royaltyAmount);
+            return (_tokenRoyaltiesSplitter[tokenId], (value * _defaultRoyaltyBPS) / TOTAL_BASIS_POINTS);
         }
         if (_defaultRoyaltyReceiver != address(0) && _defaultRoyaltyBPS != 0) {
-            (receiver, royaltyAmount) = (_defaultRoyaltyReceiver, (value * _defaultRoyaltyBPS) / TOTAL_BASIS_POINTS);
-            return (receiver, royaltyAmount);
+            return (_defaultRoyaltyReceiver, (value * _defaultRoyaltyBPS) / TOTAL_BASIS_POINTS);
         }
-        return (receiver, royaltyAmount);
+        return (address(0), 0);
     }
 
     /// @notice returns the EIP-2981 royalty receiver for each token (i.e. splitters) including the default royalty receiver.
@@ -114,16 +110,16 @@ abstract contract MultiRoyaltyDistributor is IEIP2981, IMultiRoyaltyDistributor,
     /// @notice returns the royalty recipients for each tokenId.
     /// @dev returns the default address for tokens with no recipients.
     /// @param tokenId is the token id for which the recipient should be returned.
-    /// @return defaultRecipient addresses of royalty recipient of the token.
-    function getRecipients(uint256 tokenId) public view returns (Recipient[] memory defaultRecipient) {
+    /// @return recipients array of royalty recipients for the token
+    function getRecipients(uint256 tokenId) public view returns (Recipient[] memory recipients) {
         address payable splitterAddress = _tokenRoyaltiesSplitter[tokenId];
         (address payable _defaultRoyaltyReceiver, ) = IRoyaltyManager(royaltyManager).getRoyaltyInfo();
         if (splitterAddress != address(0)) {
             return IRoyaltySplitter(splitterAddress).getRecipients();
         }
-        defaultRecipient = new Recipient[](1);
-        defaultRecipient[0] = Recipient({recipient: _defaultRoyaltyReceiver, bps: TOTAL_BASIS_POINTS});
-        return defaultRecipient;
+        recipients = new Recipient[](1);
+        recipients[0] = Recipient({recipient: _defaultRoyaltyReceiver, bps: TOTAL_BASIS_POINTS});
+        return recipients;
     }
 
     /// @notice internal function to set the token royalty splitter
@@ -138,13 +134,13 @@ abstract contract MultiRoyaltyDistributor is IEIP2981, IMultiRoyaltyDistributor,
     /// @param tokenId is the token id for which royalty splitter should be returned.
     /// @return splitterAddress address of royalty splitter for the token
     function getTokenRoyaltiesSplitter(uint256 tokenId) external view returns (address payable splitterAddress) {
-        splitterAddress = _tokenRoyaltiesSplitter[tokenId];
+        return _tokenRoyaltiesSplitter[tokenId];
     }
 
     /// @notice returns the address of royalty manager.
     /// @return managerAddress address of royalty manager.
     function getRoyaltyManager() external view returns (address managerAddress) {
-        managerAddress = royaltyManager;
+        return royaltyManager;
     }
 
     /// @notice set royalty manager address

--- a/packages/dependency-royalty-management/contracts/MultiRoyaltyDistributor.sol
+++ b/packages/dependency-royalty-management/contracts/MultiRoyaltyDistributor.sol
@@ -36,10 +36,11 @@ abstract contract MultiRoyaltyDistributor is IEIP2981, IMultiRoyaltyDistributor,
         override(ERC165Upgradeable, IERC165)
         returns (bool isSupported)
     {
-        isSupported = (interfaceId == type(IEIP2981).interfaceId ||
+        return
+            interfaceId == type(IEIP2981).interfaceId ||
             interfaceId == type(IMultiRoyaltyDistributor).interfaceId ||
             interfaceId == type(IMultiRoyaltyRecipients).interfaceId ||
-            super.supportsInterface(interfaceId));
+            super.supportsInterface(interfaceId);
     }
 
     /// @notice sets token royalty
@@ -78,17 +79,12 @@ abstract contract MultiRoyaltyDistributor is IEIP2981, IMultiRoyaltyDistributor,
         (address payable _defaultRoyaltyReceiver, uint16 _defaultRoyaltyBPS) =
             IRoyaltyManager(royaltyManager).getRoyaltyInfo();
         if (_tokenRoyaltiesSplitter[tokenId] != address(0)) {
-            (receiver, royaltyAmount) = (
-                _tokenRoyaltiesSplitter[tokenId],
-                (value * _defaultRoyaltyBPS) / TOTAL_BASIS_POINTS
-            );
-            return (receiver, royaltyAmount);
+            return (_tokenRoyaltiesSplitter[tokenId], (value * _defaultRoyaltyBPS) / TOTAL_BASIS_POINTS);
         }
         if (_defaultRoyaltyReceiver != address(0) && _defaultRoyaltyBPS != 0) {
-            (receiver, royaltyAmount) = (_defaultRoyaltyReceiver, (value * _defaultRoyaltyBPS) / TOTAL_BASIS_POINTS);
-            return (receiver, royaltyAmount);
+            return (_defaultRoyaltyReceiver, (value * _defaultRoyaltyBPS) / TOTAL_BASIS_POINTS);
         }
-        return (receiver, royaltyAmount);
+        return (address(0), 0);
     }
 
     /// @notice returns the EIP-2981 royalty receiver for each token (i.e. splitters) including the default royalty receiver.
@@ -138,13 +134,13 @@ abstract contract MultiRoyaltyDistributor is IEIP2981, IMultiRoyaltyDistributor,
     /// @param tokenId is the token id for which royalty splitter should be returned.
     /// @return splitterAddress address of royalty splitter for the token
     function getTokenRoyaltiesSplitter(uint256 tokenId) external view returns (address payable splitterAddress) {
-        splitterAddress = _tokenRoyaltiesSplitter[tokenId];
+        return _tokenRoyaltiesSplitter[tokenId];
     }
 
     /// @notice returns the address of royalty manager.
     /// @return managerAddress address of royalty manager.
     function getRoyaltyManager() external view returns (address managerAddress) {
-        managerAddress = royaltyManager;
+        return royaltyManager;
     }
 
     /// @notice set royalty manager address

--- a/packages/dependency-royalty-management/contracts/MultiRoyaltyDistributor.sol
+++ b/packages/dependency-royalty-management/contracts/MultiRoyaltyDistributor.sol
@@ -3,7 +3,10 @@ pragma solidity ^0.8.0;
 
 import {ERC165Upgradeable} from "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol";
 import {IMultiRoyaltyDistributor, IMultiRoyaltyRecipients} from "./interfaces/IMultiRoyaltyDistributor.sol";
-import {IRoyaltySplitter, IERC165} from "@manifoldxyz/royalty-registry-solidity/contracts/overrides/IRoyaltySplitter.sol";
+import {
+    IRoyaltySplitter,
+    IERC165
+} from "@manifoldxyz/royalty-registry-solidity/contracts/overrides/IRoyaltySplitter.sol";
 import {IEIP2981} from "@manifoldxyz/royalty-registry-solidity/contracts/specs/IEIP2981.sol";
 import {IRoyaltyManager, Recipient} from "./interfaces/IRoyaltyManager.sol";
 
@@ -27,9 +30,13 @@ abstract contract MultiRoyaltyDistributor is IEIP2981, IMultiRoyaltyDistributor,
     /// @notice Query if a contract implements interface `id`.
     /// @param interfaceId the interface identifier, as specified in ERC-165.
     /// @return isSupported `true` if the contract implements `id`.
-    function supportsInterface(
-        bytes4 interfaceId
-    ) public view virtual override(ERC165Upgradeable, IERC165) returns (bool isSupported) {
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(ERC165Upgradeable, IERC165)
+        returns (bool isSupported)
+    {
         return
             interfaceId == type(IEIP2981).interfaceId ||
             interfaceId == type(IMultiRoyaltyDistributor).interfaceId ||
@@ -42,7 +49,11 @@ abstract contract MultiRoyaltyDistributor is IEIP2981, IMultiRoyaltyDistributor,
     /// @param tokenId id of token
     /// @param recipient royalty recipient
     /// @param creator of the token
-    function _setTokenRoyalties(uint256 tokenId, address payable recipient, address creator) internal {
+    function _setTokenRoyalties(
+        uint256 tokenId,
+        address payable recipient,
+        address creator
+    ) internal {
         address payable creatorSplitterAddress = IRoyaltyManager(royaltyManager).deploySplitter(creator, recipient);
 
         if (_tokenRoyaltiesSplitter[tokenId] != address(0)) {
@@ -60,12 +71,14 @@ abstract contract MultiRoyaltyDistributor is IEIP2981, IMultiRoyaltyDistributor,
     /// @param value the amount on which the royalty is calculated
     /// @return receiver address the royalty receiver
     /// @return royaltyAmount value the EIP2981 royalty
-    function royaltyInfo(
-        uint256 tokenId,
-        uint256 value
-    ) public view override returns (address receiver, uint256 royaltyAmount) {
-        (address payable _defaultRoyaltyReceiver, uint16 _defaultRoyaltyBPS) = IRoyaltyManager(royaltyManager)
-            .getRoyaltyInfo();
+    function royaltyInfo(uint256 tokenId, uint256 value)
+        public
+        view
+        override
+        returns (address receiver, uint256 royaltyAmount)
+    {
+        (address payable _defaultRoyaltyReceiver, uint16 _defaultRoyaltyBPS) =
+            IRoyaltyManager(royaltyManager).getRoyaltyInfo();
         if (_tokenRoyaltiesSplitter[tokenId] != address(0)) {
             return (_tokenRoyaltiesSplitter[tokenId], (value * _defaultRoyaltyBPS) / TOTAL_BASIS_POINTS);
         }

--- a/packages/dependency-royalty-management/contracts/MultiRoyaltyDistributor.sol
+++ b/packages/dependency-royalty-management/contracts/MultiRoyaltyDistributor.sol
@@ -28,13 +28,13 @@ abstract contract MultiRoyaltyDistributor is IEIP2981, IMultiRoyaltyDistributor,
 
     /// @notice Query if a contract implements interface `id`.
     /// @param interfaceId the interface identifier, as specified in ERC-165.
-    /// @return `true` if the contract implements `id`.
+    /// @return isSupported `true` if the contract implements `id`.
     function supportsInterface(bytes4 interfaceId)
         public
         view
         virtual
         override(ERC165Upgradeable, IERC165)
-        returns (bool)
+        returns (bool isSupported)
     {
         return
             interfaceId == type(IEIP2981).interfaceId ||
@@ -68,9 +68,14 @@ abstract contract MultiRoyaltyDistributor is IEIP2981, IMultiRoyaltyDistributor,
     /// @notice EIP 2981 royalty info function to return the royalty receiver and royalty amount
     /// @param tokenId of the token for which the royalty is needed to be distributed
     /// @param value the amount on which the royalty is calculated
-    /// @return address the royalty receiver
-    /// @return value the EIP2981 royalty
-    function royaltyInfo(uint256 tokenId, uint256 value) public view override returns (address, uint256) {
+    /// @return receiver address the royalty receiver
+    /// @return royaltyAmount value the EIP2981 royalty
+    function royaltyInfo(uint256 tokenId, uint256 value)
+        public
+        view
+        override
+        returns (address receiver, uint256 royaltyAmount)
+    {
         (address payable _defaultRoyaltyReceiver, uint16 _defaultRoyaltyBPS) =
             IRoyaltyManager(royaltyManager).getRoyaltyInfo();
         if (_tokenRoyaltiesSplitter[tokenId] != address(0)) {
@@ -105,14 +110,14 @@ abstract contract MultiRoyaltyDistributor is IEIP2981, IMultiRoyaltyDistributor,
     /// @notice returns the royalty recipients for each tokenId.
     /// @dev returns the default address for tokens with no recipients.
     /// @param tokenId is the token id for which the recipient should be returned.
-    /// @return addresses of royalty recipient of the token.
-    function getRecipients(uint256 tokenId) public view returns (Recipient[] memory) {
+    /// @return defaultRecipient addresses of royalty recipient of the token.
+    function getRecipients(uint256 tokenId) public view returns (Recipient[] memory defaultRecipient) {
         address payable splitterAddress = _tokenRoyaltiesSplitter[tokenId];
         (address payable _defaultRoyaltyReceiver, ) = IRoyaltyManager(royaltyManager).getRoyaltyInfo();
         if (splitterAddress != address(0)) {
             return IRoyaltySplitter(splitterAddress).getRecipients();
         }
-        Recipient[] memory defaultRecipient = new Recipient[](1);
+        defaultRecipient = new Recipient[](1);
         defaultRecipient[0] = Recipient({recipient: _defaultRoyaltyReceiver, bps: TOTAL_BASIS_POINTS});
         return defaultRecipient;
     }

--- a/packages/dependency-royalty-management/contracts/RoyaltyDistributor.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltyDistributor.sol
@@ -53,7 +53,7 @@ abstract contract RoyaltyDistributor is IERC2981Upgradeable, ERC165Upgradeable {
     /// @notice returns the royalty manager
     /// @return royaltyManagerAddress address of royalty manager contract.
     function getRoyaltyManager() external view returns (IRoyaltyManager royaltyManagerAddress) {
-        return royaltyManager;
+        royaltyManagerAddress = royaltyManager;
     }
 
     /// @notice set royalty manager

--- a/packages/dependency-royalty-management/contracts/RoyaltyDistributor.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltyDistributor.sol
@@ -19,6 +19,7 @@ abstract contract RoyaltyDistributor is IERC2981Upgradeable, ERC165Upgradeable {
     // solhint-disable-next-line func-name-mixedcase
     function __RoyaltyDistributor_init(address _royaltyManager) internal onlyInitializing {
         _setRoyaltyManager(_royaltyManager);
+        __ERC165_init_unchained();
     }
 
     /// @notice Returns how much royalty is owed and to whom based on ERC2981

--- a/packages/dependency-royalty-management/contracts/RoyaltyDistributor.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltyDistributor.sol
@@ -38,13 +38,13 @@ abstract contract RoyaltyDistributor is IERC2981Upgradeable, ERC165Upgradeable {
 
     /// @notice Query if a contract implements interface `id`.
     /// @param interfaceId the interface identifier, as specified in ERC-165.
-    /// @return `true` if the contract implements `id`.
+    /// @return isSupported `true` if the contract implements `id`.
     function supportsInterface(bytes4 interfaceId)
         public
         view
         virtual
         override(ERC165Upgradeable, IERC165Upgradeable)
-        returns (bool)
+        returns (bool isSupported)
     {
         return interfaceId == type(IERC2981Upgradeable).interfaceId || super.supportsInterface(interfaceId);
     }

--- a/packages/dependency-royalty-management/contracts/RoyaltyDistributor.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltyDistributor.sol
@@ -52,7 +52,7 @@ abstract contract RoyaltyDistributor is IERC2981Upgradeable, ERC165Upgradeable {
     /// @notice returns the royalty manager
     /// @return royaltyManagerAddress address of royalty manager contract.
     function getRoyaltyManager() external view returns (IRoyaltyManager royaltyManagerAddress) {
-        return royaltyManager;
+        royaltyManagerAddress = royaltyManager;
     }
 
     /// @notice set royalty manager

--- a/packages/dependency-royalty-management/contracts/RoyaltyDistributor.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltyDistributor.sol
@@ -53,7 +53,7 @@ abstract contract RoyaltyDistributor is IERC2981Upgradeable, ERC165Upgradeable {
     /// @notice returns the royalty manager
     /// @return royaltyManagerAddress address of royalty manager contract.
     function getRoyaltyManager() external view returns (IRoyaltyManager royaltyManagerAddress) {
-        royaltyManagerAddress = royaltyManager;
+        return royaltyManager;
     }
 
     /// @notice set royalty manager

--- a/packages/dependency-royalty-management/contracts/RoyaltyDistributor.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltyDistributor.sol
@@ -46,13 +46,13 @@ abstract contract RoyaltyDistributor is IERC2981Upgradeable, ERC165Upgradeable {
         override(ERC165Upgradeable, IERC165Upgradeable)
         returns (bool isSupported)
     {
-        isSupported = (interfaceId == type(IERC2981Upgradeable).interfaceId || super.supportsInterface(interfaceId));
+        return (interfaceId == type(IERC2981Upgradeable).interfaceId || super.supportsInterface(interfaceId));
     }
 
     /// @notice returns the royalty manager
     /// @return royaltyManagerAddress address of royalty manager contract.
     function getRoyaltyManager() external view returns (IRoyaltyManager royaltyManagerAddress) {
-        royaltyManagerAddress = royaltyManager;
+        return royaltyManager;
     }
 
     /// @notice set royalty manager

--- a/packages/dependency-royalty-management/contracts/RoyaltyDistributor.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltyDistributor.sol
@@ -46,13 +46,13 @@ abstract contract RoyaltyDistributor is IERC2981Upgradeable, ERC165Upgradeable {
         override(ERC165Upgradeable, IERC165Upgradeable)
         returns (bool isSupported)
     {
-        return interfaceId == type(IERC2981Upgradeable).interfaceId || super.supportsInterface(interfaceId);
+        isSupported = (interfaceId == type(IERC2981Upgradeable).interfaceId || super.supportsInterface(interfaceId));
     }
 
     /// @notice returns the royalty manager
     /// @return royaltyManagerAddress address of royalty manager contract.
     function getRoyaltyManager() external view returns (IRoyaltyManager royaltyManagerAddress) {
-        return royaltyManager;
+        royaltyManagerAddress = royaltyManager;
     }
 
     /// @notice set royalty manager

--- a/packages/dependency-royalty-management/contracts/RoyaltyDistributor.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltyDistributor.sol
@@ -52,7 +52,7 @@ abstract contract RoyaltyDistributor is IERC2981Upgradeable, ERC165Upgradeable {
     /// @notice returns the royalty manager
     /// @return royaltyManagerAddress address of royalty manager contract.
     function getRoyaltyManager() external view returns (IRoyaltyManager royaltyManagerAddress) {
-        royaltyManagerAddress = royaltyManager;
+        return royaltyManager;
     }
 
     /// @notice set royalty manager

--- a/packages/dependency-royalty-management/contracts/RoyaltyManager.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltyManager.sol
@@ -157,20 +157,20 @@ contract RoyaltyManager is AccessControlUpgradeable, IRoyaltyManager {
     /// @param creator the address of the creator
     /// @return creatorSplitterAddress splitter's address deployed for a creator
     function getCreatorRoyaltySplitter(address creator) external view returns (address payable creatorSplitterAddress) {
-        return creatorRoyaltiesSplitter[creator];
+        creatorSplitterAddress = creatorRoyaltiesSplitter[creator];
     }
 
     /// @notice returns the amount of basis points allocated to the creator
     /// @return creatorSplit which is 10000 - commonSplit
     function getCreatorSplit() external view returns (uint16 creatorSplit) {
-        return TOTAL_BASIS_POINTS - commonSplit;
+        creatorSplit = TOTAL_BASIS_POINTS - commonSplit;
     }
 
     /// @notice returns the commonRecipient and EIP2981 royalty bps
     /// @return recipient address of common royalty recipient
     /// @return royaltySplit contract EIP2981 royalty bps
     function getRoyaltyInfo() external view returns (address payable recipient, uint16 royaltySplit) {
-        return (commonRecipient, contractRoyalty[msg.sender]);
+        (recipient, royaltySplit) = (commonRecipient, contractRoyalty[msg.sender]);
     }
 
     /// @notice returns the EIP2981 royalty bps

--- a/packages/dependency-royalty-management/contracts/RoyaltyManager.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltyManager.sol
@@ -177,7 +177,7 @@ contract RoyaltyManager is AccessControlUpgradeable, IRoyaltyManager {
     /// @param _contractAddress the address of the contract for which the royalty is required
     /// @return royaltyBps royalty bps of the contract
     function getContractRoyalty(address _contractAddress) external view returns (uint16 royaltyBps) {
-        return contractRoyalty[_contractAddress];
+        royaltyBps = contractRoyalty[_contractAddress];
     }
 
     uint256[46] private __gap;

--- a/packages/dependency-royalty-management/contracts/RoyaltyManager.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltyManager.sol
@@ -91,7 +91,7 @@ contract RoyaltyManager is AccessControlUpgradeable, IRoyaltyManager {
     /// @notice get the current trustedForwarder address
     /// @return trustedForwarder address of current TrustedForwarder
     function getTrustedForwarder() public view returns (address trustedForwarder) {
-        trustedForwarder = _trustedForwarder;
+        return _trustedForwarder;
     }
 
     function _setRecipient(address payable _commonRecipient) internal {
@@ -130,7 +130,7 @@ contract RoyaltyManager is AccessControlUpgradeable, IRoyaltyManager {
     /// @notice to be called by the splitters to get the common recipient and split
     /// @return recipient which has the common recipient and split
     function getCommonRecipient() external view override returns (Recipient memory recipient) {
-        recipient = Recipient({recipient: commonRecipient, bps: commonSplit});
+        return Recipient({recipient: commonRecipient, bps: commonSplit});
     }
 
     /// @notice deploys splitter for creator
@@ -157,20 +157,20 @@ contract RoyaltyManager is AccessControlUpgradeable, IRoyaltyManager {
     /// @param creator the address of the creator
     /// @return creatorSplitterAddress splitter's address deployed for a creator
     function getCreatorRoyaltySplitter(address creator) external view returns (address payable creatorSplitterAddress) {
-        creatorSplitterAddress = creatorRoyaltiesSplitter[creator];
+        return creatorRoyaltiesSplitter[creator];
     }
 
     /// @notice returns the amount of basis points allocated to the creator
     /// @return creatorSplit which is 10000 - commonSplit
     function getCreatorSplit() external view returns (uint16 creatorSplit) {
-        creatorSplit = TOTAL_BASIS_POINTS - commonSplit;
+        return TOTAL_BASIS_POINTS - commonSplit;
     }
 
     /// @notice returns the commonRecipient and EIP2981 royalty bps
     /// @return recipient address of common royalty recipient
     /// @return royaltySplit contract EIP2981 royalty bps
     function getRoyaltyInfo() external view returns (address payable recipient, uint16 royaltySplit) {
-        (recipient, royaltySplit) = (commonRecipient, contractRoyalty[msg.sender]);
+        return (commonRecipient, contractRoyalty[msg.sender]);
     }
 
     /// @notice returns the EIP2981 royalty bps

--- a/packages/dependency-royalty-management/contracts/RoyaltyManager.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltyManager.sol
@@ -157,20 +157,20 @@ contract RoyaltyManager is AccessControlUpgradeable, IRoyaltyManager {
     /// @param creator the address of the creator
     /// @return creatorSplitterAddress splitter's address deployed for a creator
     function getCreatorRoyaltySplitter(address creator) external view returns (address payable creatorSplitterAddress) {
-        creatorSplitterAddress = creatorRoyaltiesSplitter[creator];
+        return creatorRoyaltiesSplitter[creator];
     }
 
     /// @notice returns the amount of basis points allocated to the creator
     /// @return creatorSplit which is 10000 - commonSplit
     function getCreatorSplit() external view returns (uint16 creatorSplit) {
-        creatorSplit = TOTAL_BASIS_POINTS - commonSplit;
+        return TOTAL_BASIS_POINTS - commonSplit;
     }
 
     /// @notice returns the commonRecipient and EIP2981 royalty bps
     /// @return recipient address of common royalty recipient
     /// @return royaltySplit contract EIP2981 royalty bps
     function getRoyaltyInfo() external view returns (address payable recipient, uint16 royaltySplit) {
-        (recipient, royaltySplit) = (commonRecipient, contractRoyalty[msg.sender]);
+        return (commonRecipient, contractRoyalty[msg.sender]);
     }
 
     /// @notice returns the EIP2981 royalty bps

--- a/packages/dependency-royalty-management/contracts/RoyaltyManager.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltyManager.sol
@@ -150,7 +150,7 @@ contract RoyaltyManager is AccessControlUpgradeable, IRoyaltyManager {
             creatorRoyaltiesSplitter[creator] = creatorSplitterAddress;
             emit SplitterDeployed(creator, recipient, creatorSplitterAddress);
         }
-        return _creatorSplitterAddress;
+        return creatorSplitterAddress;
     }
 
     /// @notice returns the address of splitter of a creator.

--- a/packages/dependency-royalty-management/contracts/RoyaltyManager.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltyManager.sol
@@ -89,8 +89,8 @@ contract RoyaltyManager is AccessControlUpgradeable, IRoyaltyManager {
     }
 
     /// @notice get the current trustedForwarder address
-    /// @return address of current TrustedForwarder
-    function getTrustedForwarder() public view returns (address) {
+    /// @return trustedForwarder address of current TrustedForwarder
+    function getTrustedForwarder() public view returns (address trustedForwarder) {
         return _trustedForwarder;
     }
 
@@ -138,39 +138,39 @@ contract RoyaltyManager is AccessControlUpgradeable, IRoyaltyManager {
     /// @dev should only called once per creator
     /// @param creator the address of the creator
     /// @param recipient the wallet of the recipient where they would receive their royalty
-    /// @return creatorSplitterAddress deployed for a creator
+    /// @return creatorSplitterAddress creatorSplitterAddress deployed for a creator
     function deploySplitter(address creator, address payable recipient)
         external
         onlyRole(SPLITTER_DEPLOYER_ROLE)
-        returns (address payable)
+        returns (address payable creatorSplitterAddress)
     {
-        address payable _creatorSplitterAddress = creatorRoyaltiesSplitter[creator];
-        if (_creatorSplitterAddress == address(0)) {
-            _creatorSplitterAddress = payable(Clones.clone(_royaltySplitterCloneable));
-            RoyaltySplitter(_creatorSplitterAddress).initialize(recipient, address(this));
-            creatorRoyaltiesSplitter[creator] = _creatorSplitterAddress;
-            emit SplitterDeployed(creator, recipient, _creatorSplitterAddress);
+        creatorSplitterAddress = creatorRoyaltiesSplitter[creator];
+        if (creatorSplitterAddress == address(0)) {
+            creatorSplitterAddress = payable(Clones.clone(_royaltySplitterCloneable));
+            RoyaltySplitter(creatorSplitterAddress).initialize(recipient, address(this));
+            creatorRoyaltiesSplitter[creator] = creatorSplitterAddress;
+            emit SplitterDeployed(creator, recipient, creatorSplitterAddress);
         }
-        return _creatorSplitterAddress;
+        return creatorSplitterAddress;
     }
 
     /// @notice returns the address of splitter of a creator.
     /// @param creator the address of the creator
     /// @return creatorSplitterAddress deployed for a creator
-    function getCreatorRoyaltySplitter(address creator) external view returns (address payable) {
+    function getCreatorRoyaltySplitter(address creator) external view returns (address payable creatorSplitterAddress) {
         return creatorRoyaltiesSplitter[creator];
     }
 
     /// @notice returns the amount of basis points allocated to the creator
     /// @return creatorSplit which is 10000 - commonSplit
-    function getCreatorSplit() external view returns (uint16) {
+    function getCreatorSplit() external view returns (uint16 creatorSplit) {
         return TOTAL_BASIS_POINTS - commonSplit;
     }
 
     /// @notice returns the commonRecipient and EIP2981 royalty bps
-    /// @return commonRecipient address of common royalty recipient
-    /// @return contract EIP2981 royalty bps
-    function getRoyaltyInfo() external view returns (address payable, uint16) {
+    /// @return recipient address of common royalty recipient
+    /// @return royaltySplit contract EIP2981 royalty bps
+    function getRoyaltyInfo() external view returns (address payable recipient, uint16 royaltySplit) {
         return (commonRecipient, contractRoyalty[msg.sender]);
     }
 

--- a/packages/dependency-royalty-management/contracts/RoyaltyManager.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltyManager.sol
@@ -89,6 +89,7 @@ contract RoyaltyManager is AccessControlUpgradeable, IRoyaltyManager {
     }
 
     /// @notice get the current trustedForwarder address
+    /// @return address of current TrustedForwarder
     function getTrustedForwarder() public view returns (address) {
         return _trustedForwarder;
     }
@@ -115,6 +116,7 @@ contract RoyaltyManager is AccessControlUpgradeable, IRoyaltyManager {
 
     /// @notice called to set the EIP 2981 royalty split
     /// @dev can only be called by contract royalty setter.
+    /// @param contractAddress address of contract for which royalty is set
     /// @param _royaltyBps the royalty split for the EIP 2981
     function setContractRoyalty(address contractAddress, uint16 _royaltyBps)
         external

--- a/packages/dependency-royalty-management/contracts/RoyaltyManager.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltyManager.sol
@@ -91,7 +91,7 @@ contract RoyaltyManager is AccessControlUpgradeable, IRoyaltyManager {
     /// @notice get the current trustedForwarder address
     /// @return trustedForwarder address of current TrustedForwarder
     function getTrustedForwarder() public view returns (address trustedForwarder) {
-        return _trustedForwarder;
+        trustedForwarder = _trustedForwarder;
     }
 
     function _setRecipient(address payable _commonRecipient) internal {
@@ -157,20 +157,20 @@ contract RoyaltyManager is AccessControlUpgradeable, IRoyaltyManager {
     /// @param creator the address of the creator
     /// @return creatorSplitterAddress splitter's address deployed for a creator
     function getCreatorRoyaltySplitter(address creator) external view returns (address payable creatorSplitterAddress) {
-        return creatorRoyaltiesSplitter[creator];
+        creatorSplitterAddress = creatorRoyaltiesSplitter[creator];
     }
 
     /// @notice returns the amount of basis points allocated to the creator
     /// @return creatorSplit which is 10000 - commonSplit
     function getCreatorSplit() external view returns (uint16 creatorSplit) {
-        return TOTAL_BASIS_POINTS - commonSplit;
+        creatorSplit = TOTAL_BASIS_POINTS - commonSplit;
     }
 
     /// @notice returns the commonRecipient and EIP2981 royalty bps
     /// @return recipient address of common royalty recipient
     /// @return royaltySplit contract EIP2981 royalty bps
     function getRoyaltyInfo() external view returns (address payable recipient, uint16 royaltySplit) {
-        return (commonRecipient, contractRoyalty[msg.sender]);
+        (recipient, royaltySplit) = (commonRecipient, contractRoyalty[msg.sender]);
     }
 
     /// @notice returns the EIP2981 royalty bps

--- a/packages/dependency-royalty-management/contracts/RoyaltyManager.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltyManager.sol
@@ -91,7 +91,7 @@ contract RoyaltyManager is AccessControlUpgradeable, IRoyaltyManager {
     /// @notice get the current trustedForwarder address
     /// @return trustedForwarder address of current TrustedForwarder
     function getTrustedForwarder() public view returns (address trustedForwarder) {
-        trustedForwarder = _trustedForwarder;
+        return _trustedForwarder;
     }
 
     function _setRecipient(address payable _commonRecipient) internal {
@@ -157,20 +157,20 @@ contract RoyaltyManager is AccessControlUpgradeable, IRoyaltyManager {
     /// @param creator the address of the creator
     /// @return creatorSplitterAddress splitter's address deployed for a creator
     function getCreatorRoyaltySplitter(address creator) external view returns (address payable creatorSplitterAddress) {
-        creatorSplitterAddress = creatorRoyaltiesSplitter[creator];
+        return creatorRoyaltiesSplitter[creator];
     }
 
     /// @notice returns the amount of basis points allocated to the creator
     /// @return creatorSplit which is 10000 - commonSplit
     function getCreatorSplit() external view returns (uint16 creatorSplit) {
-        creatorSplit = TOTAL_BASIS_POINTS - commonSplit;
+        return TOTAL_BASIS_POINTS - commonSplit;
     }
 
     /// @notice returns the commonRecipient and EIP2981 royalty bps
     /// @return recipient address of common royalty recipient
     /// @return royaltySplit contract EIP2981 royalty bps
     function getRoyaltyInfo() external view returns (address payable recipient, uint16 royaltySplit) {
-        (recipient, royaltySplit) = (commonRecipient, contractRoyalty[msg.sender]);
+        return (commonRecipient, contractRoyalty[msg.sender]);
     }
 
     /// @notice returns the EIP2981 royalty bps

--- a/packages/dependency-royalty-management/contracts/RoyaltyManager.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltyManager.sol
@@ -90,7 +90,7 @@ contract RoyaltyManager is AccessControlUpgradeable, IRoyaltyManager {
 
     /// @notice get the current trustedForwarder address
     /// @return trustedForwarder address of current TrustedForwarder
-    function getTrustedForwarder() public view returns (address trustedForwarder) {
+    function getTrustedForwarder() external view returns (address trustedForwarder) {
         return _trustedForwarder;
     }
 

--- a/packages/dependency-royalty-management/contracts/RoyaltyManager.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltyManager.sol
@@ -150,7 +150,7 @@ contract RoyaltyManager is AccessControlUpgradeable, IRoyaltyManager {
             creatorRoyaltiesSplitter[creator] = creatorSplitterAddress;
             emit SplitterDeployed(creator, recipient, creatorSplitterAddress);
         }
-        return creatorSplitterAddress;
+        return _creatorSplitterAddress;
     }
 
     /// @notice returns the address of splitter of a creator.

--- a/packages/dependency-royalty-management/contracts/RoyaltyManager.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltyManager.sol
@@ -91,7 +91,7 @@ contract RoyaltyManager is AccessControlUpgradeable, IRoyaltyManager {
     /// @notice get the current trustedForwarder address
     /// @return trustedForwarder address of current TrustedForwarder
     function getTrustedForwarder() public view returns (address trustedForwarder) {
-        return _trustedForwarder;
+        trustedForwarder = _trustedForwarder;
     }
 
     function _setRecipient(address payable _commonRecipient) internal {
@@ -131,7 +131,6 @@ contract RoyaltyManager is AccessControlUpgradeable, IRoyaltyManager {
     /// @return recipient which has the common recipient and split
     function getCommonRecipient() external view override returns (Recipient memory recipient) {
         recipient = Recipient({recipient: commonRecipient, bps: commonSplit});
-        return recipient;
     }
 
     /// @notice deploys splitter for creator
@@ -158,20 +157,20 @@ contract RoyaltyManager is AccessControlUpgradeable, IRoyaltyManager {
     /// @param creator the address of the creator
     /// @return creatorSplitterAddress deployed for a creator
     function getCreatorRoyaltySplitter(address creator) external view returns (address payable creatorSplitterAddress) {
-        return creatorRoyaltiesSplitter[creator];
+        creatorSplitterAddress = creatorRoyaltiesSplitter[creator];
     }
 
     /// @notice returns the amount of basis points allocated to the creator
     /// @return creatorSplit which is 10000 - commonSplit
     function getCreatorSplit() external view returns (uint16 creatorSplit) {
-        return TOTAL_BASIS_POINTS - commonSplit;
+        creatorSplit = TOTAL_BASIS_POINTS - commonSplit;
     }
 
     /// @notice returns the commonRecipient and EIP2981 royalty bps
     /// @return recipient address of common royalty recipient
     /// @return royaltySplit contract EIP2981 royalty bps
     function getRoyaltyInfo() external view returns (address payable recipient, uint16 royaltySplit) {
-        return (commonRecipient, contractRoyalty[msg.sender]);
+        (recipient, royaltySplit) = (commonRecipient, contractRoyalty[msg.sender]);
     }
 
     /// @notice returns the EIP2981 royalty bps

--- a/packages/dependency-royalty-management/contracts/RoyaltyManager.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltyManager.sol
@@ -23,6 +23,12 @@ contract RoyaltyManager is AccessControlUpgradeable, IRoyaltyManager {
     address internal _royaltySplitterCloneable;
     address internal _trustedForwarder;
 
+    /// @dev this protects the implementation contract from behing initialized.
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
     /// @notice initialization function for the deployment of contract
     /// @dev called during the deployment via the proxy.
     /// @param _commonRecipient the != address(0)common recipient for all the splitters

--- a/packages/dependency-royalty-management/contracts/RoyaltyManager.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltyManager.sol
@@ -137,7 +137,7 @@ contract RoyaltyManager is AccessControlUpgradeable, IRoyaltyManager {
     /// @dev should only called once per creator
     /// @param creator the address of the creator
     /// @param recipient the wallet of the recipient where they would receive their royalty
-    /// @return creatorSplitterAddress creatorSplitterAddress deployed for a creator
+    /// @return creatorSplitterAddress splitter's address deployed for a creator
     function deploySplitter(address creator, address payable recipient)
         external
         onlyRole(SPLITTER_DEPLOYER_ROLE)
@@ -155,7 +155,7 @@ contract RoyaltyManager is AccessControlUpgradeable, IRoyaltyManager {
 
     /// @notice returns the address of splitter of a creator.
     /// @param creator the address of the creator
-    /// @return creatorSplitterAddress deployed for a creator
+    /// @return creatorSplitterAddress splitter's address deployed for a creator
     function getCreatorRoyaltySplitter(address creator) external view returns (address payable creatorSplitterAddress) {
         creatorSplitterAddress = creatorRoyaltiesSplitter[creator];
     }

--- a/packages/dependency-royalty-management/contracts/RoyaltyManager.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltyManager.sol
@@ -177,7 +177,7 @@ contract RoyaltyManager is AccessControlUpgradeable, IRoyaltyManager {
     /// @param _contractAddress the address of the contract for which the royalty is required
     /// @return royaltyBps royalty bps of the contract
     function getContractRoyalty(address _contractAddress) external view returns (uint16 royaltyBps) {
-        royaltyBps = contractRoyalty[_contractAddress];
+        return contractRoyalty[_contractAddress];
     }
 
     uint256[46] private __gap;

--- a/packages/dependency-royalty-management/contracts/RoyaltySplitter.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltySplitter.sol
@@ -55,12 +55,6 @@ contract RoyaltySplitter is
         _disableInitializers();
     }
 
-    /// @dev this protects the implementation contract from behing initialized.
-    /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor() {
-        _disableInitializers();
-    }
-
     /// @notice Query if a contract implements interface `id`.
     /// @param interfaceId the interface identifier, as specified in ERC-165.
     /// @return isSupported `true` if the contract implements `id`.

--- a/packages/dependency-royalty-management/contracts/RoyaltySplitter.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltySplitter.sol
@@ -47,7 +47,11 @@ contract RoyaltySplitter is
 
     event ETHTransferred(address indexed account, uint256 amount);
     event ERC20Transferred(address indexed erc20Contract, address indexed account, uint256 amount);
+<<<<<<< HEAD
     event RecipientSet(address indexed recipientAddress);
+=======
+    event RecipientSet(address indexed newRecipient);
+>>>>>>> 0a587f5d (feat : added events after sensitive changes)
 
     /// @notice Query if a contract implements interface `id`.
     /// @param interfaceId the interface identifier, as specified in ERC-165.

--- a/packages/dependency-royalty-management/contracts/RoyaltySplitter.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltySplitter.sol
@@ -76,6 +76,7 @@ contract RoyaltySplitter is
         royaltyManager = IRoyaltyManager(_royaltyManager); // set manager before Ownable_init for _isTrustedForwarder
         _setRecipient(recipientAddress);
         __Ownable_init();
+        __ERC165_init();
     }
 
     /// @notice sets recipient for the splitter

--- a/packages/dependency-royalty-management/contracts/RoyaltySplitter.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltySplitter.sol
@@ -53,6 +53,12 @@ contract RoyaltySplitter is
     event RecipientSet(address indexed newRecipient);
 >>>>>>> 0a587f5d (feat : added events after sensitive changes)
 
+    /// @dev this protects the implementation contract from behing initialized.
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
     /// @notice Query if a contract implements interface `id`.
     /// @param interfaceId the interface identifier, as specified in ERC-165.
     /// @return `true` if the contract implements `id`.

--- a/packages/dependency-royalty-management/contracts/RoyaltySplitter.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltySplitter.sol
@@ -153,8 +153,7 @@ contract RoyaltySplitter is
     function _splitERC20Tokens(IERC20 erc20Contract) internal returns (bool success) {
         try erc20Contract.balanceOf(address(this)) returns (uint256 balance) {
             if (balance == 0) {
-                success = false;
-                return success;
+                return false;
             }
             Recipient memory commonRecipient = royaltyManager.getCommonRecipient();
             uint16 creatorSplit = royaltyManager.getCreatorSplit();
@@ -185,9 +184,9 @@ contract RoyaltySplitter is
             }
             erc20Contract.safeTransfer(_recipients[0].recipient, amountToSend);
             emit ERC20Transferred(address(erc20Contract), _recipients[0].recipient, amountToSend);
-            success = true;
+            return true;
         } catch {
-            success = false;
+            return false;
         }
     }
 
@@ -210,7 +209,7 @@ contract RoyaltySplitter is
         override(ContextUpgradeable, ERC2771HandlerAbstract)
         returns (address sender)
     {
-        sender = ERC2771HandlerAbstract._msgSender();
+        return ERC2771HandlerAbstract._msgSender();
     }
 
     function _msgData()
@@ -220,6 +219,6 @@ contract RoyaltySplitter is
         override(ContextUpgradeable, ERC2771HandlerAbstract)
         returns (bytes calldata messageData)
     {
-        messageData = ERC2771HandlerAbstract._msgData();
+        return ERC2771HandlerAbstract._msgData();
     }
 }

--- a/packages/dependency-royalty-management/contracts/RoyaltySplitter.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltySplitter.sol
@@ -47,11 +47,7 @@ contract RoyaltySplitter is
 
     event ETHTransferred(address indexed account, uint256 amount);
     event ERC20Transferred(address indexed erc20Contract, address indexed account, uint256 amount);
-<<<<<<< HEAD
     event RecipientSet(address indexed recipientAddress);
-=======
-    event RecipientSet(address indexed newRecipient);
->>>>>>> 0a587f5d (feat : added events after sensitive changes)
 
     /// @dev this protects the implementation contract from behing initialized.
     /// @custom:oz-upgrades-unsafe-allow constructor

--- a/packages/dependency-royalty-management/contracts/RoyaltySplitter.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltySplitter.sol
@@ -47,7 +47,11 @@ contract RoyaltySplitter is
 
     event ETHTransferred(address indexed account, uint256 amount);
     event ERC20Transferred(address indexed erc20Contract, address indexed account, uint256 amount);
+<<<<<<< HEAD
     event RecipientSet(address indexed recipientAddress);
+=======
+    event RecipientSet(address indexed newRecipient);
+>>>>>>> 0a587f5d (feat : added events after sensitive changes)
 
     /// @dev this protects the implementation contract from behing initialized.
     /// @custom:oz-upgrades-unsafe-allow constructor

--- a/packages/dependency-royalty-management/contracts/RoyaltySplitter.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltySplitter.sol
@@ -152,7 +152,8 @@ contract RoyaltySplitter is
     function _splitERC20Tokens(IERC20 erc20Contract) internal returns (bool success) {
         try erc20Contract.balanceOf(address(this)) returns (uint256 balance) {
             if (balance == 0) {
-                return false;
+                success = false;
+                return success;
             }
             Recipient memory commonRecipient = royaltyManager.getCommonRecipient();
             uint16 creatorSplit = royaltyManager.getCreatorSplit();
@@ -183,9 +184,9 @@ contract RoyaltySplitter is
             }
             erc20Contract.safeTransfer(_recipients[0].recipient, amountToSend);
             emit ERC20Transferred(address(erc20Contract), _recipients[0].recipient, amountToSend);
-            return true;
+            success = true;
         } catch {
-            return false;
+            success = false;
         }
     }
 
@@ -208,7 +209,7 @@ contract RoyaltySplitter is
         override(ContextUpgradeable, ERC2771HandlerAbstract)
         returns (address sender)
     {
-        return ERC2771HandlerAbstract._msgSender();
+        sender = ERC2771HandlerAbstract._msgSender();
     }
 
     function _msgData()
@@ -218,6 +219,6 @@ contract RoyaltySplitter is
         override(ContextUpgradeable, ERC2771HandlerAbstract)
         returns (bytes calldata messageData)
     {
-        return ERC2771HandlerAbstract._msgData();
+        messageData = ERC2771HandlerAbstract._msgData();
     }
 }

--- a/packages/dependency-royalty-management/contracts/RoyaltySplitter.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltySplitter.sol
@@ -55,12 +55,6 @@ contract RoyaltySplitter is
         _disableInitializers();
     }
 
-    /// @dev this protects the implementation contract from behing initialized.
-    /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor() {
-        _disableInitializers();
-    }
-
     /// @notice Query if a contract implements interface `id`.
     /// @param interfaceId the interface identifier, as specified in ERC-165.
     /// @return `true` if the contract implements `id`.

--- a/packages/dependency-royalty-management/contracts/RoyaltySplitter.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltySplitter.sol
@@ -72,7 +72,7 @@ contract RoyaltySplitter is
     /// @dev can only be run once.
     /// @param recipientAddress the wallet of the creator when the contract is deployed
     /// @param _royaltyManager the address of the royalty manager contract
-    function initialize(address payable recipientAddress, address _royaltyManager) public initializer {
+    function initialize(address payable recipientAddress, address _royaltyManager) external initializer {
         royaltyManager = IRoyaltyManager(_royaltyManager); // set manager before Ownable_init for _isTrustedForwarder
         _setRecipient(recipientAddress);
         __Ownable_init();

--- a/packages/dependency-royalty-management/contracts/RoyaltySplitter.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltySplitter.sol
@@ -113,7 +113,7 @@ contract RoyaltySplitter is
 
     /// @notice Splits and forwards ETH to the royalty receivers
     /// @dev normally ETH should be split automatically by receive function.
-    function splitETH() public payable {
+    function splitETH() external payable {
         _splitETH(address(this).balance);
     }
 
@@ -146,7 +146,7 @@ contract RoyaltySplitter is
     /// @notice split ERC20 Tokens owned by this contract.
     /// @dev can only be called by one of the recipients
     /// @param erc20Contract the address of the tokens to be split.
-    function splitERC20Tokens(IERC20 erc20Contract) public {
+    function splitERC20Tokens(IERC20 erc20Contract) external {
         require(_splitERC20Tokens(erc20Contract), "Split: ERC20 split failed");
     }
 

--- a/packages/dependency-royalty-management/contracts/RoyaltySplitter.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltySplitter.sol
@@ -38,9 +38,6 @@ contract RoyaltySplitter is
     using SafeERC20 for IERC20;
 
     uint256 internal constant TOTAL_BASIS_POINTS = 10000;
-    uint256 internal constant IERC20_APPROVE_SELECTOR =
-        0x095ea7b300000000000000000000000000000000000000000000000000000000;
-    uint256 internal constant SELECTOR_MASK = 0xffffffff00000000000000000000000000000000000000000000000000000000;
 
     address payable public recipient;
     IRoyaltyManager public royaltyManager;

--- a/packages/dependency-royalty-management/contracts/RoyaltySplitter.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltySplitter.sol
@@ -65,7 +65,7 @@ contract RoyaltySplitter is
         override(IERC165, ERC165Upgradeable)
         returns (bool isSupported)
     {
-        isSupported = (interfaceId == type(IRoyaltySplitter).interfaceId || super.supportsInterface(interfaceId));
+        return (interfaceId == type(IRoyaltySplitter).interfaceId || super.supportsInterface(interfaceId));
     }
 
     /// @notice initialize the contract
@@ -152,8 +152,7 @@ contract RoyaltySplitter is
     function _splitERC20Tokens(IERC20 erc20Contract) internal returns (bool success) {
         try erc20Contract.balanceOf(address(this)) returns (uint256 balance) {
             if (balance == 0) {
-                success = false;
-                return success;
+                return false;
             }
             Recipient memory commonRecipient = royaltyManager.getCommonRecipient();
             uint16 creatorSplit = royaltyManager.getCreatorSplit();
@@ -184,9 +183,9 @@ contract RoyaltySplitter is
             }
             erc20Contract.safeTransfer(_recipients[0].recipient, amountToSend);
             emit ERC20Transferred(address(erc20Contract), _recipients[0].recipient, amountToSend);
-            success = true;
+            return true;
         } catch {
-            success = false;
+            return false;
         }
     }
 
@@ -199,7 +198,7 @@ contract RoyaltySplitter is
         override(ERC2771HandlerAbstract)
         returns (bool isTrusted)
     {
-        isTrusted = (forwarder == royaltyManager.getTrustedForwarder());
+        return (forwarder == royaltyManager.getTrustedForwarder());
     }
 
     function _msgSender()
@@ -209,7 +208,7 @@ contract RoyaltySplitter is
         override(ContextUpgradeable, ERC2771HandlerAbstract)
         returns (address sender)
     {
-        sender = ERC2771HandlerAbstract._msgSender();
+        return ERC2771HandlerAbstract._msgSender();
     }
 
     function _msgData()
@@ -219,6 +218,6 @@ contract RoyaltySplitter is
         override(ContextUpgradeable, ERC2771HandlerAbstract)
         returns (bytes calldata messageData)
     {
-        messageData = ERC2771HandlerAbstract._msgData();
+        return ERC2771HandlerAbstract._msgData();
     }
 }

--- a/packages/dependency-royalty-management/contracts/RoyaltySplitter.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltySplitter.sol
@@ -57,13 +57,13 @@ contract RoyaltySplitter is
 
     /// @notice Query if a contract implements interface `id`.
     /// @param interfaceId the interface identifier, as specified in ERC-165.
-    /// @return `true` if the contract implements `id`.
+    /// @return isSupported `true` if the contract implements `id`.
     function supportsInterface(bytes4 interfaceId)
         public
         view
         virtual
         override(IERC165, ERC165Upgradeable)
-        returns (bool)
+        returns (bool isSupported)
     {
         return interfaceId == type(IRoyaltySplitter).interfaceId || super.supportsInterface(interfaceId);
     }
@@ -93,11 +93,11 @@ contract RoyaltySplitter is
     }
 
     /// @notice to get recipients of royalty through this splitter and their splits of royalty.
-    /// @return recipients of royalty through this splitter and their splits of royalty.
-    function getRecipients() external view override returns (Recipient[] memory) {
+    /// @return recipients array of royalty recipients through the splitter and their splits of royalty.
+    function getRecipients() external view override returns (Recipient[] memory recipients) {
         Recipient memory commonRecipient = royaltyManager.getCommonRecipient();
         uint16 creatorSplit = royaltyManager.getCreatorSplit();
-        Recipient[] memory recipients = new Recipient[](2);
+        recipients = new Recipient[](2);
         recipients[0].recipient = recipient;
         recipients[0].bps = creatorSplit;
         recipients[1] = commonRecipient;
@@ -149,7 +149,7 @@ contract RoyaltySplitter is
         require(_splitERC20Tokens(erc20Contract), "Split: ERC20 split failed");
     }
 
-    function _splitERC20Tokens(IERC20 erc20Contract) internal returns (bool) {
+    function _splitERC20Tokens(IERC20 erc20Contract) internal returns (bool success) {
         try erc20Contract.balanceOf(address(this)) returns (uint256 balance) {
             if (balance == 0) {
                 return false;
@@ -169,7 +169,6 @@ contract RoyaltySplitter is
             unchecked {
                 for (uint256 i = _recipients.length - 1; i > 0; i--) {
                     Recipient memory _recipient = _recipients[i];
-                    bool success;
                     (success, amountToSend) = balance.tryMul(_recipient.bps);
                     require(success, "RoyaltySplitter: Multiplication Overflow");
 

--- a/packages/dependency-royalty-management/contracts/RoyaltySplitter.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltySplitter.sol
@@ -153,7 +153,8 @@ contract RoyaltySplitter is
     function _splitERC20Tokens(IERC20 erc20Contract) internal returns (bool success) {
         try erc20Contract.balanceOf(address(this)) returns (uint256 balance) {
             if (balance == 0) {
-                return false;
+                success = false;
+                return success;
             }
             Recipient memory commonRecipient = royaltyManager.getCommonRecipient();
             uint16 creatorSplit = royaltyManager.getCreatorSplit();
@@ -184,9 +185,9 @@ contract RoyaltySplitter is
             }
             erc20Contract.safeTransfer(_recipients[0].recipient, amountToSend);
             emit ERC20Transferred(address(erc20Contract), _recipients[0].recipient, amountToSend);
-            return true;
+            success = true;
         } catch {
-            return false;
+            success = false;
         }
     }
 
@@ -209,7 +210,7 @@ contract RoyaltySplitter is
         override(ContextUpgradeable, ERC2771HandlerAbstract)
         returns (address sender)
     {
-        return ERC2771HandlerAbstract._msgSender();
+        sender = ERC2771HandlerAbstract._msgSender();
     }
 
     function _msgData()
@@ -219,6 +220,6 @@ contract RoyaltySplitter is
         override(ContextUpgradeable, ERC2771HandlerAbstract)
         returns (bytes calldata messageData)
     {
-        return ERC2771HandlerAbstract._msgData();
+        messageData = ERC2771HandlerAbstract._msgData();
     }
 }

--- a/packages/dependency-royalty-management/contracts/RoyaltySplitter.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltySplitter.sol
@@ -65,7 +65,7 @@ contract RoyaltySplitter is
         override(IERC165, ERC165Upgradeable)
         returns (bool isSupported)
     {
-        return interfaceId == type(IRoyaltySplitter).interfaceId || super.supportsInterface(interfaceId);
+        isSupported = (interfaceId == type(IRoyaltySplitter).interfaceId || super.supportsInterface(interfaceId));
     }
 
     /// @notice initialize the contract
@@ -152,7 +152,8 @@ contract RoyaltySplitter is
     function _splitERC20Tokens(IERC20 erc20Contract) internal returns (bool success) {
         try erc20Contract.balanceOf(address(this)) returns (uint256 balance) {
             if (balance == 0) {
-                return false;
+                success = false;
+                return success;
             }
             Recipient memory commonRecipient = royaltyManager.getCommonRecipient();
             uint16 creatorSplit = royaltyManager.getCreatorSplit();
@@ -183,17 +184,22 @@ contract RoyaltySplitter is
             }
             erc20Contract.safeTransfer(_recipients[0].recipient, amountToSend);
             emit ERC20Transferred(address(erc20Contract), _recipients[0].recipient, amountToSend);
-            return true;
+            success = true;
         } catch {
-            return false;
+            success = false;
         }
     }
 
     /// @notice verify whether a forwarder address is the trustedForwarder address, using the manager setting
     /// @dev this function is used to avoid having a trustedForwarder variable inside the splitter
-    /// @return bool whether the forwarder is the trusted address
-    function _isTrustedForwarder(address forwarder) internal view override(ERC2771HandlerAbstract) returns (bool) {
-        return forwarder == royaltyManager.getTrustedForwarder();
+    /// @return isTrusted bool whether the forwarder is the trusted address
+    function _isTrustedForwarder(address forwarder)
+        internal
+        view
+        override(ERC2771HandlerAbstract)
+        returns (bool isTrusted)
+    {
+        isTrusted = (forwarder == royaltyManager.getTrustedForwarder());
     }
 
     function _msgSender()
@@ -203,7 +209,7 @@ contract RoyaltySplitter is
         override(ContextUpgradeable, ERC2771HandlerAbstract)
         returns (address sender)
     {
-        return ERC2771HandlerAbstract._msgSender();
+        sender = ERC2771HandlerAbstract._msgSender();
     }
 
     function _msgData()
@@ -211,8 +217,8 @@ contract RoyaltySplitter is
         view
         virtual
         override(ContextUpgradeable, ERC2771HandlerAbstract)
-        returns (bytes calldata)
+        returns (bytes calldata messageData)
     {
-        return ERC2771HandlerAbstract._msgData();
+        messageData = ERC2771HandlerAbstract._msgData();
     }
 }

--- a/packages/dependency-royalty-management/contracts/RoyaltySplitter.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltySplitter.sol
@@ -88,7 +88,6 @@ contract RoyaltySplitter is
     }
 
     function _setRecipient(address payable recipientAddress) private {
-        delete recipient;
         recipient = recipientAddress;
         emit RecipientSet(recipientAddress);
     }

--- a/packages/dependency-royalty-management/contracts/RoyaltySplitter.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltySplitter.sol
@@ -152,8 +152,7 @@ contract RoyaltySplitter is
     function _splitERC20Tokens(IERC20 erc20Contract) internal returns (bool success) {
         try erc20Contract.balanceOf(address(this)) returns (uint256 balance) {
             if (balance == 0) {
-                success = false;
-                return success;
+                return false;
             }
             Recipient memory commonRecipient = royaltyManager.getCommonRecipient();
             uint16 creatorSplit = royaltyManager.getCreatorSplit();
@@ -184,9 +183,9 @@ contract RoyaltySplitter is
             }
             erc20Contract.safeTransfer(_recipients[0].recipient, amountToSend);
             emit ERC20Transferred(address(erc20Contract), _recipients[0].recipient, amountToSend);
-            success = true;
+            return true;
         } catch {
-            success = false;
+            return false;
         }
     }
 
@@ -209,7 +208,7 @@ contract RoyaltySplitter is
         override(ContextUpgradeable, ERC2771HandlerAbstract)
         returns (address sender)
     {
-        sender = ERC2771HandlerAbstract._msgSender();
+        return ERC2771HandlerAbstract._msgSender();
     }
 
     function _msgData()
@@ -219,6 +218,6 @@ contract RoyaltySplitter is
         override(ContextUpgradeable, ERC2771HandlerAbstract)
         returns (bytes calldata messageData)
     {
-        messageData = ERC2771HandlerAbstract._msgData();
+        return ERC2771HandlerAbstract._msgData();
     }
 }

--- a/packages/dependency-royalty-management/contracts/RoyaltySplitter.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltySplitter.sol
@@ -55,6 +55,12 @@ contract RoyaltySplitter is
         _disableInitializers();
     }
 
+    /// @dev this protects the implementation contract from behing initialized.
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
     /// @notice Query if a contract implements interface `id`.
     /// @param interfaceId the interface identifier, as specified in ERC-165.
     /// @return isSupported `true` if the contract implements `id`.

--- a/packages/dependency-royalty-management/contracts/RoyaltySplitter.sol
+++ b/packages/dependency-royalty-management/contracts/RoyaltySplitter.sol
@@ -55,6 +55,12 @@ contract RoyaltySplitter is
         _disableInitializers();
     }
 
+    /// @dev this protects the implementation contract from behing initialized.
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
     /// @notice Query if a contract implements interface `id`.
     /// @param interfaceId the interface identifier, as specified in ERC-165.
     /// @return `true` if the contract implements `id`.

--- a/packages/dependency-royalty-management/contracts/interfaces/IMultiRoyaltyDistributor.sol
+++ b/packages/dependency-royalty-management/contracts/interfaces/IMultiRoyaltyDistributor.sol
@@ -24,13 +24,17 @@ interface IMultiRoyaltyDistributor is IERC165, IMultiRoyaltyRecipients {
         Recipient[] recipients;
     }
 
-    ///@dev Set per token royalties.  Passing a recipient of address(0) will delete any existing configuration
+    ///@notice Set per token royalties.  Passing a recipient of address(0) will delete any existing configuration
+    ///@param tokenId The ID of the token for which to set the royalties.
+    ///@param recipient The address that will receive the royalties.
+    ///@param creator The creator's address for the token.
     function setTokenRoyalties(
         uint256 tokenId,
         address payable recipient,
         address creator
     ) external;
 
-    ///@dev Helper function to get all splits contracts
+    ///@notice Helper function to get all splits contracts
+    ///@return an array of royalty receiver
     function getAllSplits() external view returns (address payable[] memory);
 }

--- a/packages/dependency-royalty-management/contracts/interfaces/IMultiRoyaltyDistributor.sol
+++ b/packages/dependency-royalty-management/contracts/interfaces/IMultiRoyaltyDistributor.sol
@@ -10,9 +10,9 @@ interface IMultiRoyaltyDistributor is IERC165, IMultiRoyaltyRecipients {
     event TokenRoyaltyRemoved(uint256 tokenId);
     event DefaultRoyaltyBpsSet(uint16 royaltyBPS);
 
-    event DefaultRoyaltyReceiverSet(address recipient);
+    event DefaultRoyaltyReceiverSet(address indexed recipient);
 
-    event RoyaltyRecipientSet(address splitter, address recipient);
+    event RoyaltyRecipientSet(address indexed splitter, address indexed recipient);
 
     event TokenRoyaltySplitterSet(uint256 tokenId, address splitterAddress);
 

--- a/packages/dependency-royalty-management/contracts/interfaces/IRoyaltyManager.sol
+++ b/packages/dependency-royalty-management/contracts/interfaces/IRoyaltyManager.sol
@@ -6,11 +6,11 @@ import {Recipient} from "@manifoldxyz/royalty-registry-solidity/contracts/overri
 /// @title IRoyaltyManager
 /// @notice interface for RoyaltyManager Contract
 interface IRoyaltyManager {
-    event RecipientSet(address commonRecipient);
+    event RecipientSet(address indexed commonRecipient);
 
     event SplitSet(uint16 commonSplit);
 
-    event RoyaltySet(uint16 royaltyBps, address contractAddress);
+    event RoyaltySet(uint16 royaltyBps, address indexed contractAddress);
 
     event TrustedForwarderSet(address indexed previousForwarder, address indexed newForwarder);
 

--- a/packages/dependency-royalty-management/contracts/interfaces/IRoyaltyManager.sol
+++ b/packages/dependency-royalty-management/contracts/interfaces/IRoyaltyManager.sol
@@ -29,24 +29,24 @@ interface IRoyaltyManager {
     function getCommonRecipient() external view returns (Recipient memory recipient);
 
     ///@notice returns the amount of basis points allocated to the creator
-    ///@return creator split
-    function getCreatorSplit() external view returns (uint16);
+    ///@return creatorSplit the share of creator in bps
+    function getCreatorSplit() external view returns (uint16 creatorSplit);
 
     ///@notice returns the commonRecipient and EIP2981 royalty split
-    ///@return address of common royalty recipient
-    ///@return royalty split
-    function getRoyaltyInfo() external view returns (address payable, uint16);
+    ///@return recipient address of common royalty recipient
+    ///@return royaltySplit contract EIP2981 royalty bps
+    function getRoyaltyInfo() external view returns (address payable recipient, uint16 royaltySplit);
 
     ///@notice deploys splitter for creator
     ///@param creator the address of the creator
     ///@param recipient the wallet of the recipient where they would receive their royalty
-    ///@return splitter address deployed for creator
-    function deploySplitter(address creator, address payable recipient) external returns (address payable);
+    ///@return creatorSplitterAddress splitter's address deployed for creator
+    function deploySplitter(address creator, address payable recipient) external returns (address payable creatorSplitterAddress);
 
     ///@notice returns the address of splitter of a creator.
     ///@param creator the address of the creator
-    ///@return address of creator splitter
-    function getCreatorRoyaltySplitter(address creator) external view returns (address payable);
+    ///@return creatorSplitterAddress splitter's address deployed for a creator
+    function getCreatorRoyaltySplitter(address creator) external view returns (address payable creatorSplitterAddress);
 
     ///@notice returns the EIP2981 royalty split
     ///@param _contractAddress the address of the contract for which the royalty is required
@@ -58,6 +58,6 @@ interface IRoyaltyManager {
     function setTrustedForwarder(address _newForwarder) external;
 
     ///@notice get the current trustedForwarder address
-    ///@return address of current trusted Forwarder
-    function getTrustedForwarder() external view returns (address);
+    ///@return trustedForwarder address of current trusted Forwarder
+    function getTrustedForwarder() external view returns (address trustedForwarder);
 }

--- a/packages/dependency-royalty-management/contracts/interfaces/IRoyaltyManager.sol
+++ b/packages/dependency-royalty-management/contracts/interfaces/IRoyaltyManager.sol
@@ -41,7 +41,9 @@ interface IRoyaltyManager {
     ///@param creator the address of the creator
     ///@param recipient the wallet of the recipient where they would receive their royalty
     ///@return creatorSplitterAddress splitter's address deployed for creator
-    function deploySplitter(address creator, address payable recipient) external returns (address payable creatorSplitterAddress);
+    function deploySplitter(address creator, address payable recipient)
+        external
+        returns (address payable creatorSplitterAddress);
 
     ///@notice returns the address of splitter of a creator.
     ///@param creator the address of the creator

--- a/packages/deploy/deploy/400_asset/400_asset_operator_filter_setup.ts
+++ b/packages/deploy/deploy/400_asset/400_asset_operator_filter_setup.ts
@@ -27,7 +27,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
         DEFAULT_SUBSCRIPTION
       );
       console.log(
-        "common subscription registered on operator filter registry and opensea's blacklist copied"
+        "common subscription registered on operator filter registry and OpenSea's blacklist copied"
       );
     }
   }


### PR DESCRIPTION
## Description
Catalyst and dependencies audit report fixes
![N-05](https://github.com/thesandboxgame/sandbox-smart-contracts/assets/31765733/ce345e66-3624-4061-b6e0-a19bd6c191ec)

## Dev
Any explanation for the devs that will review your implementation/code.

## Qa
Any guidance or important information for the team that will be testing your solution.

> Note: you can add any additional information you think is important for giving context to your PR.

## Checklist and Markdown
* [ ] Remember you could add any type of formatting to enhance your PR.
* [ ] Like this checklist
* [ ] And with **this** markdown format