### PR TITLE
Add Ownable extension to Asset and Catalyst

### DIFF
--- a/packages/asset/contracts/AssetV2.sol
+++ b/packages/asset/contracts/AssetV2.sol
@@ -1,0 +1,31 @@
+//SPDX-License-Identifier: MIT
+pragma solidity 0.8.18;
+
+import {Asset} from "./Asset.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {ContextUpgradeable} from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+
+/// @title AssetV2
+/// @author The Sandbox
+/// @notice ERC1155 asset token contract
+/// @notice Minting and burning tokens is only allowed through separate authorized contracts
+/// @dev This contract is final and should not be inherited
+contract AssetV2 is Asset, OwnableUpgradeable {
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    /// @notice Initialize the new Ownable extension
+    function reinitialize() external reinitializer(2) {
+        __Ownable_init();
+    }
+
+    function _msgSender() internal view virtual override(Asset, ContextUpgradeable) returns (address sender) {
+        return Asset._msgSender();
+    }
+
+    function _msgData() internal view virtual override(Asset, ContextUpgradeable) returns (bytes calldata msgData) {
+        return Asset._msgData();
+    }
+}

--- a/packages/asset/contracts/CatalystV2.sol
+++ b/packages/asset/contracts/CatalystV2.sol
@@ -1,0 +1,32 @@
+//SPDX-License-Identifier: MIT
+pragma solidity 0.8.18;
+
+import {Catalyst} from "./Catalyst.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {ContextUpgradeable} from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+
+/// @title CatalystV2
+/// @author The Sandbox
+/// @notice This contract manages catalysts which are used to mint new assets.
+/// @dev An ERC1155 contract that manages catalysts, extends multiple OpenZeppelin contracts to
+/// provide a variety of features including, AccessControl, URIStorage, Burnable and more.
+/// The contract includes support for meta transactions.
+contract CatalystV2 is Catalyst, OwnableUpgradeable {
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    /// @notice Initialize the new Ownable extension
+    function reinitialize() external reinitializer(2) {
+        __Ownable_init();
+    }
+
+    function _msgSender() internal view virtual override(Catalyst, ContextUpgradeable) returns (address sender) {
+        return Catalyst._msgSender();
+    }
+
+    function _msgData() internal view virtual override(Catalyst, ContextUpgradeable) returns (bytes calldata msgData) {
+        return Catalyst._msgData();
+    }
+}

--- a/packages/asset/package.json
+++ b/packages/asset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sandbox-smart-contracts/asset",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Asset and Catalyst L2 smart contracts",
   "license": "MIT",
   "main": "index.js",

