### PR TITLE
doc: fix the markdown formatting

### DIFF
--- a/packages/dependency-metatx/README.md
+++ b/packages/dependency-metatx/README.md
@@ -1,66 +1,83 @@
 # <PACKAGE>
 
 The Sandbox's metatx dependency package, for use by The Sandbox's contracts.
-Based on Openzeppelin [ERC2771Context](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/metatx/ERC2771Context.sol).
-This is a dependency package, and the smart contracts inside use floating pragma.
+Based on Openzeppelin
+[ERC2771Context](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/metatx/ERC2771Context.sol).
+This is a dependency package, and the smart contracts inside use floating
+pragma.
 
 ## Running the project locally
 
 Install dependencies with `yarn`
 
-Testing: Use `yarn test` inside `packages/<package>` to run tests locally inside this package
+Testing: Use `yarn test` inside `packages/<package>` to run tests locally inside
+this package
 
-For testing from root (with workspace feature) use: `yarn workspace @sandbox-smart-contracts/<package> test`
+For testing from root (with workspace feature) use:
+`yarn workspace @sandbox-smart-contracts/<package> test`
 
 Coverage: Run `yarn coverage`
 
-Formatting: Run `yarn prettier` to check and `yarn prettier:fix` to fix formatting errors
+Formatting: Run `yarn prettier` to check and `yarn prettier:fix` to fix
+formatting errors
 
-Linting: Run `yarn lint` to check and `yarn lint:fix` to fix static analysis errors
+Linting: Run `yarn lint` to check and `yarn lint:fix` to fix static analysis
+errors
 
 ## Package structure and minimum standards
 
 #### A NOTE ON DEPENDENCIES
 
-1. Add whatever dependencies you like inside your package; this template is for hardhat usage. OpenZeppelin contracts
-   are highly recommended and should be installed as a dev dependency
-2. For most Pull Requests there should be minimum changes to `yarn.lock` at root level
-3. Changes to root-level dependencies are permissible, however they should not be downgraded
+1. Add whatever dependencies you like inside your package; this template is for
+   hardhat usage. OpenZeppelin contracts are highly recommended and should be
+   installed as a dev dependency
+2. For most Pull Requests there should be minimum changes to `yarn.lock` at root
+   level
+3. Changes to root-level dependencies are permissible, however they should not
+   be downgraded
 4. Take care to run `yarn` before pushing your changes
-5. You shouldn't need to install dotenv since you won't be deploying inside this package (see below)
+5. You shouldn't need to install dotenv since you won't be deploying inside this
+   package (see below)
 
 #### UNIT TESTING
 
 1. Unit tests are to be added in `packages/<package>/test`
 2. Coverage must meet minimum requirements for CI to pass
-3. `getSigners` return an array of addresses, the first one is the default `deployer` for contracts, under no
-   circumstances should tests be written as `deployer`
-4. It's permissible to create mock contracts at `packages/<package>/contracts/mock` e.g. for third-party contracts
-5. Tests must not rely on any deploy scripts from the `deploy` package; your contracts must be deployed inside the test
-   fixture. See `test/fixtures.ts`
+3. `getSigners` return an array of addresses, the first one is the default
+   `deployer` for contracts, under no circumstances should tests be written as
+   `deployer`
+4. It's permissible to create mock contracts at
+   `packages/<package>/contracts/mock` e.g. for third-party contracts
+5. Tests must not rely on any deploy scripts from the `deploy` package; your
+   contracts must be deployed inside the test fixture. See `test/fixtures.ts`
 
 # Deployment
 
-Each package must unit-test the contracts by running everything inside the `hardhat node`. Deployment to "real"
-networks, configuration of our environment and integration tests must be done inside the `deploy` package.
+Each package must unit-test the contracts by running everything inside the
+`hardhat node`. Deployment to "real" networks, configuration of our environment
+and integration tests must be done inside the `deploy` package.
 
-The `deploy` package only imports `.sol` files. The idea is to recompile everything inside it and manage the entire
-deploy strategy from one place.
+The `deploy` package only imports `.sol` files. The idea is to recompile
+everything inside it and manage the entire deploy strategy from one place.
 
