### PR TITLE
adding cosntants for magic numbers

### DIFF
--- a/packages/marketplace/contracts/exchange/ExchangeCore.sol
+++ b/packages/marketplace/contracts/exchange/ExchangeCore.sol
@@ -28,6 +28,7 @@ abstract contract ExchangeCore is Initializable, TransferExecutor, ITransferMana
     IOrderValidator public orderValidator;
 
     uint256 private constant UINT256_MAX = type(uint256).max;
+    uint256 internal constant BASIS_POINTS = 10000;
     uint256 private matchOrdersLimit;
 
     /// @notice stores the fills for orders

--- a/packages/marketplace/contracts/exchange/ExchangeCore.sol
+++ b/packages/marketplace/contracts/exchange/ExchangeCore.sol
@@ -28,6 +28,7 @@ abstract contract ExchangeCore is Initializable, TransferExecutor, ITransferMana
     IOrderValidator public orderValidator;
 
     uint256 private constant UINT256_MAX = type(uint256).max;
+    uint96 internal constant BASIS_POINTS = 10000;
     uint256 private matchOrdersLimit;
 
     /// @notice stores the fills for orders
@@ -183,7 +184,7 @@ abstract contract ExchangeCore is Initializable, TransferExecutor, ITransferMana
     function _payToMaker(LibOrder.Order memory order) internal pure returns (LibPart.Part[] memory) {
         LibPart.Part[] memory payout = new LibPart.Part[](1);
         payout[0].account = order.maker;
-        payout[0].value = 10000;
+        payout[0].value = BASIS_POINTS;
         return payout;
     }
 

--- a/packages/marketplace/contracts/exchange/ExchangeCore.sol
+++ b/packages/marketplace/contracts/exchange/ExchangeCore.sol
@@ -28,7 +28,6 @@ abstract contract ExchangeCore is Initializable, TransferExecutor, ITransferMana
     IOrderValidator public orderValidator;
 
     uint256 private constant UINT256_MAX = type(uint256).max;
-    uint96 internal constant BASIS_POINTS = 10000;
     uint256 private matchOrdersLimit;
 
     /// @notice stores the fills for orders
@@ -184,7 +183,7 @@ abstract contract ExchangeCore is Initializable, TransferExecutor, ITransferMana
     function _payToMaker(LibOrder.Order memory order) internal pure returns (LibPart.Part[] memory) {
         LibPart.Part[] memory payout = new LibPart.Part[](1);
         payout[0].account = order.maker;
-        payout[0].value = BASIS_POINTS;
+        payout[0].value = uint96(BASIS_POINTS);
         return payout;
     }
 

--- a/packages/marketplace/contracts/exchange/libraries/LibMath.sol
+++ b/packages/marketplace/contracts/exchange/libraries/LibMath.sol
@@ -3,6 +3,8 @@
 pragma solidity 0.8.21;
 
 library LibMath {
+    uint256 internal constant BASIS_POINTS = 10000;
+
     /// @dev Calculates partial value given a numerator and denominator rounded down.
     ///      Reverts if rounding error is >= 0.1%
     /// @param numerator Numerator.
@@ -61,6 +63,6 @@ library LibMath {
         // so we have a rounding error iff:
         //        1000 * remainder  >=  numerator * target
         uint256 remainder = mulmod(target, numerator, denominator);
-        isError = remainder * 1000 >= numerator * target;
+        isError = remainder * BASIS_POINTS >= numerator * target;
     }
 }

--- a/packages/marketplace/contracts/lib-bp/BpLibrary.sol
+++ b/packages/marketplace/contracts/lib-bp/BpLibrary.sol
@@ -5,11 +5,13 @@ pragma solidity 0.8.21;
 /// @title library for Base Point calculation
 /// @notice contains a method for basepoint calculation
 library BpLibrary {
+    uint256 internal constant BASIS_POINTS = 10000;
+
     /// @notice basepoint calculation
     /// @param value value to be multiplied by basepoint
     /// @param bpValue basepoint value
     /// @return value times basepoint divided by 10000
     function bp(uint256 value, uint256 bpValue) internal pure returns (uint256) {
-        return (value * bpValue) / 10000;
+        return (value * bpValue) / BASIS_POINTS;
     }
 }

