### PR TITLE
feat: defender capture and deploy WIP

### DIFF
--- a/packages/deploy/.gitignore
+++ b/packages/deploy/.gitignore
@@ -12,5 +12,7 @@ artifacts
 # generated docs
 generated-markups
 
+defenderActions.json
+
 # editors
 .idea

--- a/packages/deploy/deployments/polygon/CHILD_CHAIN_MANAGER.json
+++ b/packages/deploy/deployments/polygon/CHILD_CHAIN_MANAGER.json
@@ -1,0 +1,391 @@
+{
+  "address": "0xA6FA4fB5f76172d178d61B04b0ecd319C5d1C0aa",
+  "abi": [
+    {
+      "type": "event",
+      "name": "RoleAdminChanged",
+      "inputs": [
+        {
+          "type": "bytes32",
+          "name": "role",
+          "internalType": "bytes32",
+          "indexed": true
+        },
+        {
+          "type": "bytes32",
+          "name": "previousAdminRole",
+          "internalType": "bytes32",
+          "indexed": true
+        },
+        {
+          "type": "bytes32",
+          "name": "newAdminRole",
+          "internalType": "bytes32",
+          "indexed": true
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "RoleGranted",
+      "inputs": [
+        {
+          "type": "bytes32",
+          "name": "role",
+          "internalType": "bytes32",
+          "indexed": true
+        },
+        {
+          "type": "address",
+          "name": "account",
+          "internalType": "address",
+          "indexed": true
+        },
+        {
+          "type": "address",
+          "name": "sender",
+          "internalType": "address",
+          "indexed": true
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "RoleRevoked",
+      "inputs": [
+        {
+          "type": "bytes32",
+          "name": "role",
+          "internalType": "bytes32",
+          "indexed": true
+        },
+        {
+          "type": "address",
+          "name": "account",
+          "internalType": "address",
+          "indexed": true
+        },
+        {
+          "type": "address",
+          "name": "sender",
+          "internalType": "address",
+          "indexed": true
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "TokenMapped",
+      "inputs": [
+        {
+          "type": "address",
+          "name": "rootToken",
+          "internalType": "address",
+          "indexed": true
+        },
+        {
+          "type": "address",
+          "name": "childToken",
+          "internalType": "address",
+          "indexed": true
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "function",
+      "stateMutability": "view",
+      "outputs": [
+        {
+          "type": "bytes32",
+          "name": "",
+          "internalType": "bytes32"
+        }
+      ],
+      "name": "DEFAULT_ADMIN_ROLE",
+      "inputs": []
+    },
+    {
+      "type": "function",
+      "stateMutability": "view",
+      "outputs": [
+        {
+          "type": "bytes32",
+          "name": "",
+          "internalType": "bytes32"
+        }
+      ],
+      "name": "DEPOSIT",
+      "inputs": []
+    },
+    {
+      "type": "function",
+      "stateMutability": "view",
+      "outputs": [
+        {
+          "type": "bytes32",
+          "name": "",
+          "internalType": "bytes32"
+        }
+      ],
+      "name": "MAPPER_ROLE",
+      "inputs": []
+    },
+    {
+      "type": "function",
+      "stateMutability": "view",
+      "outputs": [
+        {
+          "type": "bytes32",
+          "name": "",
+          "internalType": "bytes32"
+        }
+      ],
+      "name": "MAP_TOKEN",
+      "inputs": []
+    },
+    {
+      "type": "function",
+      "stateMutability": "view",
+      "outputs": [
+        {
+          "type": "bytes32",
+          "name": "",
+          "internalType": "bytes32"
+        }
+      ],
+      "name": "STATE_SYNCER_ROLE",
+      "inputs": []
+    },
+    {
+      "type": "function",
+      "stateMutability": "view",
+      "outputs": [
+        {
+          "type": "address",
+          "name": "",
+          "internalType": "address"
+        }
+      ],
+      "name": "childToRootToken",
+      "inputs": [
+        {
+          "type": "address",
+          "name": "",
+          "internalType": "address"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "stateMutability": "view",
+      "outputs": [
+        {
+          "type": "bytes32",
+          "name": "",
+          "internalType": "bytes32"
+        }
+      ],
+      "name": "getRoleAdmin",
+      "inputs": [
+        {
+          "type": "bytes32",
+          "name": "role",
+          "internalType": "bytes32"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "stateMutability": "view",
+      "outputs": [
+        {
+          "type": "address",
+          "name": "",
+          "internalType": "address"
+        }
+      ],
+      "name": "getRoleMember",
+      "inputs": [
+        {
+          "type": "bytes32",
+          "name": "role",
+          "internalType": "bytes32"
+        },
+        {
+          "type": "uint256",
+          "name": "index",
+          "internalType": "uint256"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "stateMutability": "view",
+      "outputs": [
+        {
+          "type": "uint256",
+          "name": "",
+          "internalType": "uint256"
+        }
+      ],
+      "name": "getRoleMemberCount",
+      "inputs": [
+        {
+          "type": "bytes32",
+          "name": "role",
+          "internalType": "bytes32"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "stateMutability": "nonpayable",
+      "outputs": [],
+      "name": "grantRole",
+      "inputs": [
+        {
+          "type": "bytes32",
+          "name": "role",
+          "internalType": "bytes32"
+        },
+        {
+          "type": "address",
+          "name": "account",
+          "internalType": "address"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "stateMutability": "view",
+      "outputs": [
+        {
+          "type": "bool",
+          "name": "",
+          "internalType": "bool"
+        }
+      ],
+      "name": "hasRole",
+      "inputs": [
+        {
+          "type": "bytes32",
+          "name": "role",
+          "internalType": "bytes32"
+        },
+        {
+          "type": "address",
+          "name": "account",
+          "internalType": "address"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "stateMutability": "nonpayable",
+      "outputs": [],
+      "name": "initialize",
+      "inputs": [
+        {
+          "type": "address",
+          "name": "_owner",
+          "internalType": "address"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "stateMutability": "nonpayable",
+      "outputs": [],
+      "name": "mapToken",
+      "inputs": [
+        {
+          "type": "address",
+          "name": "rootToken",
+          "internalType": "address"
+        },
+        {
+          "type": "address",
+          "name": "childToken",
+          "internalType": "address"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "stateMutability": "nonpayable",
+      "outputs": [],
+      "name": "onStateReceive",
+      "inputs": [
+        {
+          "type": "uint256",
+          "name": "",
+          "internalType": "uint256"
+        },
+        {
+          "type": "bytes",
+          "name": "data",
+          "internalType": "bytes"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "stateMutability": "nonpayable",
+      "outputs": [],
+      "name": "renounceRole",
+      "inputs": [
+        {
+          "type": "bytes32",
+          "name": "role",
+          "internalType": "bytes32"
+        },
+        {
+          "type": "address",
+          "name": "account",
+          "internalType": "address"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "stateMutability": "nonpayable",
+      "outputs": [],
+      "name": "revokeRole",
+      "inputs": [
+        {
+          "type": "bytes32",
+          "name": "role",
+          "internalType": "bytes32"
+        },
+        {
+          "type": "address",
+          "name": "account",
+          "internalType": "address"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "stateMutability": "view",
+      "outputs": [
+        {
+          "type": "address",
+          "name": "",
+          "internalType": "address"
+        }
+      ],
+      "name": "rootToChildToken",
+      "inputs": [
+        {
+          "type": "address",
+          "name": "",
+          "internalType": "address"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/deploy/hardhat.config.ts
+++ b/packages/deploy/hardhat.config.ts
@@ -2,13 +2,14 @@ import 'dotenv/config';
 import '@nomicfoundation/hardhat-chai-matchers';
 import '@nomicfoundation/hardhat-network-helpers';
 import '@nomiclabs/hardhat-ethers';
-import 'hardhat-deploy';
 import {
   addForkingSupport,
   addNodeAndMnemonic,
   skipDeploymentsOnLiveNetworks,
 } from './utils/hardhatConfig';
 import './tasks/importedPackages';
+import './tasks/defenderCapture';
+import './tasks/defenderDeploy';
 
 // Package name : solidity source code path
 const importedPackages = {

--- a/packages/deploy/package.json
+++ b/packages/deploy/package.json
@@ -47,6 +47,8 @@
         "@nomicfoundation/hardhat-chai-matchers": "1",
         "@nomicfoundation/hardhat-network-helpers": "^1.0.8",
         "@nomiclabs/hardhat-ethers": "^2.2.3",
+        "@openzeppelin/defender-sdk-deploy-client": "^1.5.0",
+        "@openzeppelin/defender-sdk-proposal-client": "^1.6.0",
         "@typechain/ethers-v5": "^11.0.0",
         "@typechain/hardhat": "^8.0.0",
         "@types/chai": "^4.3.5",

--- a/packages/deploy/tasks/defenderCapture.ts
+++ b/packages/deploy/tasks/defenderCapture.ts
@@ -1,0 +1,167 @@
+/*
+  This task extends the hardhat-deploy deploy target in two aspects:
+    1. It forbid the use of catchUnknownSigner + execute and propose the use of
+    executeAction instead. This method is similar but takes a description that
+    is used to create defender actions to be executed by a multisig.
+    2. It catches the calls to deploy and give the option of creating defender
+    deploy tasks instead.
+ */
+import {extendEnvironment, task, types} from 'hardhat/config';
+import 'dotenv/config';
+import 'hardhat-deploy';
+import {HardhatPluginError, lazyFunction} from 'hardhat/plugins';
+import {
+  DeploymentsExtension,
+  DeployOptions,
+  DeployResult,
+  Receipt,
+  TxOptions,
+} from 'hardhat-deploy/types';
+import {TASK_DEPLOY} from 'hardhat-deploy';
+import * as fs from 'fs';
+import {HardhatRuntimeEnvironment} from 'hardhat/types';
+import {
+  CollectedDefenderActionsType,
+  CollectedDefenderDeploysType,
+} from '../utils/defenderCommon';
+import {UnknownSignerError} from 'hardhat-deploy/dist/src/errors';
+import {InvalidInputError} from 'hardhat/internal/core/providers/errors';
+
+declare module 'hardhat/types/runtime' {
+  interface HardhatRuntimeEnvironment {
+    _defender:
+      | undefined
+      | {
+          captureAll: boolean;
+          collectedActions: CollectedDefenderActionsType[];
+          collectedDeploys: CollectedDefenderDeploysType[];
+        };
+  }
+}
+
+function deployHook(
+  hre: HardhatRuntimeEnvironment,
+  orig: DeploymentsExtension
+) {
+  return async (
+    name: string,
+    options: DeployOptions
+  ): Promise<DeployResult> => {
+    const result = await orig.deploy(name, options);
+    if (!hre._defender) {
+      return result;
+    }
+    if (result.newlyDeployed) {
+      hre._defender.collectedDeploys.push({name, options});
+    }
+    return result;
+  };
+}
+
+function executeActionHook(
+  hre: HardhatRuntimeEnvironment,
+  orig: DeploymentsExtension
+) {
+  return async (
+    name: string,
+    options: TxOptions,
+    methodName: string,
+    ...args: unknown[]
+  ): Promise<Receipt> => {
+    if (!hre._defender) {
+      return await orig.execute(name, options, methodName, ...args);
+    }
+    if (hre._defender.captureAll) {
+      hre._defender.collectedActions.push({
+        name,
+        options,
+        methodName,
+        args,
+      });
+    }
+    try {
+      return await orig.execute(name, options, methodName, ...args);
+    } catch (e) {
+      if (
+        !hre._defender.captureAll &&
+        (e instanceof UnknownSignerError || e instanceof InvalidInputError)
+      ) {
+        hre._defender.collectedActions.push({
+          name,
+          options,
+          methodName,
+          args,
+        });
+      }
+      if (!(e instanceof InvalidInputError)) {
+        throw e;
+      }
+      // Trick to keep going
+      return {
+        blockHash: '',
+        blockNumber: 0,
+        cumulativeGasUsed: 0,
+        from: '',
+        gasUsed: 0,
+        transactionHash: '',
+        transactionIndex: 0,
+      };
+    }
+  };
+}
+
+extendEnvironment((hre) => {
+  const origClone: DeploymentsExtension = Object.assign({}, hre.deployments);
+  hre.deployments.deploy = lazyFunction(() => deployHook(hre, origClone));
+  hre.deployments.execute = lazyFunction(() =>
+    executeActionHook(hre, origClone)
+  );
+});
+task(TASK_DEPLOY, 'use defender admin to propose transactions')
+  .addFlag('defender', 'collection of defender actions')
+  .addFlag('captureAll', 'force the collection of all the defender actions')
+  .addOptionalParam(
+    'actionsFilename',
+    'file name to save the actions',
+    'defenderActions.json',
+    types.string
+  )
+  .setAction(
+    async (
+      args: {
+        defender: boolean;
+        actionsFilename: string | undefined;
+        captureAll: boolean;
+      },
+      hre,
+      runSuper
+    ) => {
+      if (!args.defender) {
+        return await runSuper(args);
+      }
+      if (!process.env.HARDHAT_FORK) {
+        throw new HardhatPluginError('must use a fork to capture');
+      }
+      hre._defender = {
+        captureAll: args.captureAll,
+        collectedActions: [],
+        collectedDeploys: [],
+      };
+      const ret = await runSuper({...args, write: false});
+      const fileName = args.actionsFilename as string;
+      console.log(`saving to ${fileName}`);
+      fs.writeFileSync(
+        fileName,
+        JSON.stringify(
+          {
+            network: process.env.HARDHAT_FORK,
+            actions: hre._defender.collectedActions,
+            deploys: hre._defender.collectedDeploys,
+          },
+          null,
+          4
+        )
+      );
+      return ret;
+    }
+  );

--- a/packages/deploy/tasks/defenderDeploy.ts
+++ b/packages/deploy/tasks/defenderDeploy.ts
@@ -1,0 +1,223 @@
+/*
+  This task extends the hardhat-deploy deploy target in two aspects:
+    1. It forbid the use of catchUnknownSigner + execute and propose the use of
+    executeAction instead. This method is similar but takes a description that
+    is used to create defender actions to be executed by a multisig.
+    2. It catches the calls to deploy and give the option of creating defender
+    deploy tasks instead.
+ */
+import {task, types} from 'hardhat/config';
+import 'dotenv/config';
+import 'hardhat-deploy';
+import {HardhatPluginError} from 'hardhat/plugins';
+import * as fs from 'fs';
+import {HardhatRuntimeEnvironment} from 'hardhat/types';
+import {DeployClient} from '@openzeppelin/defender-sdk-deploy-client';
+import {
+  CollectedDefenderActionsType,
+  CollectedDefenderDeploysType,
+  DefenderJSONFile,
+} from '../utils/defenderCommon';
+import {prompt} from 'enquirer';
+import {ProposalClient} from '@openzeppelin/defender-sdk-proposal-client';
+
+type DeployDta =
+  | {
+      type: 'action';
+      data: CollectedDefenderActionsType;
+    }
+  | {
+      type: 'deploy';
+      data: CollectedDefenderDeploysType;
+    };
+
+async function select(choices: {[k: string]: DeployDta}): Promise<DeployDta[]> {
+  const ans = await prompt<{answer: string[]}>({
+    name: 'answer',
+    type: 'multiselect',
+    choices: Object.keys(choices).map((x) => ({name: x, value: choices[x]})),
+    message: 'Select deploys',
+  });
+  return Object.keys(choices)
+    .filter((x) => ans.answer.includes(x))
+    .map((x) => choices[x]);
+}
+
+function getFQN(d: CollectedDefenderDeploysType): string {
+  return d.options.contract && typeof d.options.contract === 'string'
+    ? (d.options.contract as string)
+    : d.name;
+}
+
+async function defenderAction(
+  hre: HardhatRuntimeEnvironment,
+  client: ProposalClient,
+  deploy: CollectedDefenderActionsType
+) {
+  // TODO: Filter the already added ones ?
+  // const l = await client.list({includeArchived: false});
+  const d = await hre.deployments.get(deploy.name);
+  // 'EOA' | 'Safe' | 'Gnosis Multisig' | 'Relayer';
+  await client.create({
+    proposal: {
+      contract: {
+        network: hre.network.name,
+        address: d.address,
+        abi: JSON.stringify(d.abi),
+      },
+      title: `action-${deploy.name}.${deploy.methodName}`,
+      description: `execute ${deploy.methodName} on ${deploy.name}. network ${hre.network.name}`,
+      type: 'custom',
+      functionInterface: d.abi.find(
+        (a) =>
+          a.name === deploy.methodName && a.inputs.length === deploy.args.length
+      ),
+      functionInputs: deploy.args.map((a) => {
+        const ret = a as string;
+        if (a === 'true') return true;
+        if (a === 'false') return false;
+        return ret;
+      }),
+      via: deploy.options.from,
+      // TODO: ?
+      //  'EOA' | 'Safe' | 'Gnosis Multisig' | 'Relayer'
+      // viaType: deploy.options.viaType || viaTypes.GnosisSafe,
+    },
+  });
+}
+
+async function defenderDeploy(
+  hre: HardhatRuntimeEnvironment,
+  client: DeployClient,
+  deploy: CollectedDefenderDeploysType
+) {
+  const fqn = getFQN(deploy);
+  const buildInfo = await hre.artifacts.getBuildInfo(fqn);
+  const artifact = await hre.artifacts.readArtifact(fqn);
+  // constructorInputs - The inputs to your contract constructor,
+  // value - ETH to be sent with the deployment.
+  // salt - deployments are done using the CREATE2 opcode, you can provide a salt or we can generate one for you if none is supplied.
+  // licenseType - This will be displayed on Etherscan e.g MIT.
+  // libraries - If you contract uses any external libraries they will need to be added here in the format { [LibraryName]: LibraryAddress }.
+  // relayerId - This property will override the default relayer assigned to the approval process for deployments. You may define this property if you wish to use a different relayer than the one assigned to the approval process in the deploy environment.
+
+  // TODO: Deal with upgradable contracts
+  console.log('deploy', fqn, 'with', deploy.options);
+  await client.deployContract({
+    contractName: artifact.contractName,
+    contractPath: artifact.sourceName,
+    verifySourceCode: false,
+    network: hre.network.name,
+    artifactPayload: JSON.stringify(buildInfo),
+    constructorInputs: deploy.options.args,
+    value: deploy.options.value && deploy.options.value.toString(),
+  });
+  //
+  // await client.deploy.upgradeContract({
+  //   upgradeParams: {
+  //     proxyAddress: '0xABC1234...',
+  //     proxyAdminAddress: '0xDEF1234...',
+  //     newImplementationABI: JSON.stringify(boxABIFile),
+  //     newImplementationAddress: '0xABCDEF1....',
+  //     network: 'mumbai',
+  //   },
+  // });
+}
+
+task('defender', 'use defender admin to propose transactions')
+  .addOptionalParam(
+    'actionsFilename',
+    'file name to save the actions',
+    'defenderActions.json',
+    types.string
+  )
+  .addFlag('dryrun', 'dry run')
+  .addFlag('yes', "don't ask on each action")
+  .setAction(
+    async (
+      args: {
+        defender: boolean;
+        actionsFilename: string | undefined;
+        dryrun: boolean;
+        yes: boolean;
+      },
+      hre
+    ) => {
+      if (!process.env.DEFENDER_KEY || !process.env.DEFENDER_SECRET) {
+        throw new HardhatPluginError(
+          'you must configure DEFENDER_SECRET and DEFENDER_KEY in .env'
+        );
+      }
+
+      const fileName = args.actionsFilename as string;
+      console.log(`reading ${fileName}`);
+      const collectedData: DefenderJSONFile = JSON.parse(
+        fs.readFileSync(fileName, 'utf-8')
+      );
+      const networkName = hre.network.name;
+      if (networkName !== collectedData.network) {
+        throw new HardhatPluginError(
+          `network miss match ${networkName} != ${collectedData.network}`
+        );
+      }
+      const proposalClient = new ProposalClient({
+        apiKey: process.env.DEFENDER_KEY,
+        apiSecret: process.env.DEFENDER_SECRET,
+      });
+      const deployClient = new DeployClient({
+        apiKey: process.env.DEFENDER_KEY,
+        apiSecret: process.env.DEFENDER_SECRET,
+      });
+      // if (!args.dryrun) {
+      //   const approval = await deployClient.getDeployApprovalProcess(
+      //     networkName
+      //   );
+      //   console.log(`Approval process for ${networkName}`, approval);
+      //   const upgradeApproval = await deployClient.getUpgradeApprovalProcess(
+      //     networkName
+      //   );
+      //   console.log(
+      //     `Upgrade approval process for ${networkName}`,
+      //     upgradeApproval
+      //   );
+      // }
+      const cList = await deployClient.listDeployments();
+      const contracts: Set<string> = new Set();
+      cList.forEach((x) =>
+        contracts.add(x.contractPath + ':' + x.contractName)
+      );
+      const choices: {[k: string]: DeployDta} = collectedData.deploys
+        .filter((x) => !contracts.has(getFQN(x)))
+        .reduce(
+          (acc, val) => ({
+            ...acc,
+            ['deploy-' + val.name]: {type: 'deploy', data: val},
+          }),
+          {}
+        );
+      collectedData.actions.forEach(
+        (x) =>
+          (choices[`action-${x.name}.${x.methodName}`] = {
+            type: 'action',
+            data: x,
+          })
+      );
+
+      const toDeploy: DeployDta[] = args.yes
+        ? Object.values(choices)
+        : await select(choices);
+      for (const d of toDeploy) {
+        if (d.type === 'deploy') {
+          console.log(d.type, d.data.name, getFQN(d.data));
+          if (!args.dryrun) {
+            await defenderDeploy(hre, deployClient, d.data);
+          }
+        } else {
+          console.log(d.type, d.data);
+          if (!args.dryrun) {
+            await defenderAction(hre, proposalClient, d.data);
+          }
+        }
+      }
+    }
+  );

--- a/packages/deploy/tasks/importedPackages.ts
+++ b/packages/deploy/tasks/importedPackages.ts
@@ -21,7 +21,7 @@ declare module 'hardhat/types/runtime' {
 }
 declare module 'hardhat/types/config' {
   interface HardhatUserConfig {
-    importedPackages: {[name: string]: string};
+    importedPackages: {[name: string]: string | string[]};
   }
 }
 

--- a/packages/deploy/utils/defenderCommon.ts
+++ b/packages/deploy/utils/defenderCommon.ts
@@ -1,0 +1,17 @@
+import {DeployOptions, TxOptions} from 'hardhat-deploy/types';
+
+export type CollectedDefenderActionsType = {
+  name: string;
+  options: TxOptions;
+  methodName: string;
+  args: unknown[];
+};
+export type CollectedDefenderDeploysType = {
+  name: string;
+  options: DeployOptions;
+};
+export type DefenderJSONFile = {
+  network: string;
+  actions: CollectedDefenderActionsType[];
+  deploys: CollectedDefenderDeploysType[];
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1916,7 +1916,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openzeppelin/defender-sdk-deploy-client@npm:^1.2.0":
+"@openzeppelin/defender-sdk-base-client@npm:^1.6.0":
+  version: 1.6.0
+  resolution: "@openzeppelin/defender-sdk-base-client@npm:1.6.0"
+  dependencies:
+    amazon-cognito-identity-js: ^6.3.6
+    async-retry: ^1.3.3
+  checksum: 4516d16d18d42f6a43a856c9a8b5569ed17482e2714d80aaca9581ba7345deec4e654844933877e2ff0addad2594e127c2ffeac0d092bbbebb0b2cc7e984fce1
+  languageName: node
+  linkType: hard
+
+"@openzeppelin/defender-sdk-deploy-client@npm:^1.2.0, @openzeppelin/defender-sdk-deploy-client@npm:^1.5.0":
   version: 1.5.0
   resolution: "@openzeppelin/defender-sdk-deploy-client@npm:1.5.0"
   dependencies:
@@ -1925,6 +1935,18 @@ __metadata:
     axios: ^1.4.0
     lodash: ^4.17.21
   checksum: fcb3564e7d1d367507dc900af6f55f7775089650e0a3e7e161163e91557c60192e924c23ede39f9a67ee5c0dc35824c7607a91fa1765ab116194455d8e42c00e
+  languageName: node
+  linkType: hard
+
+"@openzeppelin/defender-sdk-proposal-client@npm:^1.6.0":
+  version: 1.6.0
+  resolution: "@openzeppelin/defender-sdk-proposal-client@npm:1.6.0"
+  dependencies:
+    "@openzeppelin/defender-sdk-base-client": ^1.6.0
+    axios: ^1.4.0
+    ethers: ^5.7.2
+    lodash: ^4.17.21
+  checksum: 769b2f6a1a8340f686c5088048ece2a7d4d8f1f6eaadc70e656c3078e53c8a191e071bfde953ac14a1442af4f828d1756ee404f6dcba3eea399d32bed51e1951
   languageName: node
   linkType: hard
 
@@ -2339,6 +2361,8 @@ __metadata:
     "@nomicfoundation/hardhat-chai-matchers": 1
     "@nomicfoundation/hardhat-network-helpers": ^1.0.8
     "@nomiclabs/hardhat-ethers": ^2.2.3
+    "@openzeppelin/defender-sdk-deploy-client": ^1.5.0
+    "@openzeppelin/defender-sdk-proposal-client": ^1.6.0
     "@sandbox-smart-contracts/asset": "*"
     "@sandbox-smart-contracts/core": "*"
     "@sandbox-smart-contracts/dependency-operator-filter": "*"


### PR DESCRIPTION
## Description
Hardhat task to:
- capture deployments and actions of `hardhat-deploy` to a file so we can send them to OZ defender instead: ` yarn fork:deploy mumbai --defender --capture-all`
- read the file and send the captured items to defender, for example: `yarn hardhat defender --network mumbai`