-1. Your deploy scripts should not be included inside `packages/<package>`: deploy scripts live inside `packages/deploy/`
-2. The `deploy` package doesn't use the hardhat config file from the specific package. Instead, it
-   uses `packages/deploy/hardhat.config.ts`
-3. You will need to review `packages/deploy/hardhat.config.ts` and update it as needed for any new namedAccounts you
-   added to your package
-4. When it comes to deploy time, it is preferred to include deploy scripts and end-to-end tests as a separate PR
-5. The named accounts inside the `deploy` package must use the "real-life" values
-6. Refer to the readme at `packages/deploy` to learn more about importing your package
+1. Your deploy scripts should not be included inside `packages/<package>`:
+   deploy scripts live inside `packages/deploy/`
+2. The `deploy` package doesn't use the hardhat config file from the specific
+   package. Instead, it uses `packages/deploy/hardhat.config.ts`
+3. You will need to review `packages/deploy/hardhat.config.ts` and update it as
+   needed for any new namedAccounts you added to your package
+4. When it comes to deploy time, it is preferred to include deploy scripts and
+   end-to-end tests as a separate PR
+5. The named accounts inside the `deploy` package must use the "real-life"
+   values
+6. Refer to the readme at `packages/deploy` to learn more about importing your
+   package
 
 #### INTEGRATION TESTING
 
 1. End-to-end tests live at `packages/deploy/`
-2. You must add end-to-end tests ahead of deploying your package. Importantly, these tests should verify deployment and
-   initialization configuration
+2. You must add end-to-end tests ahead of deploying your package. Importantly,
+   these tests should verify deployment and initialization configuration
 
 # A NOTE ON MAKING PULL REQUESTS
 