--- a/packages/marketplace/contracts/lib-bp/BpLibrary.sol
+++ b/packages/marketplace/contracts/lib-bp/BpLibrary.sol
@@ -10,7 +10,7 @@ library BpLibrary {
     /// @notice basepoint calculation
     /// @param value value to be multiplied by basepoint
     /// @param bpValue basepoint value
-    /// @return value times basepoint divided by 10000
+    /// @return value times basepoint divided by base point (10000)
     function bp(uint256 value, uint256 bpValue) internal pure returns (uint256) {
         return (value * bpValue) / BASIS_POINTS;
     }

--- a/packages/marketplace/contracts/royalties-registry/RoyaltiesRegistry.sol
+++ b/packages/marketplace/contracts/royalties-registry/RoyaltiesRegistry.sol
@@ -48,6 +48,7 @@ contract RoyaltiesRegistry is IRoyaltiesProvider, OwnableUpgradeable {
     uint256 internal constant ROYALTIES_TYPE_EIP2981 = 3;
     uint256 internal constant ROYALTIES_TYPE_UNSUPPORTED_NONEXISTENT = 4;
     uint256 internal constant ROYALTIES_TYPES_AMOUNT = 4;
+    uint256 internal constant BASIS_POINTS = 10000;
 
     /// @dev this protects the implementation contract from being initialized.
     /// @custom:oz-upgrades-unsafe-allow constructor
@@ -115,7 +116,7 @@ contract RoyaltiesRegistry is IRoyaltiesProvider, OwnableUpgradeable {
             royaltiesByToken[token].royalties.push(royalties[i]);
             sumRoyalties += royalties[i].value;
         }
-        require(sumRoyalties < 10000, "Set by token royalties sum more, than 100%");
+        require(sumRoyalties < BASIS_POINTS, "Set by token royalties sum more, than 100%");
         royaltiesByToken[token].initialized = true;
         emit RoyaltiesSetForContract(token, royalties);
     }

--- a/packages/marketplace/contracts/royalties/LibRoyalties2981.sol
+++ b/packages/marketplace/contracts/royalties/LibRoyalties2981.sol
@@ -9,6 +9,7 @@ import {LibPart} from "../lib-part/LibPart.sol";
 library LibRoyalties2981 {
     bytes4 public constant _INTERFACE_ID_ROYALTIES = 0x2a55205a;
     uint96 internal constant _WEIGHT_VALUE = 1e6;
+    uint256 internal constant BASIS_POINTS = 10000;
 
     /// @notice method for converting amount to percent and forming LibPart
     /// @param to recipient of royalties
@@ -19,8 +20,8 @@ library LibRoyalties2981 {
         if (amount == 0) {
             return result;
         }
-        uint256 percent = (amount * 10000) / _WEIGHT_VALUE;
-        require(percent < 10000, "Royalties 2981 exceeds 100%");
+        uint256 percent = (amount * BASIS_POINTS) / _WEIGHT_VALUE;
+        require(percent < BASIS_POINTS, "Royalties 2981 exceeds 100%");
         result = new LibPart.Part[](1);
         result[0].account = payable(to);
         result[0].value = uint96(percent);

--- a/packages/marketplace/contracts/transfer-manager/TransferManager.sol
+++ b/packages/marketplace/contracts/transfer-manager/TransferManager.sol
@@ -19,7 +19,6 @@ abstract contract TransferManager is ERC165Upgradeable, ITransferManager {
     using BpLibrary for uint;
 
     bytes4 internal constant INTERFACE_ID_IROYALTYUGC = 0xa30b4db9;
-    uint256 internal constant HALF_BASIS_POINTS = 5000;
 
     /// @notice fee for primary sales
     /// @return uint256 of primary sale fee
@@ -98,8 +97,8 @@ abstract contract TransferManager is ERC165Upgradeable, ITransferManager {
     /// @param newProtocolFeePrimary fee for primary market
     /// @param newProtocolFeeSecondary fee for secondary market
     function _setProtocolFee(uint256 newProtocolFeePrimary, uint256 newProtocolFeeSecondary) internal {
-        require(newProtocolFeePrimary < HALF_BASIS_POINTS, "invalid primary fee");
-        require(newProtocolFeeSecondary < HALF_BASIS_POINTS, "invalid secondary fee");
+        require(newProtocolFeePrimary < BASIS_POINTS / 2, "invalid primary fee");
+        require(newProtocolFeeSecondary < BASIS_POINTS / 2, "invalid secondary fee");
         protocolFeePrimary = newProtocolFeePrimary;
         protocolFeeSecondary = newProtocolFeeSecondary;
 
@@ -174,16 +173,16 @@ abstract contract TransferManager is ERC165Upgradeable, ITransferManager {
 
         address creator = _getCreator(nftAssetType);
         if (creator != address(0) && payouts[0].account == creator) {
-            require(royalties[0].value <= HALF_BASIS_POINTS, "Royalties are too high (>50%)");
+            require(royalties[0].value <= BASIS_POINTS / 2, "Royalties are too high (>50%)");
             return rest;
         }
         if (royalties.length == 1 && royalties[0].account == payouts[0].account) {
-            require(royalties[0].value <= HALF_BASIS_POINTS, "Royalties are too high (>50%)");
+            require(royalties[0].value <= BASIS_POINTS / 2, "Royalties are too high (>50%)");
             return rest;
         }
 
         (uint256 result, uint256 totalRoyalties) = _transferFees(paymentAssetType, rest, amount, royalties, from);
-        require(totalRoyalties <= HALF_BASIS_POINTS, "Royalties are too high (>50%)");
+        require(totalRoyalties <= BASIS_POINTS / 2, "Royalties are too high (>50%)");
         return result;
     }
 

--- a/packages/marketplace/contracts/transfer-manager/TransferManager.sol
+++ b/packages/marketplace/contracts/transfer-manager/TransferManager.sol
@@ -19,6 +19,8 @@ abstract contract TransferManager is ERC165Upgradeable, ITransferManager {
     using BpLibrary for uint;
 
     bytes4 internal constant INTERFACE_ID_IROYALTYUGC = 0xa30b4db9;
+    uint256 internal constant protocolFeeShareLimit = 5000;
+    uint256 internal constant royaltyShareLimit = 5000;
 
     /// @notice fee for primary sales
     /// @return uint256 of primary sale fee
@@ -97,8 +99,8 @@ abstract contract TransferManager is ERC165Upgradeable, ITransferManager {
     /// @param newProtocolFeePrimary fee for primary market
     /// @param newProtocolFeeSecondary fee for secondary market
     function _setProtocolFee(uint256 newProtocolFeePrimary, uint256 newProtocolFeeSecondary) internal {
-        require(newProtocolFeePrimary < BASIS_POINTS / 2, "invalid primary fee");
-        require(newProtocolFeeSecondary < BASIS_POINTS / 2, "invalid secondary fee");
+        require(newProtocolFeePrimary < protocolFeeShareLimit, "invalid primary fee");
+        require(newProtocolFeeSecondary < protocolFeeShareLimit, "invalid secondary fee");
         protocolFeePrimary = newProtocolFeePrimary;
         protocolFeeSecondary = newProtocolFeeSecondary;
 
@@ -173,16 +175,16 @@ abstract contract TransferManager is ERC165Upgradeable, ITransferManager {
 
         address creator = _getCreator(nftAssetType);
         if (creator != address(0) && payouts[0].account == creator) {
-            require(royalties[0].value <= BASIS_POINTS / 2, "Royalties are too high (>50%)");
+            require(royalties[0].value <= royaltyShareLimit, "Royalties are too high (>50%)");
             return rest;
         }
         if (royalties.length == 1 && royalties[0].account == payouts[0].account) {
-            require(royalties[0].value <= BASIS_POINTS / 2, "Royalties are too high (>50%)");
+            require(royalties[0].value <= royaltyShareLimit, "Royalties are too high (>50%)");
             return rest;
         }
 
         (uint256 result, uint256 totalRoyalties) = _transferFees(paymentAssetType, rest, amount, royalties, from);
-        require(totalRoyalties <= BASIS_POINTS / 2, "Royalties are too high (>50%)");
+        require(totalRoyalties <= royaltyShareLimit, "Royalties are too high (>50%)");
         return result;
     }
 

--- a/packages/marketplace/contracts/transfer-manager/TransferManager.sol
+++ b/packages/marketplace/contracts/transfer-manager/TransferManager.sol
@@ -19,8 +19,8 @@ abstract contract TransferManager is ERC165Upgradeable, ITransferManager {
     using BpLibrary for uint;
 
     bytes4 internal constant INTERFACE_ID_IROYALTYUGC = 0xa30b4db9;
-    uint256 internal constant protocolFeeShareLimit = 5000;
-    uint256 internal constant royaltyShareLimit = 5000;
+    uint256 internal constant PROTOCOL_FEE_SHARE_LIMIT = 5000;
+    uint256 internal constant ROYALTY_SHARE_LIMIT = 5000;
 
     /// @notice fee for primary sales
     /// @return uint256 of primary sale fee
@@ -99,8 +99,8 @@ abstract contract TransferManager is ERC165Upgradeable, ITransferManager {
     /// @param newProtocolFeePrimary fee for primary market
     /// @param newProtocolFeeSecondary fee for secondary market
     function _setProtocolFee(uint256 newProtocolFeePrimary, uint256 newProtocolFeeSecondary) internal {
-        require(newProtocolFeePrimary < protocolFeeShareLimit, "invalid primary fee");
-        require(newProtocolFeeSecondary < protocolFeeShareLimit, "invalid secondary fee");
+        require(newProtocolFeePrimary < PROTOCOL_FEE_SHARE_LIMIT, "invalid primary fee");
+        require(newProtocolFeeSecondary < PROTOCOL_FEE_SHARE_LIMIT, "invalid secondary fee");
         protocolFeePrimary = newProtocolFeePrimary;
         protocolFeeSecondary = newProtocolFeeSecondary;
 
@@ -175,16 +175,16 @@ abstract contract TransferManager is ERC165Upgradeable, ITransferManager {
 
         address creator = _getCreator(nftAssetType);
         if (creator != address(0) && payouts[0].account == creator) {
-            require(royalties[0].value <= royaltyShareLimit, "Royalties are too high (>50%)");
+            require(royalties[0].value <= ROYALTY_SHARE_LIMIT, "Royalties are too high (>50%)");
             return rest;
         }
         if (royalties.length == 1 && royalties[0].account == payouts[0].account) {
-            require(royalties[0].value <= royaltyShareLimit, "Royalties are too high (>50%)");
+            require(royalties[0].value <= ROYALTY_SHARE_LIMIT, "Royalties are too high (>50%)");
             return rest;
         }
 
         (uint256 result, uint256 totalRoyalties) = _transferFees(paymentAssetType, rest, amount, royalties, from);
-        require(totalRoyalties <= royaltyShareLimit, "Royalties are too high (>50%)");
+        require(totalRoyalties <= ROYALTY_SHARE_LIMIT, "Royalties are too high (>50%)");
         return result;
     }
 

--- a/packages/marketplace/contracts/transfer-manager/TransferManager.sol
+++ b/packages/marketplace/contracts/transfer-manager/TransferManager.sol
@@ -19,6 +19,7 @@ abstract contract TransferManager is ERC165Upgradeable, ITransferManager {
     using BpLibrary for uint;
 
     bytes4 internal constant INTERFACE_ID_IROYALTYUGC = 0xa30b4db9;
+    uint256 internal constant HALF_BASIS_POINTS = 5000;
 
     /// @notice fee for primary sales
     /// @return uint256 of primary sale fee
@@ -97,8 +98,8 @@ abstract contract TransferManager is ERC165Upgradeable, ITransferManager {
     /// @param newProtocolFeePrimary fee for primary market
     /// @param newProtocolFeeSecondary fee for secondary market
     function _setProtocolFee(uint256 newProtocolFeePrimary, uint256 newProtocolFeeSecondary) internal {
-        require(newProtocolFeePrimary < 5000, "invalid primary fee");
-        require(newProtocolFeeSecondary < 5000, "invalid secondary fee");
+        require(newProtocolFeePrimary < HALF_BASIS_POINTS, "invalid primary fee");
+        require(newProtocolFeeSecondary < HALF_BASIS_POINTS, "invalid secondary fee");
         protocolFeePrimary = newProtocolFeePrimary;
         protocolFeeSecondary = newProtocolFeeSecondary;
 
@@ -173,16 +174,16 @@ abstract contract TransferManager is ERC165Upgradeable, ITransferManager {
 
         address creator = _getCreator(nftAssetType);
         if (creator != address(0) && payouts[0].account == creator) {
-            require(royalties[0].value <= 5000, "Royalties are too high (>50%)");
+            require(royalties[0].value <= HALF_BASIS_POINTS, "Royalties are too high (>50%)");
             return rest;
         }
         if (royalties.length == 1 && royalties[0].account == payouts[0].account) {
-            require(royalties[0].value <= 5000, "Royalties are too high (>50%)");
+            require(royalties[0].value <= HALF_BASIS_POINTS, "Royalties are too high (>50%)");
             return rest;
         }
 
         (uint256 result, uint256 totalRoyalties) = _transferFees(paymentAssetType, rest, amount, royalties, from);
-        require(totalRoyalties <= 5000, "Royalties are too high (>50%)");
+        require(totalRoyalties <= HALF_BASIS_POINTS, "Royalties are too high (>50%)");
         return result;
     }
 

--- a/packages/marketplace/contracts/transfer-manager/interfaces/ITransferManager.sol
+++ b/packages/marketplace/contracts/transfer-manager/interfaces/ITransferManager.sol
@@ -7,8 +7,6 @@ import {LibAsset} from "../../lib-asset/LibAsset.sol";
 import {LibPart} from "../../lib-part/LibPart.sol";
 
 abstract contract ITransferManager is ITransferExecutor {
-    uint256 internal constant BASIS_POINTS = 10000;
-
     struct DealSide {
         LibAsset.Asset asset;
         LibPart.Part[] payouts;

--- a/packages/marketplace/contracts/transfer-manager/interfaces/ITransferManager.sol
+++ b/packages/marketplace/contracts/transfer-manager/interfaces/ITransferManager.sol
@@ -7,6 +7,8 @@ import {LibAsset} from "../../lib-asset/LibAsset.sol";
 import {LibPart} from "../../lib-part/LibPart.sol";
 
 abstract contract ITransferManager is ITransferExecutor {
+    uint256 internal constant BASIS_POINTS = 10000;
+
     struct DealSide {
         LibAsset.Asset asset;
         LibPart.Part[] payouts;


### PR DESCRIPTION
Throughout the codebase, multiple magic numbers are used: 1000, 5000, 10000.

Following [Solidity's style guide](https://solidity.readthedocs.io/en/latest/style-guide.html#constants), consider defining constant variables to represent these numbers. This would help developers and auditors understand the code more easily.