### PR TITLE
feat: add npm scripts using during live deployments

### DIFF
--- a/packages/deploy/hardhat.config.ts
+++ b/packages/deploy/hardhat.config.ts
@@ -3,7 +3,11 @@ import '@nomicfoundation/hardhat-chai-matchers';
 import '@nomicfoundation/hardhat-network-helpers';
 import '@nomiclabs/hardhat-ethers';
 import 'hardhat-deploy';
-import {addForkingSupport, addNodeAndMnemonic} from './utils/hardhatConfig';
+import {
+  addForkingSupport,
+  addNodeAndMnemonic,
+  skipDeploymentsOnLiveNetworks,
+} from './utils/hardhatConfig';
 import './tasks/importedPackages';
 
 // Package name : solidity source code path
@@ -265,16 +269,18 @@ const compilers = [
   },
 }));
 
-const config = addForkingSupport({
-  importedPackages,
-  namedAccounts,
-  networks: addNodeAndMnemonic(networks),
-  mocha: {
-    timeout: 0,
-    ...(!process.env.CI ? {} : {invert: true, grep: '@skip-on-ci'}),
-  },
-  solidity: {
-    compilers,
-  },
-});
+const config = skipDeploymentsOnLiveNetworks(
+  addForkingSupport({
+    importedPackages,
+    namedAccounts,
+    networks: addNodeAndMnemonic(networks),
+    mocha: {
+      timeout: 0,
+      ...(!process.env.CI ? {} : {invert: true, grep: '@skip-on-ci'}),
+    },
+    solidity: {
+      compilers,
+    },
+  })
+);
 export default config;

