### PR TITLE
[Upgrade] Add owner getter and setter to Asset and Catalyst

### DIFF
--- a/packages/asset/contracts/Asset.sol
+++ b/packages/asset/contracts/Asset.sol
@@ -56,6 +56,7 @@ contract Asset is
 
     // mapping of ipfs metadata token hash to token id
     mapping(string => uint256) public hashUsed;
+    address private _owner;
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -383,8 +384,6 @@ contract Asset is
     function symbol() external pure returns (string memory _symbol) {
         return "ASSET";
     }
-
-    address private _owner;
 
     /// @notice Returns the owner of the contract
     /// @return address of the owner

--- a/packages/asset/contracts/Asset.sol
+++ b/packages/asset/contracts/Asset.sol
@@ -384,5 +384,21 @@ contract Asset is
         return "ASSET";
     }
 
-    uint256[49] private __gap;
+    address private _owner;
+
+    /// @notice Returns the owner of the contract
+    /// @return address of the owner
+    function owner() external view returns (address) {
+        return _owner;
+    }
+
+    /// @notice Sets the owner of the contract
+    /// @param newOwner address of the new owner
+    function transferOwnership(address newOwner) external {
+        require(hasRole(DEFAULT_ADMIN_ROLE, _msgSender()), "Asset: Unauthorized");
+        _owner = newOwner;
+        emit OwnershipTransferred(_owner, newOwner);
+    }
+
+    uint256[48] private __gap;
 }

--- a/packages/asset/contracts/Catalyst.sol
+++ b/packages/asset/contracts/Catalyst.sol
@@ -49,6 +49,7 @@ contract Catalyst is
     bytes32 public constant BURNER_ROLE = keccak256("BURNER_ROLE");
 
     uint256 public highestTierIndex;
+    address private _owner;
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -323,8 +324,6 @@ contract Catalyst is
     function symbol() external pure returns (string memory _symbol) {
         return "CATALYST";
     }
-
-    address private _owner;
 
     /// @notice Returns the owner of the contract
     /// @return address of the owner

--- a/packages/asset/contracts/Catalyst.sol
+++ b/packages/asset/contracts/Catalyst.sol
@@ -334,7 +334,7 @@ contract Catalyst is
     /// @notice Sets the owner of the contract
     /// @param newOwner address of the new owner
     function transferOwnership(address newOwner) external {
-        require(hasRole(DEFAULT_ADMIN_ROLE, _msgSender()), "Asset: Unauthorized");
+        require(hasRole(DEFAULT_ADMIN_ROLE, _msgSender()), "Catalyst: Unauthorized");
         _owner = newOwner;
         emit OwnershipTransferred(_owner, newOwner);
     }

--- a/packages/asset/contracts/Catalyst.sol
+++ b/packages/asset/contracts/Catalyst.sol
@@ -324,5 +324,21 @@ contract Catalyst is
         return "CATALYST";
     }
 
-    uint256[49] private __gap;
+    address private _owner;
+
+    /// @notice Returns the owner of the contract
+    /// @return address of the owner
+    function owner() external view returns (address) {
+        return _owner;
+    }
+
+    /// @notice Sets the owner of the contract
+    /// @param newOwner address of the new owner
+    function transferOwnership(address newOwner) external {
+        require(hasRole(DEFAULT_ADMIN_ROLE, _msgSender()), "Asset: Unauthorized");
+        _owner = newOwner;
+        emit OwnershipTransferred(_owner, newOwner);
+    }
+
+    uint256[48] private __gap;
 }

--- a/packages/asset/contracts/interfaces/IAsset.sol
+++ b/packages/asset/contracts/interfaces/IAsset.sol
@@ -18,6 +18,7 @@ interface IAsset {
     }
 
     event TrustedForwarderChanged(address indexed newTrustedForwarderAddress);
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
     /// @notice Mint new tokens
     /// @dev Only callable by the minter role

--- a/packages/asset/contracts/interfaces/ICatalyst.sol
+++ b/packages/asset/contracts/interfaces/ICatalyst.sol
@@ -9,6 +9,7 @@ interface ICatalyst {
     event DefaultRoyaltyChanged(address indexed newDefaultRoyaltyRecipient, uint256 newDefaultRoyaltyAmount);
     event BaseURISet(string baseURI);
     event OperatorRegistrySet(address indexed registry);
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
     /// @notice Mints a new token, limited to MINTER_ROLE only
     /// @param to The address that will own the minted token

--- a/packages/asset/test/Asset.test.ts
+++ b/packages/asset/test/Asset.test.ts
@@ -23,6 +23,34 @@ describe('Base Asset Contract (/packages/asset/contracts/Asset.sol)', function (
       expect(await AssetContract.symbol()).to.be.equal('ASSET');
     });
   });
