### PR TITLE
feat: compile to paris when the dontSupportShanghai flag is set on a network

### DIFF
--- a/packages/deploy/hardhat.config.ts
+++ b/packages/deploy/hardhat.config.ts
@@ -7,6 +7,7 @@ import {
   addForkingSupport,
   addNodeAndMnemonic,
   skipDeploymentsOnLiveNetworks,
+  skipShanghaiIfNeeded,
 } from './utils/hardhatConfig';
 import './tasks/importedPackages';
 
@@ -286,12 +287,14 @@ const networks = {
     companionNetworks: {
       l1: 'goerli',
     },
+    dontSupportShanghai: true,
   },
   polygon: {
     tags: ['mainnet', 'L2'],
     companionNetworks: {
       l1: 'mainnet',
     },
+    dontSupportShanghai: true,
   },
 };
 
@@ -315,18 +318,20 @@ const compilers = [
   },
 }));
 
-const config = skipDeploymentsOnLiveNetworks(
-  addForkingSupport({
-    importedPackages,
-    namedAccounts,
-    networks: addNodeAndMnemonic(networks),
-    mocha: {
-      timeout: 0,
-      ...(!process.env.CI ? {} : {invert: true, grep: '@skip-on-ci'}),
-    },
-    solidity: {
-      compilers,
-    },
-  })
+const config = skipShanghaiIfNeeded(
+  skipDeploymentsOnLiveNetworks(
+    addForkingSupport({
+      importedPackages,
+      namedAccounts,
+      networks: addNodeAndMnemonic(networks),
+      mocha: {
+        timeout: 0,
+        ...(!process.env.CI ? {} : {invert: true, grep: '@skip-on-ci'}),
+      },
+      solidity: {
+        compilers,
+      },
+    })
+  )
 );
 export default config;

--- a/packages/deploy/tasks/importedPackages.ts
+++ b/packages/deploy/tasks/importedPackages.ts
@@ -21,7 +21,7 @@ declare module 'hardhat/types/runtime' {
 }
 declare module 'hardhat/types/config' {
   interface HardhatUserConfig {
-    importedPackages: {[name: string]: string};
+    importedPackages: {[name: string]: string | string[]};
   }
 }
 


### PR DESCRIPTION
## Description
Add an extra flag on each network that forces solc to compile to paris target (so we use the latest compiler but the right opcodes for current matic network).
Also only the node urls that are needed are read (previously it was reading all the existing networks).