### PR TITLE
recipient for orders

### DIFF
--- a/packages/marketplace/contracts/ExchangeCore.sol
+++ b/packages/marketplace/contracts/ExchangeCore.sol
@@ -173,12 +173,12 @@ abstract contract ExchangeCore is Initializable, ITransferManager {
             ITransferManager.DealSide(
                 LibAsset.Asset(makeMatch, newFill.leftValue),
                 orderLeft.maker,
-                orderLeft.recipient
+                orderLeft.makeRecipient
             ),
             ITransferManager.DealSide(
                 LibAsset.Asset(takeMatch, newFill.rightValue),
                 orderRight.maker,
-                orderRight.recipient
+                orderRight.makeRecipient
             ),
             LibAsset.getFeeSide(makeMatch.assetClass, takeMatch.assetClass)
         );

--- a/packages/marketplace/contracts/ExchangeCore.sol
+++ b/packages/marketplace/contracts/ExchangeCore.sol
@@ -170,8 +170,16 @@ abstract contract ExchangeCore is Initializable, ITransferManager {
         LibOrder.FillResult memory newFill = _parseOrdersSetFillEmitMatch(sender, orderLeft, orderRight);
 
         doTransfers(
-            ITransferManager.DealSide(LibAsset.Asset(makeMatch, newFill.leftValue), orderLeft.maker),
-            ITransferManager.DealSide(LibAsset.Asset(takeMatch, newFill.rightValue), orderRight.maker),
+            ITransferManager.DealSide(
+                LibAsset.Asset(makeMatch, newFill.leftValue),
+                orderLeft.maker,
+                orderLeft.recipient
+            ),
+            ITransferManager.DealSide(
+                LibAsset.Asset(takeMatch, newFill.rightValue),
+                orderRight.maker,
+                orderRight.recipient
+            ),
             LibAsset.getFeeSide(makeMatch.assetClass, takeMatch.assetClass)
         );
     }

--- a/packages/marketplace/contracts/OrderValidator.sol
+++ b/packages/marketplace/contracts/OrderValidator.sol
@@ -42,6 +42,7 @@ contract OrderValidator is IOrderValidator, Initializable, EIP712Upgradeable, Wh
     /// @param sender Address of the order sender.
     function validate(LibOrder.Order calldata order, bytes memory signature, address sender) external view {
         require(order.maker != address(0), "no maker");
+        require(order.makeRecipient != address(0), "no recipient");
 
         LibOrder.validateOrderTime(order);
         _verifyWhitelists(order.makeAsset);

--- a/packages/marketplace/contracts/TransferManager.sol
+++ b/packages/marketplace/contracts/TransferManager.sol
@@ -99,10 +99,10 @@ abstract contract TransferManager is Initializable, ITransferManager {
             nftSide = left;
         }
         // Transfer NFT or left side if FeeSide.NONE
-        _transfer(nftSide.asset, nftSide.account, paymentSide.account);
+        _transfer(nftSide.asset, nftSide.account, paymentSide.recipient);
         // Transfer ERC20 or right side if FeeSide.NONE
         if (feeSide == LibAsset.FeeSide.NONE || _mustSkipFees(paymentSide.account)) {
-            _transfer(paymentSide.asset, paymentSide.account, nftSide.account);
+            _transfer(paymentSide.asset, paymentSide.account, nftSide.recipient);
         } else {
             _doTransfersWithFeesAndRoyalties(paymentSide, nftSide);
         }
@@ -155,7 +155,7 @@ abstract contract TransferManager is Initializable, ITransferManager {
             remainder = _transferPercentage(remainder, paymentSide, defaultFeeReceiver, fees, PROTOCOL_FEE_MULTIPLIER);
         }
         if (remainder > 0) {
-            _transfer(LibAsset.Asset(paymentSide.asset.assetType, remainder), paymentSide.account, nftSide.account);
+            _transfer(LibAsset.Asset(paymentSide.asset.assetType, remainder), paymentSide.account, nftSide.recipient);
         }
     }
 

--- a/packages/marketplace/contracts/TransferManager.sol
+++ b/packages/marketplace/contracts/TransferManager.sol
@@ -99,10 +99,10 @@ abstract contract TransferManager is Initializable, ITransferManager {
             nftSide = left;
         }
         // Transfer NFT or left side if FeeSide.NONE
