### PR TITLE
feat: some of the preaudit fixes

### DIFF
--- a/packages/marketplace/contracts/exchange/Exchange.sol
+++ b/packages/marketplace/contracts/exchange/Exchange.sol
@@ -83,6 +83,7 @@ contract Exchange is
     /// @notice Match orders and transact
     /// @param sender the original sender of the transaction
     /// @param matchedOrders a list of left/right orders that match each other
+    /// @dev this method is used to support ERC1776 native meta transactions
     function matchOrdersFrom(
         address sender,
         ExchangeMatch[] calldata matchedOrders
@@ -96,7 +97,7 @@ contract Exchange is
     /// @param orderKeyHash used as a checksum to avoid mistakes in the values of order
     /// @dev require msg sender to be order maker and salt different from 0
     function cancel(LibOrder.Order calldata order, bytes32 orderKeyHash) external whenNotPaused {
-        require(_msgSender() == order.maker, "ExchangeCore: not maker");
+        require(_msgSender() == order.maker, "not maker");
         _cancel(order, orderKeyHash);
     }
 

--- a/packages/marketplace/contracts/exchange/ExchangeCore.sol
+++ b/packages/marketplace/contracts/exchange/ExchangeCore.sol
@@ -37,14 +37,15 @@ abstract contract ExchangeCore is Initializable, TransferExecutor, ITransferMana
     /// @param  orderKeyHash order hash
     event Cancel(bytes32 indexed orderKeyHash, LibOrder.Order order);
 
-    /*     /// @notice event when orders match
-    /// @param from _msgSender
+    /// @notice event when orders match
+    /// @param from _msgSender or operator if used with approve and call
     /// @param leftHash left order hash
     /// @param rightHash right order hash
-    /// @param newLeftFill fill for left order
-    /// @param newRightFill fill for right order
+    /// @param newFill fill for left order
     /// @param totalFillLeft total fill left
-    /// @param totalFillRight total fill right */
+    /// @param totalFillRight total fill right
+    /// @param valueLeft asset value for left order
+    /// @param valueRight asset value for right order
     event Match(
         address indexed from,
         bytes32 leftHash,
@@ -78,9 +79,9 @@ abstract contract ExchangeCore is Initializable, TransferExecutor, ITransferMana
     /// @param orderKeyHash used as a checksum to avoid mistakes in the values of order
     /// @dev require msg sender to be order maker and salt different from 0
     function _cancel(LibOrder.Order calldata order, bytes32 orderKeyHash) internal {
-        require(order.salt != 0, "ExchangeCore: 0 salt can't be used");
+        require(order.salt != 0, "0 salt can't be used");
         bytes32 _orderKeyHash = LibOrder.hashKey(order);
-        require(_orderKeyHash == orderKeyHash, "ExchangeCore: Invalid orderHash");
+        require(_orderKeyHash == orderKeyHash, "Invalid orderHash");
         fills[orderKeyHash] = UINT256_MAX;
         emit Cancel(orderKeyHash, order);
     }

--- a/packages/marketplace/test/exchange/Exchange.test.ts
+++ b/packages/marketplace/test/exchange/Exchange.test.ts
@@ -80,7 +80,7 @@ describe('Exchange.sol', function () {
         leftOrder,
         hashOrder(leftOrder)
       )
-    ).to.be.revertedWith('ExchangeCore: not maker');
+    ).to.be.revertedWith('not maker');
   });
 
   it('should not cancel order with zero salt', async function () {
@@ -101,7 +101,7 @@ describe('Exchange.sol', function () {
     );
     await expect(
       ExchangeContractAsUser.cancel(leftOrder, hashKey(leftOrder))
-    ).to.be.revertedWith("ExchangeCore: 0 salt can't be used");
+    ).to.be.revertedWith("0 salt can't be used");
   });
 
   it('should not cancel the order with invalid order hash', async function () {
@@ -125,7 +125,7 @@ describe('Exchange.sol', function () {
       '0x1234567890123456789012345678901234567890123456789012345678901234';
     await expect(
       ExchangeContractAsUser.connect(user1).cancel(leftOrder, invalidOrderHash)
-    ).to.be.revertedWith('ExchangeCore: Invalid orderHash');
+    ).to.be.revertedWith('Invalid orderHash');
   });
 
   it('should cancel an order and update fills mapping', async function () {


### PR DESCRIPTION

## Description

- Multiple comment annotation in ExchangeCore contract on line 40 (/*     /// ` ) and line 47 (///....*/)
- In ExchangeCore contract, event Match docstring says that from is _msgSender, this is true if the emit is emitted via the Exchange.matchOrders external function but not for Exchange.matchOrdersFrom function.
- In Exchange contract, add docstring to differentiate the use-case for matchOrdersFrom from matchOrders.
- Error messages in require statement are not consistent, some state the contract name and some doesn’t. Error message on L99 in Exchange contract states incorrect name of the contract. We recommend that all revert or error messages have the contract name for easy debugging.