--- a/packages/deploy/package.json
+++ b/packages/deploy/package.json
@@ -22,7 +22,7 @@
     ],
     "scripts": {
         "compile": "hardhat compile",
-        "test": "cross-env NODE_OPTIONS=\"--max-old-space-size=8192 node --unhandled-rejections=strict\" HARDHAT_COMPILE=true NODE_ENV=test hardhat test",
+        "test": "cross-env NODE_OPTIONS=\"--max-old-space-size=8192 node --unhandled-rejections=strict\" HARDHAT_COMPILE=true hardhat test",
         "void:deploy": "cross-env NODE_OPTIONS=\"--max-old-space-size=8192 --unhandled-rejections=strict\" hardhat deploy",
         "deploy": "npm run void:deploy",
         "hardhat": "hardhat",
@@ -30,10 +30,10 @@
         "lint:fix": "eslint --fix \"**/*.{js,ts}\"",
         "format": "prettier --check \"**/*.{ts,js}\"",
         "format:fix": "prettier --write \"**/*.{ts,js}\"",
-        "fork:mainnet": "cross-env HARDHAT_FORK=mainnet HARDHAT_DEPLOY_ACCOUNTS_NETWORK=mainnet HARDHAT_DEPLOY_FIXTURE=true NODE_OPTIONS=\"--max-old-space-size=8192 node --unhandled-rejections=strict\" HARDHAT_COMPILE=true NODE_ENV=test hardhat test",
-        "fork:polygon": "cross-env HARDHAT_FORK=polygon HARDHAT_DEPLOY_ACCOUNTS_NETWORK=polygon HARDHAT_DEPLOY_FIXTURE=true NODE_OPTIONS=\"--max-old-space-size=8192 node --unhandled-rejections=strict\" HARDHAT_COMPILE=true NODE_ENV=test hardhat test",
-        "fork:goerli": "cross-env HARDHAT_FORK=goerli HARDHAT_DEPLOY_ACCOUNTS_NETWORK=goerli HARDHAT_DEPLOY_FIXTURE=true NODE_OPTIONS=\"--max-old-space-size=8192 node --unhandled-rejections=strict\" HARDHAT_COMPILE=true NODE_ENV=test hardhat test",
-        "fork:mumbai": "cross-env HARDHAT_FORK=mumbai HARDHAT_DEPLOY_ACCOUNTS_NETWORK=mumbai HARDHAT_DEPLOY_FIXTURE=true NODE_OPTIONS=\"--max-old-space-size=8192 node --unhandled-rejections=strict\" HARDHAT_COMPILE=true NODE_ENV=test hardhat test"
+        "verify": "yarn hardhat etherscan-verify --network",
+        "live:deploy": "node ./utils/npmScriptHelper.js deploy",
+        "fork:deploy": "node ./utils/npmScriptHelper.js fork:deploy",
+        "fork:test": "node ./utils/npmScriptHelper.js fork:test"
     },
     "devDependencies": {
         "@ethersproject/abi": "^5.7.0",
@@ -51,6 +51,7 @@
         "@typescript-eslint/eslint-plugin": "^5.59.8",
         "@typescript-eslint/parser": "^5.59.8",
         "chai": "^4.3.7",
+        "child_process": "^1.0.2",
         "cross-env": "^7.0.3",
         "dotenv": "^16.1.4",
         "dotenv-cli": "^7.2.1",

--- a/packages/deploy/utils/npmScriptHelper.js
+++ b/packages/deploy/utils/npmScriptHelper.js
@@ -1,0 +1,139 @@
+/*
+  This script set the environment variables needed to run hardhat in a fork
+  before executing it.
+  See the testing section of the `README.md` file.
+  Based on scripts.js in the core package!!!
+ */
+const path = require('path');
+const {spawnSync} = require('child_process');
+const dotenv = require('dotenv');
+
+dotenv.config();
+const myName = path.basename(__filename);
+const expectedOptions = {
+  blockNumber: 'string',
+  'no-impersonation': 'boolean',
+  'include-mocks': 'boolean',
+  debug: 'boolean',
+  skipFixtures: 'boolean',
+};
+
+function parseArgs() {
+  const rawArgs = process.argv.slice(process.argv.indexOf(__filename) + 1);
+  const [command, network, file] = rawArgs;
+  const numFixedArgs = ['run', 'export', 'fork:run'].includes(command) ? 3 : 2;
+  if (rawArgs.length < numFixedArgs) {
+    throw new Error('missing argument');
+  }
+  const fixedArgs = [];
+  const options = {};
+  const extra = [];
+  const alreadyCounted = {};
+  for (let i = 0; i < rawArgs.length; i++) {
+    const rawArg = rawArgs[i];
+    if (rawArg.startsWith('--')) {
+      const optionName = rawArg.slice(2);
+      const optionDetected = expectedOptions[optionName];
+      if (!alreadyCounted[optionName] && optionDetected) {
+        alreadyCounted[optionName] = true;
+        if (optionDetected === 'boolean') {
+          options[optionName] = true;
+        } else {
+          i++;
+          options[optionName] = rawArgs[i];
+        }
+        continue;
+      }
+    }
+    if (fixedArgs.length < numFixedArgs) {
+      if (Object.keys(alreadyCounted).length) {
+        throw new Error(
+          `expected ${numFixedArgs} fixed args, got only ${fixedArgs.length}`
+        );
+      }
+      fixedArgs.push(rawArg);
+    } else {
+      extra.push(rawArg);
+    }
+  }
+  return {command, network, file, options, extra, fixedArgs};
+}
+
+function usage() {
+  console.log(
+    `Usage: node ${myName} command network [ file ] ` +
+      Object.keys(expectedOptions)
+        .map(
+          (x) =>
+            `[ --${x} ${
+              expectedOptions[x] === 'string' ? x.toUpperCase() : ''
+            } ]`
+        )
+        .join(' ')
+  );
+  console.log('\tfile is only used in the run, export and fork:run commands');
+  console.log(
+    '\t--skip-test-deployments/ntd/--ntd is the default for this command, use --include-mocks if needed'
+  );
+}
+
+function getEnv({command, network, options}) {
+  const env = [];
+  if (options.debug) {
+    env.push(`DEBUG="*hardhat-deploy"`);
+  }
+  if (options.skipFixtures) {
+    env.push(`HARDHAT_SKIP_FIXTURES=true"`);
+  }
+
+  // What follows only make sense on forked networks
+  if (!command.includes('fork')) {
+    return env;
+  }
+  if (options['include-mocks']) {
+    env.push(`HARDHAT_FORK_INCLUDE_MOCKS=true`);
+  }
+  if (options.blockNumber) {
+    env.push(`HARDHAT_FORK_NUMBER=${options.blockNumber}`);
+  }
+  if (options['no-impersonation']) {
+    env.push(`HARDHAT_DEPLOY_NO_IMPERSONATION=true`);
+  }
+  env.push(
+    `HARDHAT_DEPLOY_ACCOUNTS_NETWORK=${network}`,
+    `HARDHAT_FORK=${network}`
+  );
+  return env;
+}
+
+async function main() {
+  const args = parseArgs();
+  const {network, file} = args;
+
+  const env = getEnv(args).join(' ');
+  const extraArgs = args.extra.join(' ');
+  const commands = {
+    run: `${env} HARDHAT_NETWORK=${network} ts-node --files ${file} ${extraArgs}`,
+    deploy: `${env} hardhat --network ${network} deploy ${extraArgs}`,
+    test: `${env} hardhat --network ${network} test ${extraArgs}`,
+    export: `${env} hardhat --network ${network} export --export ${file}`,
+    'fork:run': `${env} HARDHAT_NETWORK=${network} ts-node --files ${file} ${extraArgs}`,
+    'fork:deploy': `${env} hardhat deploy ${extraArgs}`,
+    'fork:test': `${env} HARDHAT_DEPLOY_FIXTURE=true HARDHAT_COMPILE=true hardhat test ${extraArgs}`,
+    'fork:dev': `${env} hardhat node --watch --export contractsInfo.json ${extraArgs}`,
+  };
+  const cmd = commands[args.command];
+  if (!cmd) {
+    throw new Error(`invalid command ${args.command}`);
+  }
+  console.log(`${myName} executing:`, cmd);
+  await spawnSync('yarn', ['cross-env', ...cmd.split(' ')], {
+    stdio: 'inherit',
+    shell: true,
+  });
+}
+
+main().catch((err) => {
+  console.error(err.toString());
+  usage();
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1978,6 +1978,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^5.59.8
     "@typescript-eslint/parser": ^5.59.8
     chai: ^4.3.7
+    child_process: ^1.0.2
     cross-env: ^7.0.3
     dotenv: ^16.1.4
     dotenv-cli: ^7.2.1
@@ -4059,6 +4060,13 @@ __metadata:
   version: 1.0.2
   resolution: "check-error@npm:1.0.2"
   checksum: d9d106504404b8addd1ee3f63f8c0eaa7cd962a1a28eb9c519b1c4a1dc7098be38007fc0060f045ee00f075fbb7a2a4f42abcf61d68323677e11ab98dc16042e
+  languageName: node
+  linkType: hard
+
+"child_process@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "child_process@npm:1.0.2"
+  checksum: bd814d82bc8c6e85ed6fb157878978121cd03b5296c09f6135fa3d081fd9a6a617a6d509c50397711df713af403331241a9c0397a7fad30672051485e156c2a1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description
Implement the npm scripts: `fork:deploy` and `yarn deploy:live`. They do the same as the scripts in the `core` package.