+  describe('Owner', function () {
+    it('should not have the owner set when initially deployed', async function () {
+      const {AssetContract} = await runAssetSetup();
+      expect(await AssetContract.owner()).to.be.equal(
+        ethers.constants.AddressZero
+      );
+    });
+    it('allows DEFAULT_ADMIN_ROLE to transfer the ownership', async function () {
+      const {AssetContract, assetAdmin} = await runAssetSetup();
+      await AssetContract.connect(assetAdmin).transferOwnership(
+        assetAdmin.address
+      );
+      expect(await AssetContract.owner()).to.be.equals(assetAdmin.address);
+    });
+    it('does not allow non-DEFAULT_ADMIN_ROLE account to transfer the ownership', async function () {
+      const {AssetContract, deployer} = await runAssetSetup();
+      await expect(
+        AssetContract.connect(deployer).transferOwnership(deployer.address)
+      ).to.be.revertedWith('Asset: Unauthorized');
+    });
+    it('emits OwnershipTransferred event when DEFAULT_ADMIN_ROLE transfers the ownership', async function () {
+      const {AssetContract, assetAdmin} = await runAssetSetup();
+      const tx = await AssetContract.connect(assetAdmin).transferOwnership(
+        assetAdmin.address
+      );
+      await expect(tx).to.emit(AssetContract, 'OwnershipTransferred');
+    });
+  });
   describe('Access Control', function () {
     it('should have MINTER_ROLE defined', async function () {
       const {AssetContract} = await runAssetSetup();

--- a/packages/asset/test/Catalyst.test.ts
+++ b/packages/asset/test/Catalyst.test.ts
@@ -259,6 +259,32 @@ describe('Catalyst (/packages/asset/contracts/Catalyst.sol)', function () {
       ).to.revertedWith('Catalyst: CID cant be empty');
     });
   });
+  describe('Owner', function () {
+    it('should not have the owner set when initially deployed', async function () {
+      const {catalyst} = await runCatalystSetup();
+      expect(await catalyst.owner()).to.be.equal(ethers.constants.AddressZero);
+    });
+    it('allows DEFAULT_ADMIN_ROLE to transfer the ownership', async function () {
+      const {catalyst, catalystAdmin} = await runCatalystSetup();
+      await catalyst
+        .connect(catalystAdmin)
+        .transferOwnership(catalystAdmin.address);
+      expect(await catalyst.owner()).to.be.equals(catalystAdmin.address);
+    });
+    it('does not allow non-DEFAULT_ADMIN_ROLE account to transfer the ownership', async function () {
+      const {catalyst, deployer} = await runCatalystSetup();
+      await expect(
+        catalyst.connect(deployer).transferOwnership(deployer.address)
+      ).to.be.revertedWith('Asset: Unauthorized');
+    });
+    it('emits OwnershipTransferred event when DEFAULT_ADMIN_ROLE transfers the ownership', async function () {
+      const {catalyst, catalystAdmin} = await runCatalystSetup();
+      const tx = await catalyst
+        .connect(catalystAdmin)
+        .transferOwnership(catalystAdmin.address);
+      await expect(tx).to.emit(catalyst, 'OwnershipTransferred');
+    });
+  });
   describe('Admin Role', function () {
     it('Admin can set minter', async function () {
       const {catalystAsAdmin, user1, minterRole} = await runCatalystSetup();

--- a/packages/asset/test/Catalyst.test.ts
+++ b/packages/asset/test/Catalyst.test.ts
@@ -275,7 +275,7 @@ describe('Catalyst (/packages/asset/contracts/Catalyst.sol)', function () {
       const {catalyst, deployer} = await runCatalystSetup();
       await expect(
         catalyst.connect(deployer).transferOwnership(deployer.address)
-      ).to.be.revertedWith('Asset: Unauthorized');
+      ).to.be.revertedWith('Catalyst: Unauthorized');
     });
     it('emits OwnershipTransferred event when DEFAULT_ADMIN_ROLE transfers the ownership', async function () {
       const {catalyst, catalystAdmin} = await runCatalystSetup();

--- a/packages/asset/test/fixtures/asset/assetFixture.ts
+++ b/packages/asset/test/fixtures/asset/assetFixture.ts
@@ -74,6 +74,7 @@ export function generateAssetId(
 
 export async function runAssetSetup() {
   const [
+    deployer,
     assetAdmin,
     owner,
     secondOwner,
@@ -272,6 +273,7 @@ export async function runAssetSetup() {
     AssetContractAsMinter,
     AssetContractAsBurner,
     AssetContractAsAdmin,
+    deployer,
     owner,
     assetAdmin,
     minter,

--- a/packages/deploy/.gitignore
+++ b/packages/deploy/.gitignore
@@ -14,3 +14,4 @@ generated-markups
 
 # editors
 .idea
+deployments/localhost

--- a/packages/deploy/deploy/300_catalyst/301_deploy_catalyst.ts
+++ b/packages/deploy/deploy/300_catalyst/301_deploy_catalyst.ts
@@ -31,7 +31,8 @@ const func: DeployFunction = async function (
   await deploy('Catalyst', {
     from: deployer,
     log: true,
-    contract: '@sandbox-smart-contracts/asset/contracts/Catalyst.sol:Catalyst',
+    contract:
+      '@sandbox-smart-contracts/asset-1.0.3/contracts/Catalyst.sol:Catalyst',
     proxy: {
       owner: upgradeAdmin,
       proxyContract: 'OpenZeppelinTransparentProxy',

--- a/packages/deploy/deploy/300_catalyst/303_catalyst_upgrade-v2.ts
+++ b/packages/deploy/deploy/300_catalyst/303_catalyst_upgrade-v2.ts
@@ -1,0 +1,25 @@
+import {DeployFunction} from 'hardhat-deploy/types';
+import {HardhatRuntimeEnvironment} from 'hardhat/types';
+
+const func: DeployFunction = async function (
+  hre: HardhatRuntimeEnvironment
+): Promise<void> {
+  const {deployments, getNamedAccounts} = hre;
+  const {deploy} = deployments;
+
+  const {deployer, upgradeAdmin} = await getNamedAccounts();
+
+  await deploy('Catalyst', {
+    from: deployer,
+    log: true,
+    contract: '@sandbox-smart-contracts/asset/contracts/Catalyst.sol:Catalyst',
+    proxy: {
+      owner: upgradeAdmin,
+      proxyContract: 'OpenZeppelinTransparentProxy',
+      upgradeIndex: 1,
+    },
+  });
+};
+export default func;
+func.tags = ['Catalyst_upgrade'];
+func.dependencies = ['Catalyst_deploy', 'Catalyst_setup'];

--- a/packages/deploy/deploy/300_catalyst/303_catalyst_upgrade-v2.ts
+++ b/packages/deploy/deploy/300_catalyst/303_catalyst_upgrade-v2.ts
@@ -4,10 +4,9 @@ import {HardhatRuntimeEnvironment} from 'hardhat/types';
 const func: DeployFunction = async function (
   hre: HardhatRuntimeEnvironment
 ): Promise<void> {
-  const {deployments, getNamedAccounts} = hre;
-  const {deploy} = deployments;
-
-  const {deployer, upgradeAdmin} = await getNamedAccounts();
+  const {deployments, getNamedAccounts, ethers} = hre;
+  const {execute, read, catchUnknownSigner, deploy} = deployments;
+  const {deployer, upgradeAdmin, catalystAdmin} = await getNamedAccounts();
 
   await deploy('Catalyst', {
     from: deployer,
@@ -19,6 +18,17 @@ const func: DeployFunction = async function (
       upgradeIndex: 1,
     },
   });
+
+  if ((await read('Catalyst', 'owner')) === ethers.constants.AddressZero) {
+    await catchUnknownSigner(
+      execute(
+        'Catalyst',
+        {from: catalystAdmin, log: true},
+        'transferOwnership',
+        catalystAdmin
+      )
+    );
+  }
 };
 export default func;
 func.tags = ['Catalyst_upgrade'];

--- a/packages/deploy/deploy/400_asset/402_deploy_asset.ts
+++ b/packages/deploy/deploy/400_asset/402_deploy_asset.ts
@@ -14,7 +14,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   await deploy('Asset', {
     from: deployer,
-    contract: '@sandbox-smart-contracts/asset/contracts/Asset.sol:Asset',
+    contract: '@sandbox-smart-contracts/asset-1.0.3/contracts/Asset.sol:Asset',
     proxy: {
       owner: upgradeAdmin,
       proxyContract: 'OpenZeppelinTransparentProxy',

--- a/packages/deploy/deploy/400_asset/408_asset_upgrade-v2.ts
+++ b/packages/deploy/deploy/400_asset/408_asset_upgrade-v2.ts
@@ -2,9 +2,9 @@ import {HardhatRuntimeEnvironment} from 'hardhat/types';
 import {DeployFunction} from 'hardhat-deploy/types';
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  const {deployments, getNamedAccounts} = hre;
-  const {deploy} = deployments;
-  const {deployer, upgradeAdmin} = await getNamedAccounts();
+  const {deployments, getNamedAccounts, ethers} = hre;
+  const {read, catchUnknownSigner, execute, deploy} = deployments;
+  const {deployer, upgradeAdmin, assetAdmin} = await getNamedAccounts();
 
   await deploy('Asset', {
     from: deployer,
@@ -16,6 +16,17 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     },
     log: true,
   });
+
+  if ((await read('Asset', 'owner')) === ethers.constants.AddressZero) {
+    await catchUnknownSigner(
+      execute(
+        'Asset',
+        {from: assetAdmin, log: true},
+        'transferOwnership',
+        assetAdmin
+      )
+    );
+  }
 };
 export default func;
 

--- a/packages/deploy/deploy/400_asset/408_asset_upgrade-v2.ts
+++ b/packages/deploy/deploy/400_asset/408_asset_upgrade-v2.ts
@@ -1,0 +1,23 @@
+import {HardhatRuntimeEnvironment} from 'hardhat/types';
+import {DeployFunction} from 'hardhat-deploy/types';
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const {deployments, getNamedAccounts} = hre;
+  const {deploy} = deployments;
+  const {deployer, upgradeAdmin} = await getNamedAccounts();
+
+  await deploy('Asset', {
+    from: deployer,
+    contract: '@sandbox-smart-contracts/asset/contracts/Asset.sol:Asset',
+    proxy: {
+      owner: upgradeAdmin,
+      proxyContract: 'OpenZeppelinTransparentProxy',
+      upgradeIndex: 1,
+    },
+    log: true,
+  });
+};
+export default func;
+
+func.tags = ['Asset_upgrade'];
+func.dependencies = ['Asset_deploy', 'Asset_setup'];

--- a/packages/deploy/hardhat.config.ts
+++ b/packages/deploy/hardhat.config.ts
@@ -14,6 +14,10 @@ import './tasks/importedPackages';
 // Package name : solidity source code path
 const importedPackages = {
   '@sandbox-smart-contracts/asset': 'contracts/',
+  '@sandbox-smart-contracts/asset-1.0.3': [
+    'contracts/Asset.sol',
+    'contracts/Catalyst.sol',
+  ],
   '@sandbox-smart-contracts/giveaway': 'contracts/SignedMultiGiveaway.sol',
   '@sandbox-smart-contracts/faucets': 'contracts/FaucetsERC1155.sol',
   '@sandbox-smart-contracts/marketplace': [

--- a/packages/deploy/package.json
+++ b/packages/deploy/package.json
@@ -16,6 +16,7 @@
     "private": true,
     "dependencies": {
         "@sandbox-smart-contracts/asset": "*",
+        "@sandbox-smart-contracts/asset-1.0.3": "npm:@sandbox-smart-contracts/asset@1.0.3",
         "@sandbox-smart-contracts/core": "*",
         "@sandbox-smart-contracts/dependency-operator-filter": "*",
         "@sandbox-smart-contracts/dependency-royalty-management": "*",

--- a/packages/deploy/test/asset/AssetCreate.test.ts
+++ b/packages/deploy/test/asset/AssetCreate.test.ts
@@ -7,7 +7,10 @@ const setupTest = deployments.createFixture(
       await getNamedAccounts();
     await deployments.fixture();
     const Asset = await deployments.get('Asset');
-    const AssetContract = await ethers.getContractAt('Asset', Asset.address);
+    const AssetContract = await ethers.getContractAt(
+      '@sandbox-smart-contracts/asset/contracts/Asset.sol:Asset',
+      Asset.address
+    );
     const AssetCreate = await deployments.get('AssetCreate');
     const AssetCreateContract = await ethers.getContractAt(
       'AssetCreate',
@@ -15,7 +18,7 @@ const setupTest = deployments.createFixture(
     );
     const Catalyst = await deployments.get('Catalyst');
     const CatalystContract = await ethers.getContractAt(
-      'Catalyst',
+      '@sandbox-smart-contracts/asset/contracts/Catalyst.sol:Catalyst',
       Catalyst.address
     );
     const TRUSTED_FORWARDER = await deployments.get('TRUSTED_FORWARDER_V2');

--- a/packages/deploy/test/asset/AssetReveal.test.ts
+++ b/packages/deploy/test/asset/AssetReveal.test.ts
@@ -7,7 +7,10 @@ const setupTest = deployments.createFixture(
       await getNamedAccounts();
     await deployments.fixture('Asset');
     const Asset = await deployments.get('Asset');
-    const AssetContract = await ethers.getContractAt('Asset', Asset.address);
+    const AssetContract = await ethers.getContractAt(
+      '@sandbox-smart-contracts/asset/contracts/Asset.sol:Asset',
+      Asset.address
+    );
     const AssetReveal = await deployments.get('AssetReveal');
     const AssetRevealContract = await ethers.getContractAt(
       'AssetReveal',
@@ -15,7 +18,7 @@ const setupTest = deployments.createFixture(
     );
     const Catalyst = await deployments.get('Catalyst');
     const CatalystContract = await ethers.getContractAt(
-      'Catalyst',
+      '@sandbox-smart-contracts/asset/contracts/Catalyst.sol:Catalyst',
       Catalyst.address
     );
     const TRUSTED_FORWARDER = await deployments.get('TRUSTED_FORWARDER_V2');

--- a/packages/deploy/test/catalyst/catalyst.test.ts
+++ b/packages/deploy/test/catalyst/catalyst.test.ts
@@ -156,7 +156,7 @@ describe('Catalyst', function () {
       const {CatalystContract, deployer} = await setupTest();
       await expect(
         CatalystContract.connect(deployer).transferOwnership(deployer.address)
-      ).to.be.revertedWith('Asset: Unauthorized');
+      ).to.be.revertedWith('Catalyst: Unauthorized');
     });
     it('emits OwnershipTransferred event when DEFAULT_ADMIN_ROLE transfers the ownership', async function () {
       const {CatalystContract, catalystAdmin, deployer} = await setupTest();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2154,6 +2154,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sandbox-smart-contracts/asset-1.0.3@npm:@sandbox-smart-contracts/asset@1.0.3":
+  version: 1.0.3
+  resolution: "@sandbox-smart-contracts/asset@npm:1.0.3"
+  dependencies:
+    "@manifoldxyz/libraries-solidity": ^1.0.4
+    "@manifoldxyz/royalty-registry-solidity": ^2.0.3
+    "@openzeppelin/contracts": 4.9.3
+    "@openzeppelin/contracts-upgradeable": 4.9.3
+    "@sandbox-smart-contracts/dependency-metatx": 1.0.1
+    "@sandbox-smart-contracts/dependency-operator-filter": 1.0.1
+    "@sandbox-smart-contracts/dependency-royalty-management": 1.0.2
+  checksum: bbf63b91b98bf694fd68592d7f35a5aacafb2bfd67243352f27b4bf062dc17c13509c480571077cadc451059c15587029145caece2814495d69cd5241e82f6db
+  languageName: node
+  linkType: hard
+
 "@sandbox-smart-contracts/asset@*, @sandbox-smart-contracts/asset@workspace:packages/asset":
   version: 0.0.0-use.local
   resolution: "@sandbox-smart-contracts/asset@workspace:packages/asset"
@@ -2411,6 +2426,7 @@ __metadata:
     "@nomiclabs/hardhat-ethers": ^2.2.3
     "@openzeppelin/hardhat-upgrades": ^2.5.0
     "@sandbox-smart-contracts/asset": "*"
+    "@sandbox-smart-contracts/asset-1.0.3": "npm:@sandbox-smart-contracts/asset@1.0.3"
     "@sandbox-smart-contracts/core": "*"
     "@sandbox-smart-contracts/dependency-operator-filter": "*"
     "@sandbox-smart-contracts/dependency-royalty-management": "*"


### PR DESCRIPTION
## Description

This PR builds on top of #1342 and requires that PR to be merged before this one.

- Catalyst and Asset have a new function called `owner` and `transferOwnership` that sets the private variable `_owner`.
- Added tests to cover the new functionalities
- Added deploy scripts and update hardhat config file

## Testing

Run the deployment process in the deploy package by calling `yarn void:deploy`