### PR TITLE
Add name and symbol to cat contract

### DIFF
--- a/packages/asset/contracts/Catalyst.sol
+++ b/packages/asset/contracts/Catalyst.sol
@@ -312,5 +312,17 @@ contract Catalyst is
         emit OperatorRegistrySet(registry);
     }
 
+    /// @notice A descriptive name for the collection of tokens in this contract.
+    /// @return _name the name of the tokens.
+    function name() external pure returns (string memory _name) {
+        return "The Sandbox's CATALYSTs";
+    }
+
+    /// @notice An abbreviated name for the collection of tokens in this contract.
+    /// @return _symbol the symbol of the tokens.
+    function symbol() external pure returns (string memory _symbol) {
+        return "CATALYST";
+    }
+
     uint256[49] private __gap;
 }

--- a/packages/asset/test/Catalyst.test.ts
+++ b/packages/asset/test/Catalyst.test.ts
@@ -15,7 +15,7 @@ import {BigNumber} from 'ethers';
 const catalystArray = [0, 1, 2, 3, 4, 5, 6];
 const zeroAddress = '0x0000000000000000000000000000000000000000';
 
-describe('Catalyst (/packages/asset/contracts/Catalyst.sol)', function () {
+describe.only('Catalyst (/packages/asset/contracts/Catalyst.sol)', function () {
   describe('Contract setup', function () {
     it('Should deploy correctly', async function () {
       const {
@@ -37,6 +37,11 @@ describe('Catalyst (/packages/asset/contracts/Catalyst.sol)', function () {
       ).to.be.equals(true);
       expect(await catalyst.highestTierIndex()).to.be.equals(6);
       expect(catalyst.address).to.be.properAddress;
+    });
+    it('Should have return correct name and symbol', async function () {
+      const {catalyst} = await runCatalystSetup();
+      expect(await catalyst.name()).to.be.equal("The Sandbox's CATALYSTs");
+      expect(await catalyst.symbol()).to.be.equal('CATALYST');
     });
     describe('Interface support', function () {
       it('should support ERC165', async function () {

--- a/packages/asset/test/Catalyst.test.ts
+++ b/packages/asset/test/Catalyst.test.ts
@@ -15,7 +15,7 @@ import {BigNumber} from 'ethers';
 const catalystArray = [0, 1, 2, 3, 4, 5, 6];
 const zeroAddress = '0x0000000000000000000000000000000000000000';
 
-describe.only('Catalyst (/packages/asset/contracts/Catalyst.sol)', function () {
+describe('Catalyst (/packages/asset/contracts/Catalyst.sol)', function () {
   describe('Contract setup', function () {
     it('Should deploy correctly', async function () {
       const {


### PR DESCRIPTION
## Description

Add name and symbol to the catalyst contract.
Add tests to confirm the values can be retrieved.