### PR TITLE
fix: reduce error messages bellow 32 bytes, fix some

### DIFF
--- a/packages/marketplace/.solhint.json
+++ b/packages/marketplace/.solhint.json
@@ -11,7 +11,6 @@
     "compiler-version": ["error", "^0.8.0"],
     "func-visibility": ["error", {"ignoreConstructors": true}],
     "custom-errors": "off",
-    "func-named-parameters": ["error", 7],
-    "reason-string": ["warn", {"maxLength": 64}]
+    "func-named-parameters": ["error", 7]
   }
 }

--- a/packages/marketplace/contracts/OrderValidator.sol
+++ b/packages/marketplace/contracts/OrderValidator.sol
@@ -63,10 +63,7 @@ contract OrderValidator is IOrderValidator, Initializable, EIP712Upgradeable, Wh
 
         bytes32 hash = LibOrder.hash(order);
 
-        require(
-            order.maker.isValidSignatureNow(_hashTypedDataV4(hash), signature),
-            "order signature verification error"
-        );
+        require(order.maker.isValidSignatureNow(_hashTypedDataV4(hash), signature), "signature verification error");
     }
 
     /// @notice if ERC20 token is accepted

--- a/packages/marketplace/contracts/RoyaltiesRegistry.sol
+++ b/packages/marketplace/contracts/RoyaltiesRegistry.sol
@@ -101,12 +101,12 @@ contract RoyaltiesRegistry is OwnableUpgradeable, IRoyaltiesProvider {
         uint256 sumRoyalties = 0;
         delete royaltiesByToken[token];
         for (uint256 i = 0; i < royalties.length; ++i) {
-            require(royalties[i].account != address(0x0), "RoyaltiesByToken recipient should be present");
-            require(royalties[i].value != 0, "Royalty value for RoyaltiesByToken should be > 0");
+            require(royalties[i].account != address(0x0), "recipient should be present");
+            require(royalties[i].value != 0, "royalty value should be > 0");
             royaltiesByToken[token].royalties.push(royalties[i]);
             sumRoyalties += royalties[i].value;
         }
-        require(sumRoyalties < BASIS_POINTS, "Set by token royalties sum more, than 100%");
+        require(sumRoyalties < BASIS_POINTS, "royalties sum more, than 100%");
         royaltiesByToken[token].initialized = true;
         emit RoyaltiesSetForContract(token, royalties);
     }

--- a/packages/marketplace/contracts/libraries/LibAsset.sol
+++ b/packages/marketplace/contracts/libraries/LibAsset.sol
@@ -61,8 +61,8 @@ library LibAsset {
         AssetClass classLeft = leftType.assetClass;
         AssetClass classRight = rightType.assetClass;
 
-        require(classLeft != AssetClass.INVALID, "not found IAssetMatcher");
-        require(classRight != AssetClass.INVALID, "not found IAssetMatcher");
+        require(classLeft != AssetClass.INVALID, "invalid left asset class");
+        require(classRight != AssetClass.INVALID, "invalid right asset class");
         require(classLeft == classRight, "assets don't match");
 
         bytes32 leftHash = keccak256(leftType.data);

--- a/packages/marketplace/contracts/mocks/AbstractRoyaltiesMock.sol
+++ b/packages/marketplace/contracts/mocks/AbstractRoyaltiesMock.sol
@@ -15,7 +15,7 @@ abstract contract AbstractRoyaltiesMock {
             totalValue += _royalties[i].value;
             royalties[id].push(_royalties[i]);
         }
-        require(totalValue < 10000, "Royalty total value should be < 10000");
+        require(totalValue < 10000, "Royalty should be < 10000");
         _onRoyaltiesSet(id, _royalties);
     }
 

--- a/packages/marketplace/test/exchange/AssetMatcher.test.ts
+++ b/packages/marketplace/test/exchange/AssetMatcher.test.ts
@@ -31,10 +31,10 @@ describe('AssetMatcher.sol', function () {
     };
     await expect(
       assetMatcherAsUser.matchAssets(leftAssetType, rightAssetType)
-    ).to.be.revertedWith('not found IAssetMatcher');
+    ).to.be.revertedWith('invalid left asset class');
     await expect(
       assetMatcherAsUser.matchAssets(rightAssetType, leftAssetType)
-    ).to.be.revertedWith('not found IAssetMatcher');
+    ).to.be.revertedWith('invalid right asset class');
   });
 
   it('should call return the expected AssetType', async function () {

--- a/packages/marketplace/test/exchange/OrderValidator.test.ts
+++ b/packages/marketplace/test/exchange/OrderValidator.test.ts
@@ -136,7 +136,7 @@ describe('OrderValidator.sol', function () {
 
     await expect(
       OrderValidatorAsUser.validate(order, signature, user2.address)
-    ).to.be.revertedWith('order signature verification error');
+    ).to.be.revertedWith('signature verification error');
   });
 
   it('should validate when sender is not Order maker but signature signer is Order maker', async function () {
@@ -209,7 +209,7 @@ describe('OrderValidator.sol', function () {
 
     await expect(
       OrderValidatorAsUser.validate(order, '0x', user1.address)
-    ).to.be.revertedWith('order signature verification error');
+    ).to.be.revertedWith('signature verification error');
   });
 
   it('should validate when maker is contract but not sender and isValidSignature returns magic value', async function () {

--- a/packages/marketplace/test/exchange/RoyaltiesRegistry.test.ts
+++ b/packages/marketplace/test/exchange/RoyaltiesRegistry.test.ts
@@ -199,7 +199,7 @@ describe('RoyaltiesRegistry.sol', function () {
         await ERC721WithRoyaltyV2981.getAddress(),
         royalties
       )
-    ).to.be.revertedWith('RoyaltiesByToken recipient should be present');
+    ).to.be.revertedWith('recipient should be present');
   });
 
   it('should not set royalties with token with invalid royalty value', async function () {
@@ -215,7 +215,7 @@ describe('RoyaltiesRegistry.sol', function () {
         await ERC721WithRoyaltyV2981.getAddress(),
         royalties
       )
-    ).to.be.revertedWith('Royalty value for RoyaltiesByToken should be > 0');
+    ).to.be.revertedWith('royalty value should be > 0');
   });
 
   it('should not set royalties with token when setting royalties exceeding 100%', async function () {
@@ -235,7 +235,7 @@ describe('RoyaltiesRegistry.sol', function () {
         await ERC721WithRoyaltyV2981.getAddress(),
         royalties
       )
-    ).to.be.revertedWith('Set by token royalties sum more, than 100%');
+    ).to.be.revertedWith('royalties sum more, than 100%');
   });
 
   it('should set royalties by token', async function () {


### PR DESCRIPTION
## Description
if IAssetMatcher error message (we removed the interface).
Sol hit now will check message length so they are less than 32 bytes => fix some messages