-        _transfer(nftSide.asset, nftSide.account, paymentSide.makeRecipient);
+        _transfer(nftSide.asset, nftSide.account, paymentSide.recipient);
         // Transfer ERC20 or right side if FeeSide.NONE
         if (feeSide == LibAsset.FeeSide.NONE || _mustSkipFees(paymentSide.account)) {
-            _transfer(paymentSide.asset, paymentSide.account, nftSide.makeRecipient);
+            _transfer(paymentSide.asset, paymentSide.account, nftSide.recipient);
         } else {
             _doTransfersWithFeesAndRoyalties(paymentSide, nftSide);
         }
@@ -155,11 +155,7 @@ abstract contract TransferManager is Initializable, ITransferManager {
             remainder = _transferPercentage(remainder, paymentSide, defaultFeeReceiver, fees, PROTOCOL_FEE_MULTIPLIER);
         }
         if (remainder > 0) {
-            _transfer(
-                LibAsset.Asset(paymentSide.asset.assetType, remainder),
-                paymentSide.account,
-                nftSide.makeRecipient
-            );
+            _transfer(LibAsset.Asset(paymentSide.asset.assetType, remainder), paymentSide.account, nftSide.recipient);
         }
     }
 
@@ -188,7 +184,7 @@ abstract contract TransferManager is Initializable, ITransferManager {
         for (uint256 i; i < len; i++) {
             IRoyaltiesProvider.Part memory r = royalties[i];
             totalRoyalties = totalRoyalties + r.basisPoints;
-            if (r.account == nftSide.makeRecipient) {
+            if (r.account == nftSide.recipient) {
                 // We just skip the transfer because the nftSide will get the full payment anyway.
                 continue;
             }

--- a/packages/marketplace/contracts/TransferManager.sol
+++ b/packages/marketplace/contracts/TransferManager.sol
@@ -99,10 +99,10 @@ abstract contract TransferManager is Initializable, ITransferManager {
             nftSide = left;
         }
         // Transfer NFT or left side if FeeSide.NONE
-        _transfer(nftSide.asset, nftSide.account, paymentSide.recipient);
+        _transfer(nftSide.asset, nftSide.account, paymentSide.makeRecipient);
         // Transfer ERC20 or right side if FeeSide.NONE
         if (feeSide == LibAsset.FeeSide.NONE || _mustSkipFees(paymentSide.account)) {
-            _transfer(paymentSide.asset, paymentSide.account, nftSide.recipient);
+            _transfer(paymentSide.asset, paymentSide.account, nftSide.makeRecipient);
         } else {
             _doTransfersWithFeesAndRoyalties(paymentSide, nftSide);
         }
@@ -155,7 +155,11 @@ abstract contract TransferManager is Initializable, ITransferManager {
             remainder = _transferPercentage(remainder, paymentSide, defaultFeeReceiver, fees, PROTOCOL_FEE_MULTIPLIER);
         }
         if (remainder > 0) {
-            _transfer(LibAsset.Asset(paymentSide.asset.assetType, remainder), paymentSide.account, nftSide.recipient);
+            _transfer(
+                LibAsset.Asset(paymentSide.asset.assetType, remainder),
+                paymentSide.account,
+                nftSide.makeRecipient
+            );
         }
     }
 
@@ -184,7 +188,7 @@ abstract contract TransferManager is Initializable, ITransferManager {
         for (uint256 i; i < len; i++) {
             IRoyaltiesProvider.Part memory r = royalties[i];
             totalRoyalties = totalRoyalties + r.basisPoints;
-            if (r.account == nftSide.account) {
+            if (r.account == nftSide.makeRecipient) {
                 // We just skip the transfer because the nftSide will get the full payment anyway.
                 continue;
             }

--- a/packages/marketplace/contracts/interfaces/ITransferManager.sol
+++ b/packages/marketplace/contracts/interfaces/ITransferManager.sol
@@ -13,6 +13,7 @@ abstract contract ITransferManager {
     struct DealSide {
         LibAsset.Asset asset; // The asset associated with this side of the deal.
         address account; // The account address associated with this side of the deal.
+        address recipient; // The account address receiving the tokens
     }
 
     /// @notice Executes the asset transfers associated with two matched orders.

--- a/packages/marketplace/contracts/interfaces/ITransferManager.sol
+++ b/packages/marketplace/contracts/interfaces/ITransferManager.sol
@@ -13,7 +13,7 @@ abstract contract ITransferManager {
     struct DealSide {
         LibAsset.Asset asset; // The asset associated with this side of the deal.
         address account; // The account address associated with this side of the deal.
-        address recipient; // The account address receiving the tokens
+        address makeRecipient; // The account address receiving the tokens
     }
 
     /// @notice Executes the asset transfers associated with two matched orders.

--- a/packages/marketplace/contracts/interfaces/ITransferManager.sol
+++ b/packages/marketplace/contracts/interfaces/ITransferManager.sol
@@ -13,7 +13,7 @@ abstract contract ITransferManager {
     struct DealSide {
         LibAsset.Asset asset; // The asset associated with this side of the deal.
         address account; // The account address associated with this side of the deal.
-        address makeRecipient; // The account address receiving the tokens
+        address recipient; // The account address receiving the tokens
     }
 
     /// @notice Executes the asset transfers associated with two matched orders.

--- a/packages/marketplace/contracts/libraries/LibOrder.sol
+++ b/packages/marketplace/contracts/libraries/LibOrder.sol
@@ -40,6 +40,7 @@ library LibOrder {
             keccak256(
                 abi.encode(
                     order.maker,
+                    order.makeRecipient,
                     LibAsset.hash(order.makeAsset.assetType),
                     LibAsset.hash(order.takeAsset.assetType),
                     order.salt

--- a/packages/marketplace/contracts/libraries/LibOrder.sol
+++ b/packages/marketplace/contracts/libraries/LibOrder.sol
@@ -11,7 +11,7 @@ import {LibMath} from "./LibMath.sol";
 library LibOrder {
     bytes32 internal constant ORDER_TYPEHASH =
         keccak256(
-            "Order(address maker,Asset makeAsset,address taker,Asset takeAsset,address recipient,uint256 salt,uint256 start,uint256 end)Asset(AssetType assetType,uint256 value)AssetType(uint256 assetClass,bytes data)"
+            "Order(address maker,Asset makeAsset,address taker,Asset takeAsset,address makeRecipient,uint256 salt,uint256 start,uint256 end)Asset(AssetType assetType,uint256 value)AssetType(uint256 assetClass,bytes data)"
         );
 
     /// @dev Represents the structure of an order.
@@ -20,7 +20,7 @@ library LibOrder {
         LibAsset.Asset makeAsset; // Asset the maker is providing.
         address taker; // Address of the taker.
         LibAsset.Asset takeAsset; // Asset the taker is providing.
-        address recipient; // recipient address.
+        address makeRecipient; // recipient address for maker.
         uint256 salt; // Random number to ensure unique order hash.
         uint256 start; // Timestamp when the order becomes valid.
         uint256 end; // Timestamp when the order expires.
@@ -60,7 +60,7 @@ library LibOrder {
                     LibAsset.hash(order.makeAsset),
                     order.taker,
                     LibAsset.hash(order.takeAsset),
-                    order.recipient,
+                    order.makeRecipient,
                     order.salt,
                     order.start,
                     order.end

--- a/packages/marketplace/contracts/libraries/LibOrder.sol
+++ b/packages/marketplace/contracts/libraries/LibOrder.sol
@@ -11,7 +11,7 @@ import {LibMath} from "./LibMath.sol";
 library LibOrder {
     bytes32 internal constant ORDER_TYPEHASH =
         keccak256(
-            "Order(address maker,Asset makeAsset,address taker,Asset takeAsset,uint256 salt,uint256 start,uint256 end)Asset(AssetType assetType,uint256 value)AssetType(uint256 assetClass,bytes data)"
+            "Order(address maker,Asset makeAsset,address taker,Asset takeAsset,address recipient,uint256 salt,uint256 start,uint256 end)Asset(AssetType assetType,uint256 value)AssetType(uint256 assetClass,bytes data)"
         );
 
     /// @dev Represents the structure of an order.
@@ -20,6 +20,7 @@ library LibOrder {
         LibAsset.Asset makeAsset; // Asset the maker is providing.
         address taker; // Address of the taker.
         LibAsset.Asset takeAsset; // Asset the taker is providing.
+        address recipient; // recipient address.
         uint256 salt; // Random number to ensure unique order hash.
         uint256 start; // Timestamp when the order becomes valid.
         uint256 end; // Timestamp when the order expires.
@@ -59,6 +60,7 @@ library LibOrder {
                     LibAsset.hash(order.makeAsset),
                     order.taker,
                     LibAsset.hash(order.takeAsset),
+                    order.recipient,
                     order.salt,
                     order.start,
                     order.end

--- a/packages/marketplace/test/OrderValidator.test.ts
+++ b/packages/marketplace/test/OrderValidator.test.ts
@@ -325,6 +325,27 @@ describe('OrderValidator.sol', function () {
     ).to.not.be.reverted;
   });
 
+  it('should not validate if recipient is zero', async function () {
+    const makerAsset = await AssetERC721(ERC721Contract, 100);
+    const takerAsset = await AssetERC20(ERC20Contract, 100);
+    const order = await OrderDefault(
+      user1,
+      makerAsset,
+      ZeroAddress,
+      takerAsset,
+      1,
+      0,
+      0,
+      ZeroAddress
+    );
+
+    const signature = await signOrder(order, user1, OrderValidatorAsUser);
+
+    await expect(
+      OrderValidatorAsUser.validate(order, signature, user2.getAddress())
+    ).to.be.revertedWith('no recipient');
+  });
+
   it('should not validate if recipient is changed after signature', async function () {
     const makerAsset = await AssetERC721(ERC721Contract, 100);
     const takerAsset = await AssetERC20(ERC20Contract, 100);

--- a/packages/marketplace/test/OrderValidator.test.ts
+++ b/packages/marketplace/test/OrderValidator.test.ts
@@ -325,6 +325,37 @@ describe('OrderValidator.sol', function () {
     ).to.not.be.reverted;
   });
 
+  it('should not validate if recipient is changed after signature', async function () {
+    const makerAsset = await AssetERC721(ERC721Contract, 100);
+    const takerAsset = await AssetERC20(ERC20Contract, 100);
+    const order = await OrderDefault(
+      user1,
+      makerAsset,
+      ZeroAddress,
+      takerAsset,
+      1,
+      0,
+      0
+    );
+
+    const signature = await signOrder(order, user1, OrderValidatorAsUser);
+
+    const newOrder = await OrderDefault(
+      user1,
+      makerAsset,
+      ZeroAddress,
+      takerAsset,
+      1,
+      0,
+      0,
+      await user2.getAddress()
+    );
+
+    await expect(
+      OrderValidatorAsUser.validate(newOrder, signature, user2.getAddress())
+    ).to.be.revertedWith('signature verification error');
+  });
+
   it('should not set permission for token if caller is not owner', async function () {
     await expect(OrderValidatorAsUser.enableRole(TSBRole)).to.revertedWith(
       `AccessControl: account ${(

--- a/packages/marketplace/test/exchange/MatchOrders.behavior.ts
+++ b/packages/marketplace/test/exchange/MatchOrders.behavior.ts
@@ -963,88 +963,86 @@ export function shouldMatchOrders() {
       });
     });
 
-    describe('different recipients ', function () {
-      it('recipient test', async function () {
-        const recipientAddress = await makeRecipient.getAddress();
-        const makerAssetForLeftOrder = await AssetERC20(
-          ERC20Contract,
-          10000000000
-        );
-        const takerAssetForLeftOrder = await AssetERC20(
-          ERC20Contract2,
-          20000000000
-        );
+    it('different recipients test', async function () {
+      const recipientAddress = await makeRecipient.getAddress();
+      const makerAssetForLeftOrder = await AssetERC20(
+        ERC20Contract,
+        10000000000
+      );
+      const takerAssetForLeftOrder = await AssetERC20(
+        ERC20Contract2,
+        20000000000
+      );
 
-        const takerAssetForRightOrder = await AssetERC20(
-          ERC20Contract2,
-          10000000000
-        );
+      const takerAssetForRightOrder = await AssetERC20(
+        ERC20Contract2,
+        10000000000
+      );
 
-        const makerAssetForRightOrder = await AssetERC20(
-          ERC20Contract,
-          5000000000
-        );
+      const makerAssetForRightOrder = await AssetERC20(
+        ERC20Contract,
+        5000000000
+      );
 
-        orderLeft = await OrderDefault(
-          maker,
-          makerAssetForLeftOrder,
-          ZeroAddress,
-          takerAssetForLeftOrder,
-          1,
-          0,
-          0,
-          recipientAddress
-        );
+      orderLeft = await OrderDefault(
+        maker,
+        makerAssetForLeftOrder,
+        ZeroAddress,
+        takerAssetForLeftOrder,
+        1,
+        0,
+        0,
+        recipientAddress
+      );
 
-        orderRight = await OrderDefault(
-          taker,
-          takerAssetForRightOrder,
-          ZeroAddress,
-          makerAssetForRightOrder,
-          1,
-          0,
-          0,
-          recipientAddress
-        );
+      orderRight = await OrderDefault(
+        taker,
+        takerAssetForRightOrder,
+        ZeroAddress,
+        makerAssetForRightOrder,
+        1,
+        0,
+        0,
+        recipientAddress
+      );
 
-        makerSig = await signOrder(orderLeft, maker, OrderValidatorAsAdmin);
-        takerSig = await signOrder(orderRight, taker, OrderValidatorAsAdmin);
+      makerSig = await signOrder(orderLeft, maker, OrderValidatorAsAdmin);
+      takerSig = await signOrder(orderRight, taker, OrderValidatorAsAdmin);
 
-        expect(
-          await ExchangeContractAsUser.fills(hashKey(orderLeft))
-        ).to.be.equal(0);
-        expect(
-          await ExchangeContractAsUser.fills(hashKey(orderRight))
-        ).to.be.equal(0);
-        expect(await ERC20Contract.balanceOf(maker)).to.be.equal(10000000000);
-        expect(await ERC20Contract.balanceOf(taker)).to.be.equal(0);
-        expect(await ERC20Contract2.balanceOf(maker)).to.be.equal(0);
-        expect(await ERC20Contract2.balanceOf(taker)).to.be.equal(20000000000);
+      expect(
+        await ExchangeContractAsUser.fills(hashKey(orderLeft))
+      ).to.be.equal(0);
+      expect(
+        await ExchangeContractAsUser.fills(hashKey(orderRight))
+      ).to.be.equal(0);
+      expect(await ERC20Contract.balanceOf(maker)).to.be.equal(10000000000);
+      expect(await ERC20Contract.balanceOf(taker)).to.be.equal(0);
+      expect(await ERC20Contract2.balanceOf(maker)).to.be.equal(0);
+      expect(await ERC20Contract2.balanceOf(taker)).to.be.equal(20000000000);
 
-        await ExchangeContractAsUser.matchOrders([
-          {
-            orderLeft,
-            signatureLeft: makerSig,
-            orderRight,
-            signatureRight: takerSig,
-          },
-        ]);
+      await ExchangeContractAsUser.matchOrders([
+        {
+          orderLeft,
+          signatureLeft: makerSig,
+          orderRight,
+          signatureRight: takerSig,
+        },
+      ]);
 
-        expect(
-          await ExchangeContractAsUser.fills(hashKey(orderLeft))
-        ).to.be.equal(10000000000);
-        expect(
-          await ExchangeContractAsUser.fills(hashKey(orderRight))
-        ).to.be.equal(5000000000);
-        expect(await ERC20Contract.balanceOf(maker)).to.be.equal(5000000000);
-        expect(await ERC20Contract.balanceOf(recipientAddress)).to.be.equal(
-          5000000000
-        );
-        expect(await ERC20Contract2.balanceOf(recipientAddress)).to.be.equal(
-          10000000000
-        );
-        expect(await ERC20Contract2.balanceOf(taker)).to.be.equal(10000000000);
-      });
+      expect(
+        await ExchangeContractAsUser.fills(hashKey(orderLeft))
+      ).to.be.equal(10000000000);
+      expect(
+        await ExchangeContractAsUser.fills(hashKey(orderRight))
+      ).to.be.equal(5000000000);
+      expect(await ERC20Contract.balanceOf(maker)).to.be.equal(5000000000);
+      expect(await ERC20Contract.balanceOf(recipientAddress)).to.be.equal(
+        5000000000
+      );
+      expect(await ERC20Contract2.balanceOf(recipientAddress)).to.be.equal(
+        10000000000
+      );
+      expect(await ERC20Contract2.balanceOf(taker)).to.be.equal(10000000000);
     });
 
     it('should emit a Match event', async function () {

--- a/packages/marketplace/test/exchange/MatchOrders.behavior.ts
+++ b/packages/marketplace/test/exchange/MatchOrders.behavior.ts
@@ -6,6 +6,7 @@ import {AssetERC20, AssetERC721, AssetERC1155, Asset} from '../utils/assets.ts';
 import {
   hashKey,
   OrderDefault,
+  OrderDifferentRecipient,
   signOrder,
   Order,
   isOrderEqual,
@@ -26,6 +27,7 @@ export function shouldMatchOrders() {
       defaultFeeReceiver: Signer,
       maker: Signer,
       taker: Signer,
+      recipient: Signer,
       user: Signer,
       makerAsset: Asset,
       takerAsset: Asset,
@@ -52,6 +54,7 @@ export function shouldMatchOrders() {
         defaultFeeReceiver,
         user1: maker,
         user2: taker,
+        user3: recipient,
         user,
         PAUSER_ROLE,
         ERC1776_OPERATOR_ROLE,
@@ -308,6 +311,88 @@ export function shouldMatchOrders() {
         expect(await ERC20Contract.balanceOf(taker)).to.be.equal(10000000000);
         expect(await ERC20Contract2.balanceOf(maker)).to.be.equal(20000000000);
         expect(await ERC20Contract2.balanceOf(taker)).to.be.equal(0);
+      });
+      it('recipient test', async function () {
+        const recipientAddress = await recipient.getAddress();
+        const makerAssetForLeftOrder = await AssetERC20(
+          ERC20Contract,
+          10000000000
+        );
+        const takerAssetForLeftOrder = await AssetERC20(
+          ERC20Contract2,
+          20000000000
+        );
+        // partially filled Asset
+        const takerAssetForRightOrder = await AssetERC20(
+          ERC20Contract2,
+          10000000000
+        );
+        // partially filled Asset
+        const makerAssetForRightOrder = await AssetERC20(
+          ERC20Contract,
+          5000000000
+        );
+
+        // left order for partial fill
+        orderLeft = await OrderDifferentRecipient(
+          maker,
+          makerAssetForLeftOrder,
+          ZeroAddress,
+          takerAssetForLeftOrder,
+          recipientAddress,
+          1,
+          0,
+          0
+        );
+        // right order for partial fill
+        orderRight = await OrderDifferentRecipient(
+          taker,
+          takerAssetForRightOrder,
+          ZeroAddress,
+          makerAssetForRightOrder,
+          recipientAddress,
+          1,
+          0,
+          0
+        );
+
+        makerSig = await signOrder(orderLeft, maker, OrderValidatorAsAdmin);
+        takerSig = await signOrder(orderRight, taker, OrderValidatorAsAdmin);
+
+        expect(
+          await ExchangeContractAsUser.fills(hashKey(orderLeft))
+        ).to.be.equal(0);
+        expect(
+          await ExchangeContractAsUser.fills(hashKey(orderRight))
+        ).to.be.equal(0);
+        expect(await ERC20Contract.balanceOf(maker)).to.be.equal(10000000000);
+        expect(await ERC20Contract.balanceOf(taker)).to.be.equal(0);
+        expect(await ERC20Contract2.balanceOf(maker)).to.be.equal(0);
+        expect(await ERC20Contract2.balanceOf(taker)).to.be.equal(20000000000);
+
+        await ExchangeContractAsUser.matchOrders([
+          {
+            orderLeft,
+            signatureLeft: makerSig,
+            orderRight,
+            signatureRight: takerSig,
+          },
+        ]);
+
+        expect(
+          await ExchangeContractAsUser.fills(hashKey(orderLeft))
+        ).to.be.equal(10000000000);
+        expect(
+          await ExchangeContractAsUser.fills(hashKey(orderRight))
+        ).to.be.equal(5000000000);
+        expect(await ERC20Contract.balanceOf(maker)).to.be.equal(5000000000);
+        expect(await ERC20Contract.balanceOf(recipientAddress)).to.be.equal(
+          5000000000
+        );
+        expect(await ERC20Contract2.balanceOf(recipientAddress)).to.be.equal(
+          10000000000
+        );
+        expect(await ERC20Contract2.balanceOf(taker)).to.be.equal(10000000000);
       });
     });
 

--- a/packages/marketplace/test/exchange/MatchOrdersWithRoyalties.behavior.ts
+++ b/packages/marketplace/test/exchange/MatchOrdersWithRoyalties.behavior.ts
@@ -30,7 +30,7 @@ export function shouldMatchOrdersWithRoyalty() {
       admin: Signer,
       maker: Signer,
       taker: Signer,
-      recipient: Signer,
+      makeRecipient: Signer,
       receiver1: Signer,
       receiver2: Signer,
       royaltyReceiver: Signer,
@@ -59,7 +59,7 @@ export function shouldMatchOrdersWithRoyalty() {
         admin,
         user1: maker,
         user2: taker,
-        user3: recipient,
+        user3: makeRecipient,
         admin: receiver1,
         user: receiver2,
         deployer: royaltyReceiver,
@@ -683,7 +683,7 @@ export function shouldMatchOrdersWithRoyalty() {
         1,
         0,
         0,
-        await recipient.getAddress()
+        await makeRecipient.getAddress()
       );
       orderRight = await OrderDefault(
         taker,
@@ -740,7 +740,9 @@ export function shouldMatchOrdersWithRoyalty() {
       ).to.be.equal(2000000000); // 20% of the amount
 
       //recipient should receive the payment in tokens
-      expect(await ERC20Contract.balanceOf(recipient.getAddress())).to.be.equal(
+      expect(
+        await ERC20Contract.balanceOf(makeRecipient.getAddress())
+      ).to.be.equal(
         7750000000 // 10000000000 - royalty - protocolFee
       );
     });

--- a/packages/marketplace/test/exchange/MatchOrdersWithRoyalties.behavior.ts
+++ b/packages/marketplace/test/exchange/MatchOrdersWithRoyalties.behavior.ts
@@ -30,6 +30,7 @@ export function shouldMatchOrdersWithRoyalty() {
       admin: Signer,
       maker: Signer,
       taker: Signer,
+      recipient: Signer,
       receiver1: Signer,
       receiver2: Signer,
       royaltyReceiver: Signer,
@@ -58,6 +59,7 @@ export function shouldMatchOrdersWithRoyalty() {
         admin,
         user1: maker,
         user2: taker,
+        user3: recipient,
         admin: receiver1,
         user: receiver2,
         deployer: royaltyReceiver,
@@ -656,6 +658,90 @@ export function shouldMatchOrdersWithRoyalty() {
 
       expect(await ERC20Contract.balanceOf(maker.getAddress())).to.be.equal(
         10000000000
+      );
+    });
+
+    it('should execute a complete match order taking in account a different recipient', async function () {
+      await ERC721Contract.mint(maker.getAddress(), 1);
+      await ERC721Contract.connect(maker).approve(
+        await ExchangeContractAsUser.getAddress(),
+        1
+      );
+
+      // set up royalties by token
+      await RoyaltiesRegistryAsDeployer.setRoyaltiesByToken(
+        await ERC721Contract.getAddress(),
+        [await LibPartData(royaltyReceiver, 2000)]
+      );
+
+      ERC721Asset = await AssetERC721(ERC721Contract, 1);
+      orderLeft = await OrderDefault(
+        maker,
+        ERC721Asset,
+        ZeroAddress,
+        ERC20Asset,
+        1,
+        0,
+        0,
+        await recipient.getAddress()
+      );
+      orderRight = await OrderDefault(
+        taker,
+        ERC20Asset,
+        ZeroAddress,
+        ERC721Asset,
+        1,
+        0,
+        0
+      );
+      makerSig = await signOrder(orderLeft, maker, OrderValidatorAsAdmin);
+      takerSig = await signOrder(orderRight, taker, OrderValidatorAsAdmin);
+
+      expect(
+        await ExchangeContractAsUser.fills(hashKey(orderLeft))
+      ).to.be.equal(0);
+      expect(
+        await ExchangeContractAsUser.fills(hashKey(orderRight))
+      ).to.be.equal(0);
+      expect(await ERC721Contract.ownerOf(1)).to.be.equal(
+        await maker.getAddress()
+      );
+      expect(await ERC20Contract.balanceOf(taker.getAddress())).to.be.equal(
+        10000000000
+      );
+
+      await ExchangeContractAsUser.matchOrders([
+        {
+          orderLeft,
+          signatureLeft: makerSig,
+          orderRight,
+          signatureRight: takerSig,
+        },
+      ]);
+
+      expect(
+        await ExchangeContractAsUser.fills(hashKey(orderLeft))
+      ).to.be.equal(10000000000);
+      expect(
+        await ExchangeContractAsUser.fills(hashKey(orderRight))
+      ).to.be.equal(1);
+      expect(await ERC721Contract.ownerOf(1)).to.be.equal(
+        await taker.getAddress()
+      );
+
+      // check protocol fee
+      expect(
+        await ERC20Contract.balanceOf(defaultFeeReceiver.getAddress())
+      ).to.be.equal(250000000); // 250 * 10000000000 / 10000 = 250000000
+
+      // check paid royalty
+      expect(
+        await ERC20Contract.balanceOf(royaltyReceiver.getAddress())
+      ).to.be.equal(2000000000); // 20% of the amount
+
+      //recipient should receive the payment in tokens
+      expect(await ERC20Contract.balanceOf(recipient.getAddress())).to.be.equal(
+        7750000000 // 10000000000 - royalty - protocolFee
       );
     });
 

--- a/packages/marketplace/test/fixtures/index.ts
+++ b/packages/marketplace/test/fixtures/index.ts
@@ -5,7 +5,7 @@ import {exchangeSetup} from './exchange';
 import {mockAssetsSetup} from './assets';
 
 export async function deployFixturesWithoutWhitelist() {
-  const [deployer, admin, user, defaultFeeReceiver, user1, user2] =
+  const [deployer, admin, user, defaultFeeReceiver, user1, user2, user3] =
     await ethers.getSigners();
 
   const exchange = await exchangeSetup();
@@ -33,6 +33,7 @@ export async function deployFixturesWithoutWhitelist() {
     user,
     user1,
     user2,
+    user3,
     defaultFeeReceiver,
     ZERO_ADDRESS: ZeroAddress,
   };

--- a/packages/marketplace/test/utils/fill.ts
+++ b/packages/marketplace/test/utils/fill.ts
@@ -20,7 +20,7 @@ export type FillData = {
 export const fillOrder = (makeValue: Numeric, takeValue: Numeric): Order => ({
   maker: ZeroAddress,
   taker: ZeroAddress,
-  recipient: ZeroAddress,
+  makeRecipient: ZeroAddress,
   end: 0,
   start: 0,
   salt: 0,

--- a/packages/marketplace/test/utils/fill.ts
+++ b/packages/marketplace/test/utils/fill.ts
@@ -20,6 +20,7 @@ export type FillData = {
 export const fillOrder = (makeValue: Numeric, takeValue: Numeric): Order => ({
   maker: ZeroAddress,
   taker: ZeroAddress,
+  recipient: ZeroAddress,
   end: 0,
   start: 0,
   salt: 0,

--- a/packages/marketplace/test/utils/order.ts
+++ b/packages/marketplace/test/utils/order.ts
@@ -53,9 +53,10 @@ export const OrderDefault = async (
 
 export function hashKey(order: Order): string {
   const encoded = AbiCoder.defaultAbiCoder().encode(
-    ['address', 'bytes32', 'bytes32', 'uint256'],
+    ['address', 'address', 'bytes32', 'bytes32', 'uint256'],
     [
       order.maker,
+      order.makeRecipient,
       hashAssetType(order.makeAsset.assetType),
       hashAssetType(order.takeAsset.assetType),
       order.salt,

--- a/packages/marketplace/test/utils/order.ts
+++ b/packages/marketplace/test/utils/order.ts
@@ -12,7 +12,7 @@ import {
 
 export const ORDER_TYPEHASH = keccak256(
   Buffer.from(
-    'Order(address maker,Asset makeAsset,address taker,Asset takeAsset,uint256 salt,uint256 start,uint256 end)Asset(AssetType assetType,uint256 value)AssetType(uint256 assetClass,bytes data)'
+    'Order(address maker,Asset makeAsset,address taker,Asset takeAsset,address recipient,uint256 salt,uint256 start,uint256 end)Asset(AssetType assetType,uint256 value)AssetType(uint256 assetClass,bytes data)'
   )
 );
 
@@ -24,6 +24,7 @@ export type Order = {
   makeAsset: Asset;
   taker: string;
   takeAsset: Asset;
+  recipient: string;
   salt: Numeric;
   start: Numeric;
   end: Numeric;
@@ -43,6 +44,28 @@ export const OrderDefault = async (
   taker:
     taker === ZeroAddress ? ZeroAddress : await (taker as Signer).getAddress(),
   takeAsset,
+  recipient: await maker.getAddress(),
+  salt,
+  start,
+  end,
+});
+
+export const OrderDifferentRecipient = async (
+  maker: {getAddress: () => Promise<string>},
+  makeAsset: Asset,
+  taker: Signer | ZeroAddress,
+  takeAsset: Asset,
+  recipient: Address,
+  salt: Numeric,
+  start: Numeric,
+  end: Numeric
+): Promise<Order> => ({
+  maker: await maker.getAddress(),
+  makeAsset,
+  taker:
+    taker === ZeroAddress ? ZeroAddress : await (taker as Signer).getAddress(),
+  takeAsset,
+  recipient: recipient,
   salt,
   start,
   end,
@@ -72,7 +95,11 @@ export const getSymmetricOrder = async (
     takeAsset: o.makeAsset,
   };
   if (taker) {
-    return {...ret, maker: await taker.getAddress()};
+    return {
+      ...ret,
+      maker: await taker.getAddress(),
+      recipient: await taker.getAddress(),
+    };
   }
   if (o.taker === ZeroAddress) {
     throw new Error(
@@ -90,6 +117,7 @@ export function hashOrder(order: Order): string {
       'bytes32',
       'address',
       'bytes32',
+      'address',
       'uint256',
       'uint256',
       'uint256',
@@ -100,6 +128,7 @@ export function hashOrder(order: Order): string {
       hashAsset(order.makeAsset),
       order.taker,
       hashAsset(order.takeAsset),
+      order.recipient, // it was .maker, I changed to recipient// recipient
       order.salt,
       order.start,
       order.end,
@@ -135,6 +164,7 @@ export async function signOrder(
         {name: 'makeAsset', type: 'Asset'},
         {name: 'taker', type: 'address'},
         {name: 'takeAsset', type: 'Asset'},
+        {name: 'recipient', type: 'address'},
         {name: 'salt', type: 'uint256'},
         {name: 'start', type: 'uint256'},
         {name: 'end', type: 'uint256'},


### PR DESCRIPTION
Right now, when an exchange is done on the marketplace, the seller address is the one receiving the payment.

In order to send the payment to another recipient, we have to change the order structure on the marketplace so that the seller and buyer can change their recipient address.