### PR TITLE
Royalties and protocol fee

### DIFF
--- a/packages/marketplace/contracts/mocks/TestERC721WithRoyaltyV2981Multi.sol
+++ b/packages/marketplace/contracts/mocks/TestERC721WithRoyaltyV2981Multi.sol
@@ -18,6 +18,8 @@ contract TestERC721WithRoyaltyV2981Multi is
 
     bytes4 internal constant INTERFACE_ID_IROYALTYUGC = 0xa30b4db9;
 
+    bytes4 internal constant INTERFACE_ID_GET_RECIPIENTS = 0xfd90e897;
+
     struct Recipient {
         address payable recipient;
         uint16 bps;
@@ -39,6 +41,7 @@ contract TestERC721WithRoyaltyV2981Multi is
         bytes4 interfaceId
     ) public view virtual override(ERC721Upgradeable, Royalties2981TestImpl) returns (bool) {
         return
+            interfaceId == INTERFACE_ID_GET_RECIPIENTS ||
             interfaceId == LibRoyalties2981._INTERFACE_ID_ROYALTIES ||
             interfaceId == INTERFACE_ID_IROYALTYUGC ||
             ERC721Upgradeable.supportsInterface(interfaceId) ||
@@ -58,7 +61,7 @@ contract TestERC721WithRoyaltyV2981Multi is
         require(totalBPS == BASIS_POINTS, "Total bps must be 10000");
     }
 
-    function getRecipients() external view returns (Recipient[] memory) {
+    function getRecipients(uint256 /* tokenId */) external view returns (Recipient[] memory) {
         return _recipients;
     }
 

--- a/packages/marketplace/test/exchange/Exchange.test.ts
+++ b/packages/marketplace/test/exchange/Exchange.test.ts
@@ -743,10 +743,13 @@ describe('Exchange.sol', function () {
       deployer: royaltyReceiver,
       user1: maker,
       user2: taker,
+      admin: receiver1,
+      user: receiver2,
     } = await loadFixture(deployFixtures);
 
     await ERC721WithRoyaltyV2981.mint(maker.address, 1, [
-      await FeeRecipientsData(maker.address, 10000),
+      await FeeRecipientsData(receiver1.address, 3000),
+      await FeeRecipientsData(receiver2.address, 7000),
     ]);
 
     await ERC721WithRoyaltyV2981.connect(maker).approve(
@@ -828,12 +831,15 @@ describe('Exchange.sol', function () {
     // check primary market protocol fee
     expect(
       await ERC20Contract.balanceOf(defaultFeeReceiver.address)
-    ).to.be.equal(2500000000); // 250 * 10000000000 / 10000 = 250000000
+    ).to.be.equal(2500000000); // 250 * 100000000000 / 10000 = 2500000000
 
-    // check paid royalty
-    expect(await ERC20Contract.balanceOf(royaltyReceiver.address)).to.be.equal(
-      50000000000
-    ); // 50% of the amount
+    expect(await ERC20Contract.balanceOf(receiver1.address)).to.be.equal(
+      15000000000 // 1500 * 100000000000 / 10000 = 15000000000
+    );
+
+    expect(await ERC20Contract.balanceOf(receiver2.address)).to.be.equal(
+      35000000000 // 3500 * 100000000000 / 10000 = 35000000000
+    );
 
     expect(await ERC20Contract.balanceOf(maker.address)).to.be.equal(
       47500000000 // 100000000000 - royalty - protocolFee

--- a/packages/marketplace/test/fixtures.ts
+++ b/packages/marketplace/test/fixtures.ts
@@ -76,6 +76,18 @@ async function deploy() {
   );
   await ERC721WithRoyaltyV2981.waitForDeployment();
 
+  const TestERC721WithRoyaltyFactory = await ethers.getContractFactory(
+    'TestERC721WithRoyaltyV2981'
+  );
+  const ERC721WithRoyalty = await upgrades.deployProxy(
+    TestERC721WithRoyaltyFactory,
+    [],
+    {
+      initializer: 'initialize',
+    }
+  );
+  await ERC721WithRoyalty.waitForDeployment();
+
   const ERC20ContractFactory = await ethers.getContractFactory('TestERC20');
   const ERC20Contract = await ERC20ContractFactory.deploy();
   await ERC20Contract.waitForDeployment();
@@ -120,6 +132,7 @@ async function deploy() {
     RoyaltiesRegistryAsDeployer,
     RoyaltiesRegistryAsUser,
     ERC721WithRoyaltyV2981,
+    ERC721WithRoyalty,
     RoyaltiesProvider,
     deployer,
     admin,


### PR DESCRIPTION
## Description

- Added compatibility for `INTERFACE_ID_GET_RECIPIENTS` in the `supportsInterface` function.
- Added test for execution of a complete match order with ERC-2981 and Royalty Recipients set