### PR TITLE
Add read checks in deployment scripts

### DIFF
--- a/packages/deploy/deploy/400_asset/405_asset_create_setup.ts
+++ b/packages/deploy/deploy/400_asset/405_asset_create_setup.ts
@@ -53,17 +53,24 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     log(`Catalyst BURNER_ROLE granted to ${assetCreate.address}`);
   }
 
-  await catchUnknownSigner(
-    execute(
-      'AuthSuperValidator',
-      {from: assetAdmin, log: true},
-      'setSigner',
-      assetCreate.address,
-      backendAuthWallet
-    )
-  );
-
-  log(`AuthSuperValidator signer for Asset Create set to ${backendAuthWallet}`);
+  if (
+    (
+      await read('AuthSuperValidator', 'getSigner', assetCreate.address)
+    ).toLowerCase() !== backendAuthWallet.toLowerCase()
+  ) {
+    await catchUnknownSigner(
+      execute(
+        'AuthSuperValidator',
+        {from: assetAdmin, log: true},
+        'setSigner',
+        assetCreate.address,
+        backendAuthWallet
+      )
+    );
+    log(
+      `AuthSuperValidator signer for Asset Create set to ${backendAuthWallet}`
+    );
+  }
 };
 
 export default func;

--- a/packages/deploy/deploy/400_asset/407_asset_setup.ts
+++ b/packages/deploy/deploy/400_asset/407_asset_setup.ts
@@ -24,31 +24,45 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     log(`Asset MODERATOR_ROLE granted to ${assetAdmin}`);
   }
 
-  await catchUnknownSigner(
-    execute(
-      'RoyaltyManager',
-      {from: contractRoyaltySetter, log: true},
-      'setContractRoyalty',
-      Asset.address,
-      DEFAULT_BPS
-    )
-  );
-  log(`Asset set on RoyaltyManager with ${DEFAULT_BPS} BPS royalty`);
+  if (
+    (await read('RoyaltyManager', 'getContractRoyalty', Asset.address)) !==
+    DEFAULT_BPS
+  ) {
+    await catchUnknownSigner(
+      execute(
+        'RoyaltyManager',
+        {from: contractRoyaltySetter, log: true},
+        'setContractRoyalty',
+        Asset.address,
+        DEFAULT_BPS
+      )
+    );
+    log(`Asset set on RoyaltyManager with ${DEFAULT_BPS} BPS royalty`);
+  }
 
   const splitterDeployerRole = await read(
     'RoyaltyManager',
     'SPLITTER_DEPLOYER_ROLE'
   );
-  await catchUnknownSigner(
-    execute(
+  if (
+    !(await read(
       'RoyaltyManager',
-      {from: royaltyManagerAdmin, log: true},
-      'grantRole',
+      'hasRole',
       splitterDeployerRole,
       Asset.address
-    )
-  );
-  log(`Asset set on RoyaltyManager with Splitter Deployer Role`);
+    ))
+  ) {
+    await catchUnknownSigner(
+      execute(
+        'RoyaltyManager',
+        {from: royaltyManagerAdmin, log: true},
+        'grantRole',
+        splitterDeployerRole,
+        Asset.address
+      )
+    );
+    log(`Asset set on RoyaltyManager with Splitter Deployer Role`);
+  }
 };
 
 export default func;


### PR DESCRIPTION
## Description

Add read checks in the Asset deploy scripts so that we don't execute transactions that have already been called.