### PR TITLE
feat: remove getFeeSide improve code readability

### DIFF
--- a/packages/marketplace/contracts/ExchangeCore.sol
+++ b/packages/marketplace/contracts/ExchangeCore.sol
@@ -168,9 +168,8 @@ abstract contract ExchangeCore is Initializable, ITransferManager {
         LibOrder.FillResult memory newFill = _parseOrdersSetFillEmitMatch(sender, orderLeft, orderRight);
 
         doTransfers(
-            ITransferManager.DealSide(LibAsset.Asset(makeMatch, newFill.leftValue), orderLeft.maker),
-            ITransferManager.DealSide(LibAsset.Asset(takeMatch, newFill.rightValue), orderRight.maker),
-            LibAsset.getFeeSide(makeMatch.assetClass, takeMatch.assetClass)
+            ITransferManager.DealSide(makeMatch, newFill.leftValue, orderLeft.maker),
+            ITransferManager.DealSide(takeMatch, newFill.rightValue, orderRight.maker)
         );
     }
 

--- a/packages/marketplace/contracts/interfaces/ITransferManager.sol
+++ b/packages/marketplace/contracts/interfaces/ITransferManager.sol
@@ -11,15 +11,15 @@ abstract contract ITransferManager {
     /// @dev Represents a side (either maker or taker) of a deal.
     /// Each side has an associated asset and an account address.
     struct DealSide {
-        LibAsset.Asset asset; // The asset associated with this side of the deal.
+        LibAsset.AssetType assetType; // The type asset associated with this side of the deal.
+        uint256 value; // The amount of assets
         address account; // The account address associated with this side of the deal.
     }
 
     /// @notice Executes the asset transfers associated with two matched orders.
     /// @param left The DealSide representing the left order's side.
     /// @param right The DealSide representing the right order's side.
-    /// @param feeSide Indicates which side of the deal will bear the fee.
     /// @dev This function serves as the primary entry point for asset transfers.
     /// If used in a separate contract, the visibility of this method might change to external.
-    function doTransfers(DealSide memory left, DealSide memory right, LibAsset.FeeSide feeSide) internal virtual;
+    function doTransfers(DealSide memory left, DealSide memory right) internal virtual;
 }

--- a/packages/marketplace/contracts/libraries/LibAsset.sol
+++ b/packages/marketplace/contracts/libraries/LibAsset.sol
@@ -14,13 +14,6 @@ library LibAsset {
         ERC1155 // Represents an ERC1155 token.
     }
 
-    /// @dev Represents the side of the trade from which a fee should be taken, if any.
-    enum FeeSide {
-        NONE, // No fees are taken.
-        LEFT, // Fees are taken from the left side of the trade.
-        RIGHT // Fees are taken from the right side of the trade.
-    }
-
     /// @dev Represents the type of a specific asset.
     /// AssetType can represent a specific ERC-721 token (defined by the token contract address and tokenId) or
     /// a specific ERC-20 token (like DAI).
@@ -39,20 +32,6 @@ library LibAsset {
 
     bytes32 internal constant ASSET_TYPEHASH =
         keccak256("Asset(AssetType assetType,uint256 value)AssetType(uint256 assetClass,bytes data)");
-
-    /// @notice Determine which side of a trade should bear the fee, based on the asset types.
-    /// @param leftClass The asset class type of the left side of the trade.
-    /// @param rightClass The asset class type of the right side of the trade.
-    /// @return FeeSide representing which side should bear the fee, if any.
-    function getFeeSide(AssetClass leftClass, AssetClass rightClass) internal pure returns (FeeSide) {
-        if (leftClass == AssetClass.ERC20 && rightClass != AssetClass.ERC20) {
-            return FeeSide.LEFT;
-        }
-        if (rightClass == AssetClass.ERC20 && leftClass != AssetClass.ERC20) {
-            return FeeSide.RIGHT;
-        }
-        return FeeSide.NONE;
-    }
 
     /// @notice Check if two asset types match.
     /// @param leftType Asset type on the left side of a trade.
@@ -103,5 +82,26 @@ library LibAsset {
     /// @return The address of the token.
     function decodeAddress(AssetType memory assetType) internal pure returns (address) {
         return abi.decode(assetType.data, (address));
+    }
+
+    /// @notice check if an asset is of type ERC20
+    /// @param assetType to check
+    /// @return true if asset is ERC20
+    function isERC20(AssetType memory assetType) internal pure returns (bool) {
+        return assetType.assetClass == AssetClass.ERC20;
+    }
+
+    /// @notice check if an asset is of type ERC721
+    /// @param assetType to check
+    /// @return true if asset is ERC721
+    function isERC721(AssetType memory assetType) internal pure returns (bool) {
+        return assetType.assetClass == AssetClass.ERC721;
+    }
+
+    /// @notice check if an asset is of type ERC1155
+    /// @param assetType to check
+    /// @return true if asset is ERC1155
+    function isERC1155(AssetType memory assetType) internal pure returns (bool) {
+        return assetType.assetClass == AssetClass.ERC1155;
     }
 }

--- a/packages/marketplace/contracts/mocks/LibAssetMock.sol
+++ b/packages/marketplace/contracts/mocks/LibAssetMock.sol
@@ -5,13 +5,6 @@ pragma solidity 0.8.19;
 import {LibAsset} from "../libraries/LibAsset.sol";
 
 contract LibAssetMock {
-    function getFeeSide(
-        LibAsset.AssetClass leftClass,
-        LibAsset.AssetClass rightClass
-    ) external pure returns (LibAsset.FeeSide) {
-        return LibAsset.getFeeSide(leftClass, rightClass);
-    }
-
     /// @notice calculate if Asset types match with each other
     /// @param leftType to be matched with rightAssetType
     /// @param rightType to be matched with leftAssetType


### PR DESCRIPTION
## Description
remove get fee side and move code to doTransfer, now it is more clear that we only take fees and
royalties if one side is ERC20.
Improve code readability by splitting asset type and value in DealSide struct.