--- a/packages/dependency-metatx/package.json
+++ b/packages/dependency-metatx/package.json
@@ -10,8 +10,8 @@
   "scripts": {
     "lint": "eslint --max-warnings 0 \"**/*.{js,ts}\" && solhint --max-warnings 0 \"contracts/**/*.sol\"",
     "lint:fix": "eslint --fix \"**/*.{js,ts}\" && solhint --fix \"contracts/**/*.sol\"",
-    "format": "prettier --check \"**/*.{ts,js,sol.md}\"",
-    "format:fix": "prettier --write \"**/*.{ts,js,sol.md}\"",
+    "format": "prettier --check \"**/*.{ts,js,sol,md}\"",
+    "format:fix": "prettier --write \"**/*.{ts,js,sol,md}\"",
     "test": "hardhat test",
     "coverage": "hardhat coverage --testfiles 'test/*.ts''test/*.js'",
     "hardhat": "hardhat",

--- a/packages/dependency-operator-filter/README.md
+++ b/packages/dependency-operator-filter/README.md
@@ -1,66 +1,81 @@
 # <PACKAGE>
 
-The Sandbox's operator-filter dependency package, for use by The Sandbox's token contracts.
-Based on OpenSea's operator-filter.
-This is a dependency package, and the smart contracts inside use floating pragma.
+The Sandbox's operator-filter dependency package, for use by The Sandbox's token
+contracts. Based on OpenSea's operator-filter. This is a dependency package, and
+the smart contracts inside use floating pragma.
 
 ## Running the project locally
 
 Install dependencies with `yarn`
 
-Testing: Use `yarn test` inside `packages/<package>` to run tests locally inside this package
+Testing: Use `yarn test` inside `packages/<package>` to run tests locally inside
+this package
 
-For testing from root (with workspace feature) use: `yarn workspace @sandbox-smart-contracts/<package> test`
+For testing from root (with workspace feature) use:
+`yarn workspace @sandbox-smart-contracts/<package> test`
 
 Coverage: Run `yarn coverage`
 
-Formatting: Run `yarn prettier` to check and `yarn prettier:fix` to fix formatting errors
+Formatting: Run `yarn prettier` to check and `yarn prettier:fix` to fix
+formatting errors
 
-Linting: Run `yarn lint` to check and `yarn lint:fix` to fix static analysis errors
+Linting: Run `yarn lint` to check and `yarn lint:fix` to fix static analysis
+errors
 
 ## Package structure and minimum standards
 
 #### A NOTE ON DEPENDENCIES
 
-1. Add whatever dependencies you like inside your package; this template is for hardhat usage. OpenZeppelin contracts
-   are highly recommended and should be installed as a dev dependency
-2. For most Pull Requests there should be minimum changes to `yarn.lock` at root level
-3. Changes to root-level dependencies are permissible, however they should not be downgraded
+1. Add whatever dependencies you like inside your package; this template is for
+   hardhat usage. OpenZeppelin contracts are highly recommended and should be
+   installed as a dev dependency
+2. For most Pull Requests there should be minimum changes to `yarn.lock` at root
+   level
+3. Changes to root-level dependencies are permissible, however they should not
+   be downgraded
 4. Take care to run `yarn` before pushing your changes
-5. You shouldn't need to install dotenv since you won't be deploying inside this package (see below)
+5. You shouldn't need to install dotenv since you won't be deploying inside this
+   package (see below)
 
 #### UNIT TESTING
 
 1. Unit tests are to be added in `packages/<package>/test`
 2. Coverage must meet minimum requirements for CI to pass
-3. `getSigners` return an array of addresses, the first one is the default `deployer` for contracts, under no
-   circumstances should tests be written as `deployer`
-4. It's permissible to create mock contracts at `packages/<package>/contracts/mock` e.g. for third-party contracts
-5. Tests must not rely on any deploy scripts from the `deploy` package; your contracts must be deployed inside the test
-   fixture. See `test/fixtures.ts`
+3. `getSigners` return an array of addresses, the first one is the default
+   `deployer` for contracts, under no circumstances should tests be written as
+   `deployer`
+4. It's permissible to create mock contracts at
+   `packages/<package>/contracts/mock` e.g. for third-party contracts
+5. Tests must not rely on any deploy scripts from the `deploy` package; your
+   contracts must be deployed inside the test fixture. See `test/fixtures.ts`
 
 # Deployment
 
-Each package must unit-test the contracts by running everything inside the `hardhat node`. Deployment to "real"
-networks, configuration of our environment and integration tests must be done inside the `deploy` package.
+Each package must unit-test the contracts by running everything inside the
+`hardhat node`. Deployment to "real" networks, configuration of our environment
+and integration tests must be done inside the `deploy` package.
 
-The `deploy` package only imports `.sol` files. The idea is to recompile everything inside it and manage the entire
-deploy strategy from one place.
+The `deploy` package only imports `.sol` files. The idea is to recompile
+everything inside it and manage the entire deploy strategy from one place.
 
-1. Your deploy scripts should not be included inside `packages/<package>`: deploy scripts live inside `packages/deploy/`
-2. The `deploy` package doesn't use the hardhat config file from the specific package. Instead, it
-   uses `packages/deploy/hardhat.config.ts`
-3. You will need to review `packages/deploy/hardhat.config.ts` and update it as needed for any new namedAccounts you
-   added to your package
-4. When it comes to deploy time, it is preferred to include deploy scripts and end-to-end tests as a separate PR
-5. The named accounts inside the `deploy` package must use the "real-life" values
-6. Refer to the readme at `packages/deploy` to learn more about importing your package
+1. Your deploy scripts should not be included inside `packages/<package>`:
+   deploy scripts live inside `packages/deploy/`
+2. The `deploy` package doesn't use the hardhat config file from the specific
+   package. Instead, it uses `packages/deploy/hardhat.config.ts`
+3. You will need to review `packages/deploy/hardhat.config.ts` and update it as
+   needed for any new namedAccounts you added to your package
+4. When it comes to deploy time, it is preferred to include deploy scripts and
+   end-to-end tests as a separate PR
+5. The named accounts inside the `deploy` package must use the "real-life"
+   values
+6. Refer to the readme at `packages/deploy` to learn more about importing your
+   package
 
 #### INTEGRATION TESTING
 
 1. End-to-end tests live at `packages/deploy/`
-2. You must add end-to-end tests ahead of deploying your package. Importantly, these tests should verify deployment and
-   initialization configuration
+2. You must add end-to-end tests ahead of deploying your package. Importantly,
+   these tests should verify deployment and initialization configuration
 
 # A NOTE ON MAKING PULL REQUESTS
 

--- a/packages/dependency-operator-filter/contracts/OperatorFilterRegistrant.md
+++ b/packages/dependency-operator-filter/contracts/OperatorFilterRegistrant.md
@@ -1,29 +1,52 @@
 # OperatorFilterRegistry
 
-OpenSea in an attempt to regularize market places and creator earnings deployed a registry(https://github.com/ProjectOpenSea/operator-filter-registry) and asked NFT token contract to add filter logic(https://github.com/ProjectOpenSea/operator-filter-registry/blob/main/src/OperatorFilterer.sol).
+OpenSea in an attempt to regularize market places and creator earnings deployed
+a registry(https://github.com/ProjectOpenSea/operator-filter-registry) and asked
+NFT token contract to add filter
+logic(https://github.com/ProjectOpenSea/operator-filter-registry/blob/main/src/OperatorFilterer.sol).
 
-These filter has two modifier
-1st : onlyAllowedOperator
-2nd : onlyAllowedOperatorApproval
+These filter has two modifier 1st : onlyAllowedOperator 2nd :
+onlyAllowedOperatorApproval
 
-These modifiers are added to to the transfer functions(onlyAllowedOperator) and approval function(onlyAllowedOperatorApproval) such that the when not an owner tried to transfer a Token(ex: Marketplace) or owner approves an operator(ex : Marketplace) they would be filtered on the OperatorFilterRegistry.
+These modifiers are added to to the transfer functions(onlyAllowedOperator) and
+approval function(onlyAllowedOperatorApproval) such that the when not an owner
+tried to transfer a Token(ex: Marketplace) or owner approves an operator(ex :
+Marketplace) they would be filtered on the OperatorFilterRegistry.
 
-If the operator or the token transfer is not approved by the registry the transaction would be reverted.
+If the operator or the token transfer is not approved by the registry the
+transaction would be reverted.
 
-On OperatorFilterRegistry a contract owner or the contract can register and maintain there own blacklist or subscribe to other blacklists but that blacklist should contain the default marketplaces blacklisted by OpenSea.
+On OperatorFilterRegistry a contract owner or the contract can register and
+maintain there own blacklist or subscribe to other blacklists but that blacklist
+should contain the default marketplaces blacklisted by OpenSea.
 
 # OperatorFiltererRegistrant
 
-The OperatorFiltererRegistrant contract is made to be registered on the OperatorFilterRegistry and copy the default blacklist of the OpenSea. This contract would then be subscribed by the contract such as AssetERC721 and AssetERC1155.
+The OperatorFiltererRegistrant contract is made to be registered on the
+OperatorFilterRegistry and copy the default blacklist of the OpenSea. This
+contract would then be subscribed by the contract such as AssetERC721 and
+AssetERC1155.
 
-The OperatorFiltererRegistrant would be the subscription for our token contracts on a layer(layer-1 : Ethereum , layer-2: Polygon), such that when a address is added or removed from OperatorFiltererRegistrant's blacklist it would be come in affect for each contact which subscribe to the OperatorFiltererRegistrant's blacklist.
+The OperatorFiltererRegistrant would be the subscription for our token contracts
+on a layer(layer-1 : Ethereum , layer-2: Polygon), such that when a address is
+added or removed from OperatorFiltererRegistrant's blacklist it would be come in
+affect for each contact which subscribe to the OperatorFiltererRegistrant's
+blacklist.
 
 # Intended usage
 
-The OperatorFiltererRegistrant is so that sandbox will have a common blacklist that would be utilized by every Token contract on a layer. This would create a single list that would be subscribed by each contract to provide uniformity to which market places sandbox wants to blacklist. This would also provide a focal point to remove and add market places such that it would be applicable to every contract that subscribe to it.
+The OperatorFiltererRegistrant is so that sandbox will have a common blacklist
+that would be utilized by every Token contract on a layer. This would create a
+single list that would be subscribed by each contract to provide uniformity to
+which market places sandbox wants to blacklist. This would also provide a focal
+point to remove and add market places such that it would be applicable to every
+contract that subscribe to it.
 
 # Implementation
 
-We didn't use the npm package as its solidity pragma(solidity version) doesn't match the one we have for our Asset contracts and updating our solidity version for Assets would have been to time consuming.
+We didn't use the npm package as its solidity pragma(solidity version) doesn't
+match the one we have for our Asset contracts and updating our solidity version
+for Assets would have been to time consuming.
 
-You won't find OperatorFilterRegistrant in the npm package as this contract is our implementation.
+You won't find OperatorFilterRegistrant in the npm package as this contract is
+our implementation.

--- a/packages/dependency-operator-filter/package.json
+++ b/packages/dependency-operator-filter/package.json
@@ -8,8 +8,8 @@
   "scripts": {
     "lint": "eslint --max-warnings 0 \"**/*.{js,ts}\" && solhint --max-warnings 0 \"contracts/**/*.sol\"",
     "lint:fix": "eslint --fix \"**/*.{js,ts}\" && solhint --fix \"contracts/**/*.sol\"",
-    "format": "prettier --check \"**/*.{ts,js,sol.md}\"",
-    "format:fix": "prettier --write \"**/*.{ts,js,sol.md}\"",
+    "format": "prettier --check \"**/*.{ts,js,sol,md}\"",
+    "format:fix": "prettier --write \"**/*.{ts,js,sol,md}\"",
     "test": "hardhat test",
     "coverage": "hardhat coverage --testfiles 'test/*.ts''test/*.js'",
     "hardhat": "hardhat",

--- a/packages/giveaway/CHANGELOG.md
+++ b/packages/giveaway/CHANGELOG.md
@@ -3,12 +3,13 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.0.0] - 2023-09-14
 
 - first official version using release-it.
-- deploy to polygon 
+- deploy to polygon
 
 ## [0.0.3] - 2023-08-24
 

--- a/packages/giveaway/README.md
+++ b/packages/giveaway/README.md
@@ -2,20 +2,23 @@
 
 This is a hardhat project, see [https://hardhat.org](https://hardhat.org)
 
-The main contract gives rewards in any ERC20, ERC721 or ERC1155 when the backend authorize it via message signing.
+The main contract gives rewards in any ERC20, ERC721 or ERC1155 when the backend
+authorize it via message signing.
 
 The message is composed of:
 
-- A list of signatures. If the contract holt too much value more than one signature is needed. Ideally the systems that
-  sign must be independent.
+- A list of signatures. If the contract holt too much value more than one
+  signature is needed. Ideally the systems that sign must be independent.
 - A list of claim ids used by the backend to avoid double spending.
-- Expiration the expiration time of the message in unix timestamp. After the expiration the message cannot be used
-  anymore.
-- From: usually the rewards must be transferred to the contract and this value is address(this), if a strategy with
-  approve and transfer is used this is the address of the source.
+- Expiration the expiration time of the message in unix timestamp. After the
+  expiration the message cannot be used anymore.
+- From: usually the rewards must be transferred to the contract and this value
+  is address(this), if a strategy with approve and transfer is used this is the
+  address of the source.
 - To: the destination address that will get the rewards.
-- Claims: A list of union structs (ClaimEntry) that include: token type (ERC20, ERC721, ERC1155, etc), token address and
-  a data field that depending on the token type may have: amount, tokenId, etc.
+- Claims: A list of union structs (ClaimEntry) that include: token type (ERC20,
+  ERC721, ERC1155, etc), token address and a data field that depending on the
+  token type may have: amount, tokenId, etc.
 
 # Usage
 
@@ -29,5 +32,5 @@ yarn hardhat markup
 
 # Deployment
 
-This package exports the contract source code, for deployments see: [@sandbox-smart-contract/deploy](../deploy) package.
-
+This package exports the contract source code, for deployments see:
+[@sandbox-smart-contract/deploy](../deploy) package.

--- a/packages/giveaway/contracts/SignedMultiGiveaway.md
+++ b/packages/giveaway/contracts/SignedMultiGiveaway.md
@@ -1,22 +1,25 @@
 # Audience
 
-The intended audience for .md documentation is auditors, internal developers and external developer contributors.
+The intended audience for .md documentation is auditors, internal developers and
+external developer contributors.
 
 # Features
 
-This contract give rewards in any ERC20, ERC721 or ERC1155 when the backend authorize it via message signing. The
-message is composed of:
+This contract give rewards in any ERC20, ERC721 or ERC1155 when the backend
+authorize it via message signing. The message is composed of:
 
-- A list of signatures. If the contract holds too much value more than one signature is needed. Ideally the systems that
-  sign must be independent.
+- A list of signatures. If the contract holds too much value more than one
+  signature is needed. Ideally the systems that sign must be independent.
 - A list of claim ids used by the backend to avoid double spending.
-- Expiration the expiration time of the message in unix timestamp. After the expiration the message cannot be used
-  anymore.
-- From: usually the rewards must be transferred to the contract and this value is address(this), if a strategy with
-  approve and transfer is used this is the address of the source.
+- Expiration the expiration time of the message in unix timestamp. After the
+  expiration the message cannot be used anymore.
+- From: usually the rewards must be transferred to the contract and this value
+  is address(this), if a strategy with approve and transfer is used this is the
+  address of the source.
 - To: the destination address that will get the rewards.
-- Claims: A list of union structs (ClaimEntry) that include: token type (ERC20, ERC721, ERC1155, etc), token address and
-  a data field that depending on the token type may have: amount, tokenId, etc.
+- Claims: A list of union structs (ClaimEntry) that include: token type (ERC20,
+  ERC721, ERC1155, etc), token address and a data field that depending on the
+  token type may have: amount, tokenId, etc.
 
 ```solidity
 Signature[] calldata sigs,
@@ -30,23 +33,26 @@ ClaimEntry[] calldata claims
 ## Roles
 
 - SIGNERS: This role corresponds to the addresses authorized to sign claims.
-- DEFAULT_ADMIN_ROLE: This role can grant and revoke access to the other roles also it is in charge of setting the
-  limits and un-pausing the contract.
-- BACKOFFICE_ADMIN: Addresses in this role help the admin but with fewer privileges. They can revoke claims, pause the
-  contract in the case of an emergency (but cannot unpause it).
+- DEFAULT_ADMIN_ROLE: This role can grant and revoke access to the other roles
+  also it is in charge of setting the limits and un-pausing the contract.
+- BACKOFFICE_ADMIN: Addresses in this role help the admin but with fewer
+  privileges. They can revoke claims, pause the contract in the case of an
+  emergency (but cannot unpause it).
 
 ## Limits
 
-The contract implement some limits on the amount that can be claim at once, this doesn't protect us completely but at
-least it will force the attacker to send a lot of transactions. The limits can be imposed over a certain token address
-and for ERC1155 a token address plus token id.
+The contract implement some limits on the amount that can be claim at once, this
+doesn't protect us completely but at least it will force the attacker to send a
+lot of transactions. The limits can be imposed over a certain token address and
+for ERC1155 a token address plus token id.
 
 We have the following limits:
 
-- Number of signatures: number of backend signatures needed to approve a claim, this can be used to have a multi-sig
-  structure on the backend side (default is 1).
-- Max entries per claim: maximum amount of claim entries (token transferred) that can be done in one claim (default is
+- Number of signatures: number of backend signatures needed to approve a claim,
+  this can be used to have a multi-sig structure on the backend side (default is
   1).
+- Max entries per claim: maximum amount of claim entries (token transferred)
+  that can be done in one claim (default is 1).
 - Max wei per claim: maximum amount of tokens transferred for each claim entry.
 
 ## Structs info
@@ -55,7 +61,7 @@ We have the following limits:
 
 ```solidity
 struct PerTokenLimitData {
-    uint256 maxWeiPerClaim;
+  uint256 maxWeiPerClaim;
 }
 ```
 
@@ -63,8 +69,8 @@ struct PerTokenLimitData {
 
 ```solidity
 struct LimitData {
-    uint128 numberOfSignaturesNeeded;
-    uint128 maxClaimEntries;
+  uint128 numberOfSignaturesNeeded;
+  uint128 maxClaimEntries;
 }
 ```
 
@@ -72,12 +78,12 @@ struct LimitData {
 
 ```solidity
 struct BatchClaimData {
-    SignedMultiGiveawayBase.Signature[] sigs;
-    uint256[] claimIds;
-    uint256 expiration;
-    address from;
-    address to;
-    SignedMultiGiveawayBase.ClaimEntry[] claims;
+  SignedMultiGiveawayBase.Signature[] sigs;
+  uint256[] claimIds;
+  uint256 expiration;
+  address from;
+  address to;
+  SignedMultiGiveawayBase.ClaimEntry[] claims;
 }
 ```
 
@@ -93,13 +99,13 @@ This event is emitted when a claim occurs.
 
 Parameters:
 
-| Name     | Type                                        | Description                                                     |
-| :------- | :------------------------------------------ | :-------------------------------------------------------------- |
-| claimIds | uint256[]                                   | unique claim ids, used by the backend to avoid double spending  |
-| from     | address                                     | source user                                                     |
-| to       | address                                     | destination user                                                |
-| claims   | struct SignedMultiGiveawayBase.ClaimEntry[] | list of tokens to do transfer                                   |
-| operator | address                                     | the sender of the transaction                                   |
+| Name     | Type                                        | Description                                                    |
+| :------- | :------------------------------------------ | :------------------------------------------------------------- |
+| claimIds | uint256[]                                   | unique claim ids, used by the backend to avoid double spending |
+| from     | address                                     | source user                                                    |
+| to       | address                                     | destination user                                               |
+| claims   | struct SignedMultiGiveawayBase.ClaimEntry[] | list of tokens to do transfer                                  |
+| operator | address                                     | the sender of the transaction                                  |
 
 ### RevokedClaims
 
@@ -111,10 +117,10 @@ This event is emitted when a claim is revoked.
 
 Parameters:
 
-| Name     | Type      | Description                                                     |
-| :------- | :-------- | :-------------------------------------------------------------- |
-| claimIds | uint256[] | unique claim ids, used by the backend to avoid double spending  |
-| operator | address   | the sender of the transaction                                   |
+| Name     | Type      | Description                                                    |
+| :------- | :-------- | :------------------------------------------------------------- |
+| claimIds | uint256[] | unique claim ids, used by the backend to avoid double spending |
+| operator | address   | the sender of the transaction                                  |
 
 ### AssetsRecovered
 
@@ -126,11 +132,11 @@ This event is emitted when assets are recovered from the contract.
 
 Parameters:
 
-| Name     | Type                                        | Description                                                     |
-| :------- | :------------------------------------------ | :-------------------------------------------------------------- |
-| to       | address                                     | destination user                                                |
-| claims   | struct SignedMultiGiveawayBase.ClaimEntry[] | unique claim ids, used by the backend to avoid double spending  |
-| operator | address                                     | the sender of the transaction                                   |
+| Name     | Type                                        | Description                                                    |
+| :------- | :------------------------------------------ | :------------------------------------------------------------- |
+| to       | address                                     | destination user                                               |
+| claims   | struct SignedMultiGiveawayBase.ClaimEntry[] | unique claim ids, used by the backend to avoid double spending |
+| operator | address                                     | the sender of the transaction                                  |
 
 ### MaxWeiPerClaimSet
 
@@ -142,12 +148,12 @@ This event is emitted when the max wei per claim is set
 
 Parameters:
 
-| Name           | Type    | Description                                                           |
-| :------------- | :------ | :-------------------------------------------------------------------- |
-| token          | address | address of the token to configure                                     |
-| tokenId        | uint256 | of the token                                                          |
-| maxWeiPerClaim | uint256 | maximum amount of wei per each individual claim, 0 => check disabled  |
-| operator       | address | the sender of the transaction                                         |
+| Name           | Type    | Description                                                          |
+| :------------- | :------ | :------------------------------------------------------------------- |
+| token          | address | address of the token to configure                                    |
+| tokenId        | uint256 | of the token                                                         |
+| maxWeiPerClaim | uint256 | maximum amount of wei per each individual claim, 0 => check disabled |
+| operator       | address | the sender of the transaction                                        |
 
 ### NumberOfSignaturesNeededSet
 
@@ -159,10 +165,10 @@ This event is emitted when the number of signatures needed to claim is set
 
 Parameters:
 
-| Name                     | Type    | Description                                 |
-| :----------------------- | :------ | :------------------------------------------ |
-| numberOfSignaturesNeeded | uint128 | amount of valid signatures needed to claim  |
-| operator                 | address | the sender of the transaction               |
+| Name                     | Type    | Description                                |
+| :----------------------- | :------ | :----------------------------------------- |
+| numberOfSignaturesNeeded | uint128 | amount of valid signatures needed to claim |
+| operator                 | address | the sender of the transaction              |
 
 ### MaxClaimEntriesSet
 
@@ -174,10 +180,10 @@ This event is emitted when the max entries per claim is set
 
 Parameters:
 
-| Name            | Type    | Description                                  |
-| :-------------- | :------ | :------------------------------------------- |
-| maxClaimEntries | uint128 | maximum amount of claim entries per message  |
-| operator        | address | the sender of the transaction                |
+| Name            | Type    | Description                                 |
+| :-------------- | :------ | :------------------------------------------ |
+| maxClaimEntries | uint128 | maximum amount of claim entries per message |
+| operator        | address | the sender of the transaction               |
 
 ## Constants info
 
@@ -199,7 +205,8 @@ string constant VERSION = "1.0"
 bytes32 constant BACKOFFICE_ROLE = keccak256("BACKOFFICE_ROLE")
 ```
 
-this role is for addresses that help the admin. Can pause the contract, but, only the admin can unpause it.
+this role is for addresses that help the admin. Can pause the contract, but,
+only the admin can unpause it.
 
 ## Modifiers info
 
@@ -240,10 +247,10 @@ initializer method, called during deployment
 
 Parameters:
 
-| Name              | Type    | Description                                          |
-| :---------------- | :------ | :--------------------------------------------------- |
-| trustedForwarder_ | address | address of the ERC2771 trusted forwarder             |
-| admin_            | address | address that have admin access and can assign roles. |
+| Name               | Type    | Description                                          |
+| :----------------- | :------ | :--------------------------------------------------- |
+| trustedForwarder\_ | address | address of the ERC2771 trusted forwarder             |
+| admin\_            | address | address that have admin access and can assign roles. |
 
 ### claim (0xbec74704)
 
@@ -258,18 +265,19 @@ function claim(
 ) external whenNotPaused
 ```
 
-verifies the ERC712 signatures and transfer tokens from the source user to the destination user.
+verifies the ERC712 signatures and transfer tokens from the source user to the
+destination user.
 
 Parameters:
 
-| Name       | Type                                        | Description                                                      |
-| :--------- | :------------------------------------------ | :--------------------------------------------------------------- |
-| sigs       | struct SignedMultiGiveawayBase.Signature[]  | signature part (v,r,s) the array of signatures M in N of M sigs  |
-| claimIds   | uint256[]                                   | unique claim ids, used by the backend to avoid double spending   |
-| expiration | uint256                                     | expiration timestamp                                             |
-| from       | address                                     | source user                                                      |
-| to         | address                                     | destination user                                                 |
-| claims     | struct SignedMultiGiveawayBase.ClaimEntry[] | list of tokens to do transfer                                    |
+| Name       | Type                                        | Description                                                     |
+| :--------- | :------------------------------------------ | :-------------------------------------------------------------- |
+| sigs       | struct SignedMultiGiveawayBase.Signature[]  | signature part (v,r,s) the array of signatures M in N of M sigs |
+| claimIds   | uint256[]                                   | unique claim ids, used by the backend to avoid double spending  |
+| expiration | uint256                                     | expiration timestamp                                            |
+| from       | address                                     | source user                                                     |
+| to         | address                                     | destination user                                                |
+| claims     | struct SignedMultiGiveawayBase.ClaimEntry[] | list of tokens to do transfer                                   |
 
 ### batchClaim (0x4ac48bc1)
 
@@ -300,10 +308,10 @@ let the admin recover tokens from the contract
 
 Parameters:
 
-| Name   | Type                                        | Description                                |
-| :----- | :------------------------------------------ | :----------------------------------------- |
-| to     | address                                     | destination address of the recovered fund  |
-| claims | struct SignedMultiGiveawayBase.ClaimEntry[] | list of the tokens to transfer             |
+| Name   | Type                                        | Description                               |
+| :----- | :------------------------------------------ | :---------------------------------------- |
+| to     | address                                     | destination address of the recovered fund |
+| claims | struct SignedMultiGiveawayBase.ClaimEntry[] | list of the tokens to transfer            |
 
 ### revokeClaims (0xe5dac0d0)
 
@@ -381,11 +389,11 @@ even tokenId is kind of inconsistent for tokenType!=ERC1155 it doesn't harm
 
 Parameters:
 
-| Name           | Type    | Description                                                   |
-| :------------- | :------ | :------------------------------------------------------------ |
-| token          | address | the token to which will assign the limit                      |
-| tokenId        | uint256 | for ERC1155 is the id of the token, else it must be zero      |
-| maxWeiPerClaim | uint256 | the max amount per each claim, for example 0.01eth per claim  |
+| Name           | Type    | Description                                                  |
+| :------------- | :------ | :----------------------------------------------------------- |
+| token          | address | the token to which will assign the limit                     |
+| tokenId        | uint256 | for ERC1155 is the id of the token, else it must be zero     |
+| maxWeiPerClaim | uint256 | the max amount per each claim, for example 0.01eth per claim |
 
 ### setTrustedForwarder (0xda742228)
 
@@ -411,9 +419,9 @@ return true if already claimed
 
 Parameters:
 
-| Name    | Type    | Description                              |
-| :------ | :------ | :--------------------------------------- |
-| claimId | uint256 | unique id used to avoid double spending  |
+| Name    | Type    | Description                             |
+| :------ | :------ | :-------------------------------------- |
+| claimId | uint256 | unique id used to avoid double spending |
 
 Return values:
 
@@ -438,14 +446,14 @@ verifies a ERC712 signature for the Claim data type.
 
 Parameters:
 
-| Name       | Type                                        | Description                              |
-| :--------- | :------------------------------------------ | :--------------------------------------- |
-| sig        | struct SignedMultiGiveawayBase.Signature    | signature part (v,r,s)                   |
-| claimIds   | uint256[]                                   | unique id used to avoid double spending  |
-| expiration | uint256                                     | expiration timestamp                     |
-| from       | address                                     | source user                              |
-| to         | address                                     | destination user                         |
-| claims     | struct SignedMultiGiveawayBase.ClaimEntry[] | list of tokens to do transfer            |
+| Name       | Type                                        | Description                             |
+| :--------- | :------------------------------------------ | :-------------------------------------- |
+| sig        | struct SignedMultiGiveawayBase.Signature    | signature part (v,r,s)                  |
+| claimIds   | uint256[]                                   | unique id used to avoid double spending |
+| expiration | uint256                                     | expiration timestamp                    |
+| from       | address                                     | source user                             |
+| to         | address                                     | destination user                        |
+| claims     | struct SignedMultiGiveawayBase.ClaimEntry[] | list of tokens to do transfer           |
 
 Return values:
 
@@ -510,10 +518,10 @@ even tokenId is kind of inconsistent for tokenType!=ERC1155 it doesn't harm
 
 Parameters:
 
-| Name    | Type    | Description                                |
-| :------ | :------ | :----------------------------------------- |
-| token   | address | the token contract address                 |
-| tokenId | uint256 | if ERC1155 the token id else must be zero  |
+| Name    | Type    | Description                               |
+| :------ | :------ | :---------------------------------------- |
+| token   | address | the token contract address                |
+| tokenId | uint256 | if ERC1155 the token id else must be zero |
 
 Return values:
 

--- a/packages/giveaway/package.json
+++ b/packages/giveaway/package.json
@@ -15,8 +15,8 @@
     "scripts": {
         "lint": "eslint --max-warnings 0 \"**/*.{js,ts}\" && solhint --max-warnings 0 \"contracts/**/*.sol\"",
         "lint:fix": "eslint --fix \"**/*.{js,ts}\" && solhint --fix \"contracts/**/*.sol\"",
-        "format": "prettier --check \"**/*.{ts,js,sol.md}\"",
-        "format:fix": "prettier --write \"**/*.{ts,js,sol.md}\"",
+        "format": "prettier --check \"**/*.{ts,js,sol,md}\"",
+        "format:fix": "prettier --write \"**/*.{ts,js,sol,md}\"",
         "test": "hardhat test",
         "coverage": "hardhat coverage --testfiles 'test/*.ts''test/*.js'",
         "hardhat": "hardhat",


### PR DESCRIPTION
## Description
In the previous [PR](https://github.com/thesandboxgame/sandbox-smart-contracts/pull/1266) there was an error on some package (instead of matching `sol,md` we did `sol.md`)