--- a/packages/asset/test/Asset.test.ts
+++ b/packages/asset/test/Asset.test.ts
@@ -641,10 +641,10 @@ describe('Base Asset Contract (/packages/asset/contracts/Asset.sol)', function (
       await MockAssetContract.msgData();
     });
     it('should allow DEFAULT_ADMIN to set the trusted forwarder ', async function () {
-      const {AssetContract} = await runAssetSetup();
+      const {AssetContractAsAdmin} = await runAssetSetup();
       const randomAddress = ethers.Wallet.createRandom().address;
-      await AssetContract.setTrustedForwarder(randomAddress);
-      expect(await AssetContract.getTrustedForwarder()).to.be.equal(
+      await AssetContractAsAdmin.setTrustedForwarder(randomAddress);
+      expect(await AssetContractAsAdmin.getTrustedForwarder()).to.be.equal(
         randomAddress
       );
     });
@@ -2243,8 +2243,8 @@ describe('Base Asset Contract (/packages/asset/contracts/Asset.sol)', function (
     it('successfully upgrades to AssetV2', async function () {
       const {AssetContract} = await runAssetSetup();
       const AssetV2 = await ethers.getContractFactory('AssetV2');
-      expect(await upgrades.upgradeProxy(AssetContract.address, AssetV2)).to.not
-        .be.reverted;
+      await expect(await upgrades.upgradeProxy(AssetContract.address, AssetV2))
+        .to.not.be.reverted;
     });
     it('successfully reinitializes', async function () {
       const {AssetContract} = await runAssetSetup();
@@ -2253,7 +2253,7 @@ describe('Base Asset Contract (/packages/asset/contracts/Asset.sol)', function (
         AssetContract.address,
         AssetV2
       );
-      expect(await AsetV2Contract.reinitialize()).to.not.be.reverted;
+      await expect(await AsetV2Contract.reinitialize()).to.not.be.reverted;
     });
     it('correctly returns the contract owner', async function () {
       const {AssetContract, deployer} = await runAssetSetup();

--- a/packages/asset/test/Catalyst.test.ts
+++ b/packages/asset/test/Catalyst.test.ts
@@ -1965,8 +1965,8 @@ describe('Catalyst (/packages/asset/contracts/Catalyst.sol)', function () {
     it('successfully upgrades to CatalystV2', async function () {
       const {catalyst} = await runCatalystSetup();
       const CatalystV2 = await ethers.getContractFactory('CatalystV2');
-      expect(await upgrades.upgradeProxy(catalyst.address, CatalystV2)).to.not
-        .be.reverted;
+      await expect(await upgrades.upgradeProxy(catalyst.address, CatalystV2)).to
+        .not.be.reverted;
     });
     it('successfully reinitializes', async function () {
       const {catalyst} = await runCatalystSetup();
@@ -1975,7 +1975,7 @@ describe('Catalyst (/packages/asset/contracts/Catalyst.sol)', function () {
         catalyst.address,
         CatalystV2
       );
-      expect(await AsetV2Contract.reinitialize()).to.not.be.reverted;
+      await expect(await AsetV2Contract.reinitialize()).to.not.be.reverted;
     });
     it('correctly returns the contract owner', async function () {
       const {catalyst, deployer} = await runCatalystSetup();

--- a/packages/asset/test/Catalyst.test.ts
+++ b/packages/asset/test/Catalyst.test.ts
@@ -1961,4 +1961,56 @@ describe('Catalyst (/packages/asset/contracts/Catalyst.sol)', function () {
       });
     });
   });
+  describe('CatalystV2', function () {
+    it('successfully upgrades to CatalystV2', async function () {
+      const {catalyst} = await runCatalystSetup();
+      const CatalystV2 = await ethers.getContractFactory('CatalystV2');
+      expect(await upgrades.upgradeProxy(catalyst.address, CatalystV2)).to.not
+        .be.reverted;
+    });
+    it('successfully reinitializes', async function () {
+      const {catalyst} = await runCatalystSetup();
+      const CatalystV2 = await ethers.getContractFactory('CatalystV2');
+      const AsetV2Contract = await upgrades.upgradeProxy(
+        catalyst.address,
+        CatalystV2
+      );
+      expect(await AsetV2Contract.reinitialize()).to.not.be.reverted;
+    });
+    it('correctly returns the contract owner', async function () {
+      const {catalyst, deployer} = await runCatalystSetup();
+      const CatalystV2 = await ethers.getContractFactory('CatalystV2');
+      const AssetV2Contract = await upgrades.upgradeProxy(
+        catalyst.address,
+        CatalystV2
+      );
+      await AssetV2Contract.reinitialize();
+      expect(await AssetV2Contract.owner()).to.be.equals(deployer.address);
+    });
+    it('allows owner to transfer the ownership', async function () {
+      const {catalyst, catalystAdmin} = await runCatalystSetup();
+      const CatalystV2 = await ethers.getContractFactory('CatalystV2');
+      const AssetV2Contract = await upgrades.upgradeProxy(
+        catalyst.address,
+        CatalystV2
+      );
+      await AssetV2Contract.reinitialize();
+      await AssetV2Contract.transferOwnership(catalystAdmin.address);
+      expect(await AssetV2Contract.owner()).to.be.equals(catalystAdmin.address);
+    });
+    it('does not allow non-owner to transfer the ownership', async function () {
+      const {catalyst, catalystAdmin} = await runCatalystSetup();
+      const CatalystV2 = await ethers.getContractFactory('CatalystV2');
+      const AssetV2Contract = await upgrades.upgradeProxy(
+        catalyst.address,
+        CatalystV2
+      );
+      await AssetV2Contract.reinitialize();
+      await expect(
+        AssetV2Contract.connect(catalystAdmin).transferOwnership(
+          catalystAdmin.address
+        )
+      ).to.be.revertedWith('Ownable: caller is not the owner');
+    });
+  });
 });

--- a/packages/asset/test/fixtures/asset/assetFixture.ts
+++ b/packages/asset/test/fixtures/asset/assetFixture.ts
@@ -74,6 +74,7 @@ export function generateAssetId(
 
 export async function runAssetSetup() {
   const [
+    deployer,
     assetAdmin,
     owner,
     secondOwner,
@@ -273,6 +274,7 @@ export async function runAssetSetup() {
     AssetContractAsBurner,
     AssetContractAsAdmin,
     owner,
+    deployer,
     assetAdmin,
     minter,
     burner,

--- a/packages/deploy/.gitignore
+++ b/packages/deploy/.gitignore
@@ -14,3 +14,5 @@ generated-markups
 
 # editors
 .idea
+
+deployments/localhost

--- a/packages/deploy/deploy/300_catalyst/303_upgrade_catalyst_v2.ts
+++ b/packages/deploy/deploy/300_catalyst/303_upgrade_catalyst_v2.ts
@@ -1,0 +1,28 @@
+import {HardhatRuntimeEnvironment} from 'hardhat/types';
+import {DeployFunction} from 'hardhat-deploy/types';
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const {deployments, getNamedAccounts} = hre;
+  const {deploy} = deployments;
+  const {deployer, upgradeAdmin} = await getNamedAccounts();
+
+  // Upgrade implementation contract
+  await deploy('Catalyst', {
+    from: deployer,
+    contract: 'CatalystV2',
+    proxy: {
+      owner: upgradeAdmin,
+      proxyContract: 'OpenZeppelinTransparentProxy',
+      upgradeIndex: 1,
+      methodName: 'reinitialize',
+      viaAdminContract: {
+        name: 'DefaultProxyAdmin',
+      },
+    },
+    log: true,
+  });
+};
+export default func;
+
+func.tags = ['Catalyst', 'Catalyst_upgrade_v2', 'L2'];
+func.dependencies = ['Catalyst_deploy'];

--- a/packages/deploy/deploy/400_asset/408_upgrade_asset_v2.ts
+++ b/packages/deploy/deploy/400_asset/408_upgrade_asset_v2.ts
@@ -1,0 +1,28 @@
+import {HardhatRuntimeEnvironment} from 'hardhat/types';
+import {DeployFunction} from 'hardhat-deploy/types';
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const {deployments, getNamedAccounts} = hre;
+  const {deploy} = deployments;
+  const {deployer, upgradeAdmin} = await getNamedAccounts();
+
+  // Upgrade implementation contract
+  await deploy('Asset', {
+    from: deployer,
+    contract: 'AssetV2',
+    proxy: {
+      owner: upgradeAdmin,
+      proxyContract: 'OpenZeppelinTransparentProxy',
+      upgradeIndex: 1,
+      methodName: 'reinitialize',
+      viaAdminContract: {
+        name: 'DefaultProxyAdmin',
+      },
+    },
+    log: true,
+  });
+};
+export default func;
+
+func.tags = ['Asset', 'Asset_upgrade_v2', 'L2'];
+func.dependencies = ['Asset_deploy'];


### PR DESCRIPTION
## Description

This PR upgrades Catalyst and Asset implementation by adding OpenZeppelin's Ownable extension for each of the contracts.

Tests covering the upgrade and the new functionalities were also added

## Testing

Running `yarn void:deploy` on the branch should show how new implementation is deployed and how DefaultProxyAdmin calls `upgradeAndCall`.

To deploy on a local node run the following:

```bash
npx hardhat node --no-deploy
```
Open a new terminal window and deploy original asset
```bash
npx hardhat deploy --tags Asset_deploy --network localhost
```
Then run the upgrade script
```bash
npx hardhat deploy --tags Asset_upgrade_v2 --network localhost
```

## Upgrade
To run the upgrade we need to call the deploy script with tags `Asset_upgrade_v2` and `Catalyst_upgrade_v2`.

## Todo

- [ ] Release new asset package version to nom