### PR TITLE
Remove reinitializer from land

### DIFF
--- a/packages/land/contracts/Land.sol
+++ b/packages/land/contracts/Land.sol
@@ -21,14 +21,14 @@ contract Land is LandStorageMixin, LandBaseToken, OperatorFiltererUpgradeable {
 
     IRoyaltyManager private _royaltyManager;
     address private _owner;
-    bool private _initializing;
+    bool private _initV4;
 
     event OperatorRegistrySet(address indexed registry);
     event RoyaltyManagerSet(address indexed royaltyManager);
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
     modifier initializer() {
-        require(!_initializing, "already initialized");
+        require(!_initV4, "already initialized");
         _;
     }
 
@@ -38,7 +38,7 @@ contract Land is LandStorageMixin, LandBaseToken, OperatorFiltererUpgradeable {
      */
     function initialize(address admin) public initializer {
         _admin = admin;
-        _initializing = true;
+        _initV4 = true;
         emit AdminChanged(address(0), _admin);
     }
 

--- a/packages/land/contracts/Land.sol
+++ b/packages/land/contracts/Land.sol
@@ -21,10 +21,26 @@ contract Land is LandStorageMixin, LandBaseToken, OperatorFiltererUpgradeable {
 
     IRoyaltyManager private _royaltyManager;
     address private _owner;
+    bool private _initializing;
 
     event OperatorRegistrySet(address indexed registry);
     event RoyaltyManagerSet(address indexed royaltyManager);
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    modifier initializer() {
+        require(!_initializing, "already initialized");
+        _;
+    }
+
+    /**
+     * @notice Initializes the contract with the admin
+     * @param admin Admin of the contract
+     */
+    function initialize(address admin) public initializer {
+        _admin = admin;
+        _initializing = true;
+        emit AdminChanged(address(0), _admin);
+    }
 
     /// @notice This function is used to register Land contract on the Operator Filterer Registry of Opensea.can only be called by admin.
     /// @dev used to register contract and subscribe to the subscriptionOrRegistrantToCopy's black list.

--- a/packages/land/contracts/Land.sol
+++ b/packages/land/contracts/Land.sol
@@ -26,78 +26,6 @@ contract Land is LandStorageMixin, LandBaseToken, OperatorFiltererUpgradeable {
     event RoyaltyManagerSet(address indexed royaltyManager);
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
-    /**
-     * @notice Return the name of the token contract
-     * @return The name of the token contract
-     */
-    function name() external pure returns (string memory) {
-        return "Sandbox's LANDs";
-    }
-
-    /**
-     * @notice Return the symbol of the token contract
-     * @return The symbol of the token contract
-     */
-    function symbol() external pure returns (string memory) {
-        return "LAND";
-    }
-
-    function uint2str(uint256 _i) internal pure returns (string memory) {
-        if (_i == 0) {
-            return "0";
-        }
-        uint256 j = _i;
-        uint256 len;
-        while (j != 0) {
-            len++;
-            j /= 10;
-        }
-        bytes memory bstr = new bytes(len);
-        while (_i != 0) {
-            bstr[--len] = bytes1(uint8(48 + (_i % 10)));
-            _i /= 10;
-        }
-        return string(bstr);
-    }
-
-    function _setRoyaltyManager(address royaltyManager) internal {
-        _royaltyManager = IRoyaltyManager(royaltyManager);
-        emit RoyaltyManagerSet(royaltyManager);
-    }
-
-    function _transferOwnership(address newOwner) internal {
-        emit OwnershipTransferred(_owner, newOwner);
-        _owner = newOwner;
-    }
-
-    /**
-     * @notice Return the URI of a specific token
-     * @param id The id of the token
-     * @return The URI of the token
-     */
-    function tokenURI(uint256 id) public view returns (string memory) {
-        require(_ownerOf(id) != address(0), "Land: Id does not exist");
-        return string(abi.encodePacked("https://api.sandbox.game/lands/", uint2str(id), "/metadata.json"));
-    }
-
-    /**
-     * @notice Check if the contract supports an interface
-     * 0x01ffc9a7 is ERC-165
-     * 0x80ac58cd is ERC-721
-     * 0x5b5e139f is ERC-721 metadata
-     * 0x7f5828d0 is ERC-173
-     * @param id The id of the interface
-     * @return True if the interface is supported
-     */
-    function supportsInterface(bytes4 id) public pure override(ERC721BaseToken) returns (bool) {
-        return
-            id == 0x01ffc9a7 ||
-            id == 0x80ac58cd ||
-            id == 0x5b5e139f ||
-            id == 0x7f5828d0 ||
-            id == type(IERC2981Upgradeable).interfaceId;
-    }
-
     /// @notice This function is used to register Land contract on the Operator Filterer Registry of Opensea.can only be called by admin.
     /// @dev used to register contract and subscribe to the subscriptionOrRegistrantToCopy's black list.
     /// @param subscriptionOrRegistrantToCopy registration address of the list to subscribe.
@@ -112,6 +40,28 @@ contract Land is LandStorageMixin, LandBaseToken, OperatorFiltererUpgradeable {
     function setOperatorRegistry(address registry) external onlyAdmin {
         operatorFilterRegistry = IOperatorFilterRegistry(registry);
         emit OperatorRegistrySet(registry);
+    }
+
+    /// @notice set royalty manager
+    /// @param royaltyManager address of the manager contract for common royalty recipient
+    function setRoyaltyManager(address royaltyManager) external onlyAdmin {
+        _setRoyaltyManager(royaltyManager);
+    }
+
+    /// @notice Set the address of the new owner of the contract
+    /// @param newOwner address of new owner
+    function transferOwnership(address newOwner) external onlyAdmin {
+        _transferOwnership(newOwner);
+    }
+
+    /**
+     * @notice Transfer a token between 2 addresses letting the receiver knows of the transfer
+     * @param from The send of the token
+     * @param to The recipient of the token
+     * @param id The id of the token
+     */
+    function safeTransferFrom(address from, address to, uint256 id) external override onlyAllowedOperator(from) {
+        super.safeTransferFrom(from, to, id, "");
     }
 
     /// @notice Returns how much royalty is owed and to whom based on ERC2981
@@ -141,16 +91,20 @@ contract Land is LandStorageMixin, LandBaseToken, OperatorFiltererUpgradeable {
         return _owner;
     }
 
-    /// @notice set royalty manager
-    /// @param royaltyManager address of the manager contract for common royalty recipient
-    function setRoyaltyManager(address royaltyManager) external onlyAdmin {
-        _setRoyaltyManager(royaltyManager);
+    /**
+     * @notice Return the name of the token contract
+     * @return The name of the token contract
+     */
+    function name() external pure returns (string memory) {
+        return "Sandbox's LANDs";
     }
 
-    /// @notice Set the address of the new owner of the contract
-    /// @param newOwner address of new owner
-    function transferOwnership(address newOwner) external onlyAdmin {
-        _transferOwnership(newOwner);
+    /**
+     * @notice Return the symbol of the token contract
+     * @return The symbol of the token contract
+     */
+    function symbol() external pure returns (string memory) {
+        return "LAND";
     }
 
     /**
@@ -226,12 +180,58 @@ contract Land is LandStorageMixin, LandBaseToken, OperatorFiltererUpgradeable {
     }
 
     /**
-     * @notice Transfer a token between 2 addresses letting the receiver knows of the transfer
-     * @param from The send of the token
-     * @param to The recipient of the token
+     * @notice Return the URI of a specific token
      * @param id The id of the token
+     * @return The URI of the token
      */
-    function safeTransferFrom(address from, address to, uint256 id) external override onlyAllowedOperator(from) {
-        super.safeTransferFrom(from, to, id, "");
+    function tokenURI(uint256 id) public view returns (string memory) {
+        require(_ownerOf(id) != address(0), "Land: Id does not exist");
+        return string(abi.encodePacked("https://api.sandbox.game/lands/", uint2str(id), "/metadata.json"));
+    }
+
+    /**
+     * @notice Check if the contract supports an interface
+     * 0x01ffc9a7 is ERC-165
+     * 0x80ac58cd is ERC-721
+     * 0x5b5e139f is ERC-721 metadata
+     * 0x7f5828d0 is ERC-173
+     * @param id The id of the interface
+     * @return True if the interface is supported
+     */
+    function supportsInterface(bytes4 id) public pure override(ERC721BaseToken) returns (bool) {
+        return
+            id == 0x01ffc9a7 ||
+            id == 0x80ac58cd ||
+            id == 0x5b5e139f ||
+            id == 0x7f5828d0 ||
+            id == type(IERC2981Upgradeable).interfaceId;
+    }
+
+    function _setRoyaltyManager(address royaltyManager) internal {
+        _royaltyManager = IRoyaltyManager(royaltyManager);
+        emit RoyaltyManagerSet(royaltyManager);
+    }
+
+    function _transferOwnership(address newOwner) internal {
+        emit OwnershipTransferred(_owner, newOwner);
+        _owner = newOwner;
+    }
+
+    function uint2str(uint256 _i) internal pure returns (string memory) {
+        if (_i == 0) {
+            return "0";
+        }
+        uint256 j = _i;
+        uint256 len;
+        while (j != 0) {
+            len++;
+            j /= 10;
+        }
+        bytes memory bstr = new bytes(len);
+        while (_i != 0) {
+            bstr[--len] = bytes1(uint8(48 + (_i % 10)));
+            _i /= 10;
+        }
+        return string(bstr);
     }
 }

--- a/packages/land/contracts/Land.sol
+++ b/packages/land/contracts/Land.sol
@@ -9,6 +9,7 @@ import {LandBaseToken} from "./mainnet/LandBaseToken.sol";
 import {ERC721BaseToken} from "./mainnet/ERC721BaseToken.sol";
 import {OperatorFiltererUpgradeable} from "./mainnet/OperatorFiltererUpgradeable.sol";
 import {LandStorageMixin} from "./mainnet/LandStorageMixin.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
 /**
  * @title Land Contract
@@ -16,7 +17,7 @@ import {LandStorageMixin} from "./mainnet/LandStorageMixin.sol";
  * @notice LAND contract
  * @dev LAND contract implements ERC721, quad and marketplace filtering functionalities
  */
-contract Land is LandStorageMixin, LandBaseToken, OperatorFiltererUpgradeable {
+contract Land is LandStorageMixin, LandBaseToken, OperatorFiltererUpgradeable, Initializable {
     uint16 internal constant TOTAL_BASIS_POINTS = 10000;
 
     IRoyaltyManager private _royaltyManager;
@@ -26,17 +27,13 @@ contract Land is LandStorageMixin, LandBaseToken, OperatorFiltererUpgradeable {
     event RoyaltyManagerSet(address indexed royaltyManager);
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
-    modifier initializer() {
-        require(_admin == address(0), "already initialized");
-        _;
-    }
-
     /**
      * @notice Initializes the contract with the admin
      * @param admin Admin of the contract
      */
     function initialize(address admin) public initializer {
         require(admin != address(0), "invalid admin");
+        require(_admin == address(0), "already initialized");
         _admin = admin;
         emit AdminChanged(address(0), _admin);
     }

--- a/packages/land/contracts/Land.sol
+++ b/packages/land/contracts/Land.sol
@@ -21,14 +21,13 @@ contract Land is LandStorageMixin, LandBaseToken, OperatorFiltererUpgradeable {
 
     IRoyaltyManager private _royaltyManager;
     address private _owner;
-    bool private _initV4;
 
     event OperatorRegistrySet(address indexed registry);
     event RoyaltyManagerSet(address indexed royaltyManager);
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
     modifier initializer() {
-        require(!_initV4, "already initialized");
+        require(_admin == address(0), "already initialized");
         _;
     }
 
@@ -37,8 +36,8 @@ contract Land is LandStorageMixin, LandBaseToken, OperatorFiltererUpgradeable {
      * @param admin Admin of the contract
      */
     function initialize(address admin) public initializer {
+        require(admin != address(0), "invalid admin");
         _admin = admin;
-        _initV4 = true;
         emit AdminChanged(address(0), _admin);
     }
 

--- a/packages/land/contracts/Land.sol
+++ b/packages/land/contracts/Land.sol
@@ -21,44 +21,10 @@ contract Land is LandStorageMixin, LandBaseToken, OperatorFiltererUpgradeable {
 
     IRoyaltyManager private _royaltyManager;
     address private _owner;
-    uint8 private initialized;
-    bool private _initializing;
 
     event OperatorRegistrySet(address indexed registry);
     event RoyaltyManagerSet(address indexed royaltyManager);
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
-    event Initialized(uint8 version);
-
-    modifier reinitializer(uint8 version) {
-        require(!_initializing && initialized < version, "contract is already initialized");
-        initialized = version;
-        _initializing = true;
-        _;
-        _initializing = false;
-        emit Initialized(version);
-    }
-
-    /**
-     * @notice Initializes the contract with the meta-transaction contract, admin & royalty-manager
-     * @param metaTransactionContract Authorized contract for meta-transactions
-     * @param admin Admin of the contract
-     * @param royaltyManager address of the manager contract for common royalty recipient
-     * @param newOwner address of new owner
-     * @param version version number to which Land contract is being upgraded
-     */
-    function initialize(
-        address metaTransactionContract,
-        address admin,
-        address royaltyManager,
-        address newOwner,
-        uint8 version
-    ) public reinitializer(version) {
-        _admin = admin;
-        _setMetaTransactionProcessor(metaTransactionContract, true);
-        _setRoyaltyManager(royaltyManager);
-        _transferOwnership(newOwner);
-        emit AdminChanged(address(0), _admin);
-    }
 
     /**
      * @notice Return the name of the token contract
@@ -94,8 +60,6 @@ contract Land is LandStorageMixin, LandBaseToken, OperatorFiltererUpgradeable {
         return string(bstr);
     }
 
-    /// @notice set royalty manager
-    /// @param royaltyManager address of royalty manager to set
     function _setRoyaltyManager(address royaltyManager) internal {
         _royaltyManager = IRoyaltyManager(royaltyManager);
         emit RoyaltyManagerSet(royaltyManager);
@@ -175,6 +139,12 @@ contract Land is LandStorageMixin, LandBaseToken, OperatorFiltererUpgradeable {
     /// @return ownerAddress The address of the owner.
     function owner() external view returns (address ownerAddress) {
         return _owner;
+    }
+
+    /// @notice set royalty manager
+    /// @param royaltyManager address of the manager contract for common royalty recipient
+    function setRoyaltyManager(address royaltyManager) external onlyAdmin {
+        _setRoyaltyManager(royaltyManager);
     }
 
     /// @notice Set the address of the new owner of the contract

--- a/packages/land/contracts/PolygonLand.sol
+++ b/packages/land/contracts/PolygonLand.sol
@@ -25,30 +25,6 @@ contract PolygonLand is PolygonLandStorageMixin, PolygonLandBaseToken, ERC2771Ha
     event RoyaltyManagerSet(address indexed royaltyManager);
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
-    /**
-     * @notice Initializes the contract with the trustedForwarder, admin & royalty-manager
-     * @param trustedForwarder TrustedForwarder address
-     * @param admin Admin of the contract
-     * @param royaltyManager address of the manager contract for common royalty recipient
-     * @param newOwner address of new owner
-     * @param version version number to which PolygonLand contract is being upgraded
-     */
-    function initialize(
-        address trustedForwarder,
-        address admin,
-        address royaltyManager,
-        address newOwner,
-        uint8 version
-    ) external reinitializer(version) {
-        _admin = admin;
-        __ERC2771Handler_initialize(trustedForwarder);
-        _setRoyaltyManager(royaltyManager);
-        _transferOwnership(newOwner);
-        emit AdminChanged(address(0), _admin);
-    }
-
-    /// @notice set royalty manager
-    /// @param royaltyManager address of royalty manager to set
     function _setRoyaltyManager(address royaltyManager) internal {
         _royaltyManager = IRoyaltyManager(royaltyManager);
         emit RoyaltyManagerSet(royaltyManager);
@@ -91,6 +67,12 @@ contract PolygonLand is PolygonLandStorageMixin, PolygonLandBaseToken, ERC2771Ha
     /// @return ownerAddress The address of the owner.
     function owner() external view returns (address ownerAddress) {
         return _owner;
+    }
+
+    /// @notice set royalty manager
+    /// @param royaltyManager address of the manager contract for common royalty recipient
+    function setRoyaltyManager(address royaltyManager) external onlyAdmin {
+        _setRoyaltyManager(royaltyManager);
     }
 
     /// @notice Set the address of the new owner of the contract

--- a/packages/land/contracts/PolygonLand.sol
+++ b/packages/land/contracts/PolygonLand.sol
@@ -25,6 +25,15 @@ contract PolygonLand is PolygonLandStorageMixin, PolygonLandBaseToken, ERC2771Ha
     event RoyaltyManagerSet(address indexed royaltyManager);
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
+    /**
+     * @notice Initializes the contract with the admin
+     * @param admin Admin of the contract
+     */
+    function initialize(address admin) external initializer {
+        _admin = admin;
+        emit AdminChanged(address(0), _admin);
+    }
+
     /// @dev Change the address of the trusted forwarder for meta-TX
     /// @param trustedForwarder The new trustedForwarder
     function setTrustedForwarder(address trustedForwarder) external onlyAdmin {

--- a/packages/land/contracts/PolygonLand.sol
+++ b/packages/land/contracts/PolygonLand.sol
@@ -25,21 +25,39 @@ contract PolygonLand is PolygonLandStorageMixin, PolygonLandBaseToken, ERC2771Ha
     event RoyaltyManagerSet(address indexed royaltyManager);
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
-    function _setRoyaltyManager(address royaltyManager) internal {
-        _royaltyManager = IRoyaltyManager(royaltyManager);
-        emit RoyaltyManagerSet(royaltyManager);
-    }
-
-    function _transferOwnership(address newOwner) internal {
-        emit OwnershipTransferred(_owner, newOwner);
-        _owner = newOwner;
-    }
-
     /// @dev Change the address of the trusted forwarder for meta-TX
     /// @param trustedForwarder The new trustedForwarder
     function setTrustedForwarder(address trustedForwarder) external onlyAdmin {
         _trustedForwarder = trustedForwarder;
         emit TrustedForwarderSet(trustedForwarder);
+    }
+
+    /// @notice set royalty manager
+    /// @param royaltyManager address of the manager contract for common royalty recipient
+    function setRoyaltyManager(address royaltyManager) external onlyAdmin {
+        _setRoyaltyManager(royaltyManager);
+    }
+
+    /// @notice Set the address of the new owner of the contract
+    /// @param newOwner address of new owner
+    function transferOwnership(address newOwner) external onlyAdmin {
+        _transferOwnership(newOwner);
+    }
+
+    /// @notice This function is used to register Land contract on the Operator Filterer Registry of Opensea.
+    /// @dev can only be called by admin.
+    /// @param subscriptionOrRegistrantToCopy registration address of the list to subscribe.
+    /// @param subscribe bool to signify subscription 'true' or to copy the list 'false'.
+    function register(address subscriptionOrRegistrantToCopy, bool subscribe) external onlyAdmin {
+        require(subscriptionOrRegistrantToCopy != address(0), "subscription can't be zero");
+        _register(subscriptionOrRegistrantToCopy, subscribe);
+    }
+
+    /// @notice sets filter registry address deployed in test
+    /// @param registry the address of the registry
+    function setOperatorRegistry(address registry) external virtual onlyAdmin {
+        operatorFilterRegistry = IOperatorFilterRegistry(registry);
+        emit OperatorRegistrySet(registry);
     }
 
     /// @notice Returns how much royalty is owed and to whom based on ERC2981
@@ -67,26 +85,6 @@ contract PolygonLand is PolygonLandStorageMixin, PolygonLandBaseToken, ERC2771Ha
     /// @return ownerAddress The address of the owner.
     function owner() external view returns (address ownerAddress) {
         return _owner;
-    }
-
-    /// @notice set royalty manager
-    /// @param royaltyManager address of the manager contract for common royalty recipient
-    function setRoyaltyManager(address royaltyManager) external onlyAdmin {
-        _setRoyaltyManager(royaltyManager);
-    }
-
-    /// @notice Set the address of the new owner of the contract
-    /// @param newOwner address of new owner
-    function transferOwnership(address newOwner) external onlyAdmin {
-        _transferOwnership(newOwner);
-    }
-
-    function _msgSender() internal view override(ContextUpgradeable, ERC2771Handler) returns (address) {
-        return ERC2771Handler._msgSender();
-    }
-
-    function _msgData() internal view override(ContextUpgradeable, ERC2771Handler) returns (bytes calldata) {
-        return ERC2771Handler._msgData();
     }
 
     /**
@@ -189,19 +187,21 @@ contract PolygonLand is PolygonLandStorageMixin, PolygonLandBaseToken, ERC2771Ha
             id == type(IERC2981Upgradeable).interfaceId;
     }
 
-    /// @notice This function is used to register Land contract on the Operator Filterer Registry of Opensea.
-    /// @dev can only be called by admin.
-    /// @param subscriptionOrRegistrantToCopy registration address of the list to subscribe.
-    /// @param subscribe bool to signify subscription 'true' or to copy the list 'false'.
-    function register(address subscriptionOrRegistrantToCopy, bool subscribe) external onlyAdmin {
-        require(subscriptionOrRegistrantToCopy != address(0), "subscription can't be zero");
-        _register(subscriptionOrRegistrantToCopy, subscribe);
+    function _setRoyaltyManager(address royaltyManager) internal {
+        _royaltyManager = IRoyaltyManager(royaltyManager);
+        emit RoyaltyManagerSet(royaltyManager);
     }
 
-    /// @notice sets filter registry address deployed in test
-    /// @param registry the address of the registry
-    function setOperatorRegistry(address registry) external virtual onlyAdmin {
-        operatorFilterRegistry = IOperatorFilterRegistry(registry);
-        emit OperatorRegistrySet(registry);
+    function _transferOwnership(address newOwner) internal {
+        emit OwnershipTransferred(_owner, newOwner);
+        _owner = newOwner;
+    }
+
+    function _msgSender() internal view override(ContextUpgradeable, ERC2771Handler) returns (address) {
+        return ERC2771Handler._msgSender();
+    }
+
+    function _msgData() internal view override(ContextUpgradeable, ERC2771Handler) returns (bytes calldata) {
+        return ERC2771Handler._msgData();
     }
 }

--- a/packages/land/contracts/mock/LandMock.sol
+++ b/packages/land/contracts/mock/LandMock.sol
@@ -5,13 +5,6 @@ pragma solidity 0.8.23;
 import {Land} from "../Land.sol";
 
 contract LandMock is Land {
-    /// @notice Set admin adress
-    /// @param admin Admin of the contract
-    function setAdmin(address admin) external {
-        _admin = admin;
-        emit AdminChanged(address(0), _admin);
-    }
-
     struct VarsStorage {
         uint256 _admin;
         uint256 _superOperators;

--- a/packages/land/contracts/mock/LandMock.sol
+++ b/packages/land/contracts/mock/LandMock.sol
@@ -5,19 +5,11 @@ pragma solidity 0.8.23;
 import {Land} from "../Land.sol";
 
 contract LandMock is Land {
-    /// @notice sets Approvals with operator filterer check in case to test the transfer.
-    /// @param operator address of the operator to be approved
-    /// @param approved bool value denoting approved (true) or not Approved(false)
-    function setApprovalForAllWithOutFilter(address operator, bool approved) external {
-        super._setApprovalForAll(msg.sender, operator, approved);
-    }
-
-    /// @notice This function is used to register Land contract on the Operator Filterer Registry of Opensea.can only be called by admin.
-    /// @dev used to register contract and subscribe to the subscriptionOrRegistrantToCopy's black list.
-    /// @param subscriptionOrRegistrantToCopy registration address of the list to subscribe.
-    /// @param subscribe bool to signify subscription "true"" or to copy the list "false".
-    function registerFilterer(address subscriptionOrRegistrantToCopy, bool subscribe) external {
-        _register(subscriptionOrRegistrantToCopy, subscribe);
+    /// @notice Set admin adress
+    /// @param admin Admin of the contract
+    function setAdmin(address admin) external {
+        _admin = admin;
+        emit AdminChanged(address(0), _admin);
     }
 
     struct VarsStorage {

--- a/packages/land/contracts/mock/LandMockWithoutCheck.sol
+++ b/packages/land/contracts/mock/LandMockWithoutCheck.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.23;
+
+import {Land} from "../Land.sol";
+
+contract LandMockWithoutCheck is Land {
+    /// @notice Set admin adress
+    /// @param admin Admin of the contract
+    function setAdmin(address admin) external {
+        _admin = admin;
+        emit AdminChanged(address(0), _admin);
+    }
+
+    /// @notice sets Approvals with operator filterer check in case to test the transfer.
+    /// @param operator address of the operator to be approved
+    /// @param approved bool value denoting approved (true) or not Approved(false)
+    function setApprovalForAllWithOutFilter(address operator, bool approved) external {
+        super._setApprovalForAll(msg.sender, operator, approved);
+    }
+
+    /**
+     * @notice Mint a new quad (aligned to a quad tree with size 1, 3, 6, 12 or 24 only)
+     * @param to The recipient of the new quad
+     * @param size The size of the new quad
+     * @param x The top left x coordinate of the new quad
+     * @param y The top left y coordinate of the new quad
+     * @param data extra data to pass to the transfer
+     */
+    function mintQuadWithOutMinterCheck(address to, uint256 size, uint256 x, uint256 y, bytes calldata data) external {
+        require(to != address(0), "to is zero address");
+        require(x % size == 0 && y % size == 0, "Invalid coordinates");
+        require(x <= GRID_SIZE - size && y <= GRID_SIZE - size, "Out of bounds");
+
+        (uint256 layer, , ) = _getQuadLayer(size);
+        uint256 quadId = _getQuadId(layer, x, y);
+
+        _checkOwner(size, x, y, 24);
+        for (uint256 i = 0; i < size * size; i++) {
+            uint256 _id = _idInPath(i, size, x, y);
+            require(_owners[_id] == 0, "Already minted");
+            emit Transfer(address(0), to, _id);
+        }
+
+        _owners[quadId] = uint160(to);
+        _numNFTPerAddress[to] += size * size;
+
+        _checkBatchReceiverAcceptQuad(msg.sender, address(0), to, size, x, y, data);
+    }
+
+    /// @notice This function is used to register Land contract on the Operator Filterer Registry of Opensea.can only be called by admin.
+    /// @dev used to register contract and subscribe to the subscriptionOrRegistrantToCopy's black list.
+    /// @param subscriptionOrRegistrantToCopy registration address of the list to subscribe.
+    /// @param subscribe bool to signify subscription "true"" or to copy the list "false".
+    function registerFilterer(address subscriptionOrRegistrantToCopy, bool subscribe) external {
+        _register(subscriptionOrRegistrantToCopy, subscribe);
+    }
+}

--- a/packages/land/contracts/mock/LandMockWithoutCheck.sol
+++ b/packages/land/contracts/mock/LandMockWithoutCheck.sol
@@ -5,13 +5,6 @@ pragma solidity 0.8.23;
 import {Land} from "../Land.sol";
 
 contract LandMockWithoutCheck is Land {
-    /// @notice Set admin adress
-    /// @param admin Admin of the contract
-    function setAdmin(address admin) external {
-        _admin = admin;
-        emit AdminChanged(address(0), _admin);
-    }
-
     /// @notice sets Approvals with operator filterer check in case to test the transfer.
     /// @param operator address of the operator to be approved
     /// @param approved bool value denoting approved (true) or not Approved(false)

--- a/packages/land/contracts/mock/PolygonLandMock.sol
+++ b/packages/land/contracts/mock/PolygonLandMock.sol
@@ -2,42 +2,14 @@
 
 pragma solidity 0.8.23;
 
-import {IOperatorFilterRegistry} from "../common/IOperatorFilterRegistry.sol";
 import {PolygonLand} from "../PolygonLand.sol";
 
 contract PolygonLandMock is PolygonLand {
-    /// @notice sets filter registry address deployed in test
-    /// @param registry the address of the registry
-    function setOperatorRegistry(address registry) external override {
-        operatorFilterRegistry = IOperatorFilterRegistry(registry);
-        emit OperatorRegistrySet(registry);
-    }
-
-    /// @notice sets Approvals with operator filterer check in case to test the transfer.
-    /// @param operator address of the operator to be approved
-    /// @param approved bool value denoting approved (true) or not Approved(false)
-    function setApprovalForAllWithOutFilter(address operator, bool approved) external {
-        super._setApprovalForAll(msg.sender, operator, approved);
-    }
-
-    /**
-     * @notice Mint a new quad without a minter (aligned to a quad tree with size 1, 3, 6, 12 or 24 only)
-     * @param user The recipient of the new quad
-     * @param size The size of the new quad
-     * @param x The top left x coordinate of the new quad
-     * @param y The top left y coordinate of the new quad
-     * @param data extra data to pass to the transfer
-     */
-    function mintQuad(address user, uint256 size, uint256 x, uint256 y, bytes memory data) external override {
-        _mintQuad(user, size, x, y, data);
-    }
-
-    /// @notice This function is used to register Land contract on the Operator Filterer Registry of Opensea.can only be called by admin.
-    /// @dev used to register contract and subscribe to the subscriptionOrRegistrantToCopy's black list.
-    /// @param subscriptionOrRegistrantToCopy registration address of the list to subscribe.
-    /// @param subscribe bool to signify subscription "true"" or to copy the list "false".
-    function registerFilterer(address subscriptionOrRegistrantToCopy, bool subscribe) external {
-        _register(subscriptionOrRegistrantToCopy, subscribe);
+    /// @notice Set admin adress
+    /// @param admin Admin of the contract
+    function setAdmin(address admin) external {
+        _admin = admin;
+        emit AdminChanged(address(0), _admin);
     }
 
     struct VarsStorage {

--- a/packages/land/contracts/mock/PolygonLandMock.sol
+++ b/packages/land/contracts/mock/PolygonLandMock.sol
@@ -5,13 +5,6 @@ pragma solidity 0.8.23;
 import {PolygonLand} from "../PolygonLand.sol";
 
 contract PolygonLandMock is PolygonLand {
-    /// @notice Set admin adress
-    /// @param admin Admin of the contract
-    function setAdmin(address admin) external {
-        _admin = admin;
-        emit AdminChanged(address(0), _admin);
-    }
-
     struct VarsStorage {
         uint256 _admin;
         uint256 _superOperators;

--- a/packages/land/contracts/mock/PolygonLandWithoutCheck.sol
+++ b/packages/land/contracts/mock/PolygonLandWithoutCheck.sol
@@ -2,7 +2,7 @@
 
 pragma solidity 0.8.23;
 
-import {IOperatorFilterRegistry} from "../polygon/IOperatorFilterRegistry.sol";
+import {IOperatorFilterRegistry} from "../common/IOperatorFilterRegistry.sol";
 import {PolygonLand} from "../PolygonLand.sol";
 
 contract PolygonLandMockWithoutCheck is PolygonLand {

--- a/packages/land/contracts/mock/PolygonLandWithoutCheck.sol
+++ b/packages/land/contracts/mock/PolygonLandWithoutCheck.sol
@@ -6,13 +6,6 @@ import {IOperatorFilterRegistry} from "../common/IOperatorFilterRegistry.sol";
 import {PolygonLand} from "../PolygonLand.sol";
 
 contract PolygonLandMockWithoutCheck is PolygonLand {
-    /// @notice Set admin adress
-    /// @param admin Admin of the contract
-    function setAdmin(address admin) external {
-        _admin = admin;
-        emit AdminChanged(address(0), _admin);
-    }
-
     /// @notice sets filter registry address deployed in test
     /// @param registry the address of the registry
     function setOperatorRegistry(address registry) external override {

--- a/packages/land/contracts/mock/PolygonLandWithoutCheck.sol
+++ b/packages/land/contracts/mock/PolygonLandWithoutCheck.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.23;
+
+import {IOperatorFilterRegistry} from "../polygon/IOperatorFilterRegistry.sol";
+import {PolygonLand} from "../PolygonLand.sol";
+
+contract PolygonLandMockWithoutCheck is PolygonLand {
+    /// @notice Set admin adress
+    /// @param admin Admin of the contract
+    function setAdmin(address admin) external {
+        _admin = admin;
+        emit AdminChanged(address(0), _admin);
+    }
+
+    /// @notice sets filter registry address deployed in test
+    /// @param registry the address of the registry
+    function setOperatorRegistry(address registry) external override {
+        operatorFilterRegistry = IOperatorFilterRegistry(registry);
+    }
+
+    /// @notice sets Approvals with operator filterer check in case to test the transfer.
+    /// @param operator address of the operator to be approved
+    /// @param approved bool value denoting approved (true) or not Approved(false)
+    function setApprovalForAllWithOutFilter(address operator, bool approved) external {
+        super._setApprovalForAll(msg.sender, operator, approved);
+    }
+
+    /**
+     * @notice Mint a new quad without a minter (aligned to a quad tree with size 1, 3, 6, 12 or 24 only)
+     * @param user The recipient of the new quad
+     * @param size The size of the new quad
+     * @param x The top left x coordinate of the new quad
+     * @param y The top left y coordinate of the new quad
+     * @param data extra data to pass to the transfer
+     */
+    function mintQuad(address user, uint256 size, uint256 x, uint256 y, bytes memory data) external override {
+        _mintQuad(user, size, x, y, data);
+    }
+
+    /// @notice This function is used to register Land contract on the Operator Filterer Registry of Opensea.can only be called by admin.
+    /// @dev used to register contract and subscribe to the subscriptionOrRegistrantToCopy's black list.
+    /// @param subscriptionOrRegistrantToCopy registration address of the list to subscribe.
+    /// @param subscribe bool to signify subscription "true"" or to copy the list "false".
+    function registerFilterer(address subscriptionOrRegistrantToCopy, bool subscribe) external {
+        _register(subscriptionOrRegistrantToCopy, subscribe);
+    }
+}

--- a/packages/land/hardhat.config.ts
+++ b/packages/land/hardhat.config.ts
@@ -23,9 +23,5 @@ const config: HardhatUserConfig = {
   mocha: {
     ...(!process.env.CI ? {} : {invert: true, grep: '@skip-on-ci'}),
   },
-  // TODO: Remove or at least check that the only contracts over the max size are mocks.
-  networks: {
-    hardhat: {allowUnlimitedContractSize: true},
-  },
 };
 export default config;

--- a/packages/land/hardhat.config.ts
+++ b/packages/land/hardhat.config.ts
@@ -23,5 +23,9 @@ const config: HardhatUserConfig = {
   mocha: {
     ...(!process.env.CI ? {} : {invert: true, grep: '@skip-on-ci'}),
   },
+  // TODO: Remove or at least check that the only contracts over the max size are mocks.
+  networks: {
+    hardhat: {allowUnlimitedContractSize: true},
+  },
 };
 export default config;

--- a/packages/land/test/fixtures.ts
+++ b/packages/land/test/fixtures.ts
@@ -96,16 +96,10 @@ export async function setupLandContract() {
     await ethers.getContractFactory('ContractMock');
   const MetaTransactionContract = await MetaTransactionContractFactory.deploy();
 
-  const LandFactory = await ethers.getContractFactory('Land');
+  const LandFactory = await ethers.getContractFactory('LandMock');
   const LandContract = await LandFactory.deploy();
 
-  await LandContract.initialize(
-    await MetaTransactionContract.getAddress(),
-    await landAdmin.getAddress(),
-    await RoyaltyManagerContract.getAddress(),
-    await landOwner.getAddress(),
-    4,
-  );
+  await LandContract.setAdmin(landAdmin);
 
   // deploy mocks
   const TestERC721TokenReceiverFactory = await ethers.getContractFactory(
@@ -133,6 +127,10 @@ export async function setupLandContract() {
   const LandAsOther2 = LandContract.connect(other2);
 
   await TestERC721TokenReceiver.setTokenContract(LandAsOther);
+  await LandAsAdmin.transferOwnership(await landOwner.getAddress());
+  await LandAsAdmin.setRoyaltyManager(
+    await RoyaltyManagerContract.getAddress(),
+  );
   await LandAsAdmin.setMetaTransactionProcessor(MetaTransactionContract, false);
   const managerAsRoyaltySetter = RoyaltyManagerContract.connect(
     contractRoyaltySetter,
@@ -224,16 +222,10 @@ export async function setupLandOperatorFilter() {
     await ethers.getContractFactory('ContractMock');
   const MetaTransactionContract = await MetaTransactionContractFactory.deploy();
 
-  const LandFactory = await ethers.getContractFactory('LandMock');
+  const LandFactory = await ethers.getContractFactory('LandMockWithoutCheck');
   const LandContract = await LandFactory.deploy();
 
-  await LandContract.initialize(
-    await MetaTransactionContract.getAddress(),
-    await landAdmin.getAddress(),
-    await RoyaltyManagerContract.getAddress(),
-    await landOwner.getAddress(),
-    4,
-  );
+  await LandContract.setAdmin(landAdmin);
 
   const LandAsAdmin = LandContract.connect(landAdmin);
   await LandAsAdmin.setMinter(await landMinter.getAddress(), true);
@@ -242,13 +234,7 @@ export async function setupLandOperatorFilter() {
   const LandAsOther = LandContract.connect(other);
   const LandAsOther1 = LandContract.connect(other1);
   const LandMockContract = await LandFactory.deploy();
-  await LandMockContract.initialize(
-    await MetaTransactionContract.getAddress(),
-    await landAdmin.getAddress(),
-    await RoyaltyManagerContract.getAddress(),
-    await landOwner.getAddress(),
-    4,
-  );
+  await LandMockContract.setAdmin(landAdmin);
 
   const MarketPlaceToFilterMockFactory = await ethers.getContractFactory(
     'MarketPlaceToFilterMock',
@@ -273,6 +259,10 @@ export async function setupLandOperatorFilter() {
     defaultSubscription,
   );
 
+  await LandAsAdmin.transferOwnership(await landOwner.getAddress());
+  await LandAsAdmin.setRoyaltyManager(
+    await RoyaltyManagerContract.getAddress(),
+  );
   await LandAsAdmin.setOperatorRegistry(OperatorFilterRegistry);
   await LandAsAdmin.register(operatorFilterSubscription, true);
 
@@ -351,20 +341,10 @@ export async function setupPolygonLandContract() {
   const TrustedForwarderContract =
     await TrustedForwarderContractFactory.deploy();
 
-  const PolygonLandFactory = await ethers.getContractFactory('PolygonLand');
-  const PolygonLandContract = await upgrades.deployProxy(
-    PolygonLandFactory,
-    [
-      await TrustedForwarderContract.getAddress(),
-      await landAdmin.getAddress(),
-      await RoyaltyManagerContract.getAddress(),
-      await landOwner.getAddress(),
-      3,
-    ],
-    {
-      initializer: 'initialize',
-    },
-  );
+  const PolygonLandFactory = await ethers.getContractFactory('PolygonLandMock');
+  const PolygonLandContract = await PolygonLandFactory.deploy();
+
+  await PolygonLandContract.setAdmin(landAdmin);
 
   // mock contract deploy
   const TestERC721TokenReceiverFactory = await ethers.getContractFactory(
@@ -388,6 +368,15 @@ export async function setupPolygonLandContract() {
 
   // setup role
   const LandAsAdmin = PolygonLandContract.connect(landAdmin);
+
+  await LandAsAdmin.setTrustedForwarder(
+    await TrustedForwarderContract.getAddress(),
+  );
+
+  await LandAsAdmin.transferOwnership(await landOwner.getAddress());
+  await LandAsAdmin.setRoyaltyManager(
+    await RoyaltyManagerContract.getAddress(),
+  );
   await PolygonLandContract.connect(landAdmin).setMinter(
     await landMinter.getAddress(),
     true,
@@ -485,22 +474,23 @@ export async function setupPolygonLandOperatorFilter() {
   const TrustedForwarderContract =
     await TrustedForwarderContractFactory.deploy();
 
-  const PolygonLandFactory = await ethers.getContractFactory('PolygonLandMock');
-  const PolygonLandContract = await upgrades.deployProxy(
-    PolygonLandFactory,
-    [
-      await TrustedForwarderContract.getAddress(),
-      await landAdmin.getAddress(),
-      await RoyaltyManagerContract.getAddress(),
-      await landOwner.getAddress(),
-      4,
-    ],
-    {
-      initializer: 'initialize',
-    },
+  const PolygonLandFactory = await ethers.getContractFactory(
+    'PolygonLandMockWithoutCheck',
   );
+  const PolygonLandContract = await PolygonLandFactory.deploy();
+
+  await PolygonLandContract.setAdmin(landAdmin);
 
   const LandAsAdmin = PolygonLandContract.connect(landAdmin);
+  await LandAsAdmin.setTrustedForwarder(
+    await TrustedForwarderContract.getAddress(),
+  );
+
+  await LandAsAdmin.transferOwnership(await landOwner.getAddress());
+  await LandAsAdmin.setRoyaltyManager(
+    await RoyaltyManagerContract.getAddress(),
+  );
+
   const LandAsOther = PolygonLandContract.connect(other);
   const LandAsOther1 = PolygonLandContract.connect(other1);
   const MarketPlaceToFilterMockFactory = await ethers.getContractFactory(
@@ -529,19 +519,8 @@ export async function setupPolygonLandOperatorFilter() {
   await LandAsAdmin.setOperatorRegistry(OperatorFilterRegistry);
   await LandAsAdmin.register(operatorFilterSubscription, true);
 
-  const PolygonLandMockContract = await upgrades.deployProxy(
-    PolygonLandFactory,
-    [
-      await TrustedForwarderContract.getAddress(),
-      await landAdmin.getAddress(),
-      await RoyaltyManagerContract.getAddress(),
-      await landOwner.getAddress(),
-      4,
-    ],
-    {
-      initializer: 'initialize',
-    },
-  );
+  const PolygonLandMockContract = await PolygonLandFactory.deploy();
+  await PolygonLandMockContract.setAdmin(landAdmin);
   const LandRegistryNotSetAsDeployer =
     PolygonLandMockContract.connect(deployer);
   const LandRegistryNotSetAsAdmin = PolygonLandMockContract.connect(landAdmin);

--- a/packages/land/test/fixtures.ts
+++ b/packages/land/test/fixtures.ts
@@ -99,7 +99,7 @@ export async function setupLandContract() {
   const LandFactory = await ethers.getContractFactory('LandMock');
   const LandContract = await LandFactory.deploy();
 
-  await LandContract.setAdmin(landAdmin);
+  await LandContract.initialize(await landAdmin.getAddress());
 
   // deploy mocks
   const TestERC721TokenReceiverFactory = await ethers.getContractFactory(
@@ -225,7 +225,7 @@ export async function setupLandOperatorFilter() {
   const LandFactory = await ethers.getContractFactory('LandMockWithoutCheck');
   const LandContract = await LandFactory.deploy();
 
-  await LandContract.setAdmin(landAdmin);
+  await LandContract.initialize(await landAdmin.getAddress());
 
   const LandAsAdmin = LandContract.connect(landAdmin);
   await LandAsAdmin.setMinter(await landMinter.getAddress(), true);
@@ -234,7 +234,7 @@ export async function setupLandOperatorFilter() {
   const LandAsOther = LandContract.connect(other);
   const LandAsOther1 = LandContract.connect(other1);
   const LandMockContract = await LandFactory.deploy();
-  await LandMockContract.setAdmin(landAdmin);
+  await LandMockContract.initialize(await landAdmin.getAddress());
 
   const MarketPlaceToFilterMockFactory = await ethers.getContractFactory(
     'MarketPlaceToFilterMock',
@@ -342,9 +342,13 @@ export async function setupPolygonLandContract() {
     await TrustedForwarderContractFactory.deploy();
 
   const PolygonLandFactory = await ethers.getContractFactory('PolygonLandMock');
-  const PolygonLandContract = await PolygonLandFactory.deploy();
-
-  await PolygonLandContract.setAdmin(landAdmin);
+  const PolygonLandContract = await upgrades.deployProxy(
+    PolygonLandFactory,
+    [await landAdmin.getAddress()],
+    {
+      initializer: 'initialize',
+    },
+  );
 
   // mock contract deploy
   const TestERC721TokenReceiverFactory = await ethers.getContractFactory(
@@ -477,9 +481,13 @@ export async function setupPolygonLandOperatorFilter() {
   const PolygonLandFactory = await ethers.getContractFactory(
     'PolygonLandMockWithoutCheck',
   );
-  const PolygonLandContract = await PolygonLandFactory.deploy();
-
-  await PolygonLandContract.setAdmin(landAdmin);
+  const PolygonLandContract = await upgrades.deployProxy(
+    PolygonLandFactory,
+    [await landAdmin.getAddress()],
+    {
+      initializer: 'initialize',
+    },
+  );
 
   const LandAsAdmin = PolygonLandContract.connect(landAdmin);
   await LandAsAdmin.setTrustedForwarder(
@@ -519,8 +527,14 @@ export async function setupPolygonLandOperatorFilter() {
   await LandAsAdmin.setOperatorRegistry(OperatorFilterRegistry);
   await LandAsAdmin.register(operatorFilterSubscription, true);
 
-  const PolygonLandMockContract = await PolygonLandFactory.deploy();
-  await PolygonLandMockContract.setAdmin(landAdmin);
+  const PolygonLandMockContract = await upgrades.deployProxy(
+    PolygonLandFactory,
+    [await landAdmin.getAddress()],
+    {
+      initializer: 'initialize',
+    },
+  );
+
   const LandRegistryNotSetAsDeployer =
     PolygonLandMockContract.connect(deployer);
   const LandRegistryNotSetAsAdmin = PolygonLandMockContract.connect(landAdmin);

--- a/packages/land/test/mainnet/land.test.ts
+++ b/packages/land/test/mainnet/land.test.ts
@@ -98,37 +98,6 @@ describe('Land.sol', function () {
       });
     });
 
-    it('should return owner address', async function () {
-      const {LandContract, landOwner} = await loadFixture(setupLand);
-      expect(await LandContract.owner()).to.be.equal(
-        await landOwner.getAddress(),
-      );
-    });
-
-    it('should not set owner if caller is not admin', async function () {
-      const {LandAsOther, other} = await loadFixture(setupLand);
-      await expect(
-        LandAsOther.transferOwnership(await other.getAddress()),
-      ).to.be.revertedWith('only admin allowed');
-    });
-
-    it('should emit OwnershipTransferred event', async function () {
-      const {LandAsAdmin, other, landOwner} = await loadFixture(setupLand);
-      const tx = await LandAsAdmin.transferOwnership(await other.getAddress());
-      await expect(tx)
-        .to.emit(LandAsAdmin, 'OwnershipTransferred')
-        .withArgs(await landOwner.getAddress(), await other.getAddress());
-    });
-
-    it('should set owner', async function () {
-      const {LandAsAdmin, other, landOwner} = await loadFixture(setupLand);
-      expect(await LandAsAdmin.owner()).to.be.equal(
-        await landOwner.getAddress(),
-      );
-      await LandAsAdmin.transferOwnership(await other.getAddress());
-      expect(await LandAsAdmin.owner()).to.be.equal(await other.getAddress());
-    });
-
     it(`should revert for invalid size`, async function () {
       const {LandContract} = await loadFixture(setupLand);
       await expect(LandContract.exists(5, 5, 5)).to.be.revertedWith(
@@ -931,6 +900,69 @@ describe('Land.sol', function () {
       ).not.to.be.reverted;
     });
   });
+
+  it('should return royaltyManager address', async function () {
+    const {LandContract, manager} = await loadFixture(setupLand);
+    expect(await LandContract.getRoyaltyManager()).to.be.equal(
+      await manager.getAddress(),
+    );
+  });
+
+  it('should not set royaltyManager if caller is not admin', async function () {
+    const {LandAsOther, other} = await loadFixture(setupLand);
+    await expect(
+      LandAsOther.setRoyaltyManager(await other.getAddress()),
+    ).to.be.revertedWith('only admin allowed');
+  });
+
+  it('should emit RoyaltyManagerSet event', async function () {
+    const {LandAsAdmin, other} = await loadFixture(setupLand);
+    const tx = await LandAsAdmin.setRoyaltyManager(await other.getAddress());
+    await expect(tx)
+      .to.emit(LandAsAdmin, 'RoyaltyManagerSet')
+      .withArgs(await other.getAddress());
+  });
+
+  it('should set royaltyManager', async function () {
+    const {LandAsAdmin, other, manager} = await loadFixture(setupLand);
+    expect(await LandAsAdmin.getRoyaltyManager()).to.be.equal(
+      await manager.getAddress(),
+    );
+    await LandAsAdmin.setRoyaltyManager(await other.getAddress());
+    expect(await LandAsAdmin.getRoyaltyManager()).to.be.equal(
+      await other.getAddress(),
+    );
+  });
+
+  it('should return owner address', async function () {
+    const {LandContract, landOwner} = await loadFixture(setupLand);
+    expect(await LandContract.owner()).to.be.equal(
+      await landOwner.getAddress(),
+    );
+  });
+
+  it('should not set owner if caller is not admin', async function () {
+    const {LandAsOther, other} = await loadFixture(setupLand);
+    await expect(
+      LandAsOther.transferOwnership(await other.getAddress()),
+    ).to.be.revertedWith('only admin allowed');
+  });
+
+  it('should emit OwnershipTransferred event', async function () {
+    const {LandAsAdmin, other, landOwner} = await loadFixture(setupLand);
+    const tx = await LandAsAdmin.transferOwnership(await other.getAddress());
+    await expect(tx)
+      .to.emit(LandAsAdmin, 'OwnershipTransferred')
+      .withArgs(await landOwner.getAddress(), await other.getAddress());
+  });
+
+  it('should set owner', async function () {
+    const {LandAsAdmin, other, landOwner} = await loadFixture(setupLand);
+    expect(await LandAsAdmin.owner()).to.be.equal(await landOwner.getAddress());
+    await LandAsAdmin.transferOwnership(await other.getAddress());
+    expect(await LandAsAdmin.owner()).to.be.equal(await other.getAddress());
+  });
+
   it('check storage structure', async function () {
     const {landContract} = await loadFixture(setupLandMock);
     const slots = await landContract.getStorageStructure();

--- a/packages/land/test/polygon/PolygonLand.test.ts
+++ b/packages/land/test/polygon/PolygonLand.test.ts
@@ -785,6 +785,32 @@ describe('PolygonLand.sol', function () {
     expect(await LandAsMinter.ownerOf(getId(1, 1, 1))).to.be.equal(deployer);
   });
 
+  it('should not set royaltyManager if caller is not admin', async function () {
+    const {LandAsOther, other} = await loadFixture(setupPolygonLand);
+    await expect(
+      LandAsOther.setRoyaltyManager(await other.getAddress()),
+    ).to.be.revertedWith('ADMIN_ONLY');
+  });
+
+  it('should emit RoyaltyManagerSet event', async function () {
+    const {LandAsAdmin, other} = await loadFixture(setupPolygonLand);
+    const tx = await LandAsAdmin.setRoyaltyManager(await other.getAddress());
+    await expect(tx)
+      .to.emit(LandAsAdmin, 'RoyaltyManagerSet')
+      .withArgs(await other.getAddress());
+  });
+
+  it('should set royaltyManager', async function () {
+    const {LandAsAdmin, other, manager} = await loadFixture(setupPolygonLand);
+    expect(await LandAsAdmin.getRoyaltyManager()).to.be.equal(
+      await manager.getAddress(),
+    );
+    await LandAsAdmin.setRoyaltyManager(await other.getAddress());
+    expect(await LandAsAdmin.getRoyaltyManager()).to.be.equal(
+      await other.getAddress(),
+    );
+  });
+
   it('should not set owner if caller is not admin', async function () {
     const {LandAsOther, other} = await loadFixture(setupPolygonLand);
     await expect(
@@ -1546,6 +1572,14 @@ describe('PolygonLand.sol', function () {
         await loadFixture(setupPolygonLand);
       expect(await PolygonLandContract.owner()).to.be.equal(
         await landOwner.getAddress(),
+      );
+    });
+
+    it('should return royaltyManager address', async function () {
+      const {PolygonLandContract, manager} =
+        await loadFixture(setupPolygonLand);
+      expect(await PolygonLandContract.getRoyaltyManager()).to.be.equal(
+        await manager.getAddress(),
       );
     });
 


### PR DESCRIPTION
## Description

-  Removed `reinitializer` from Land and PolygonLand

- Added test cases as required

- Added new Mocks for testing 

- Initial Contract size 

>  `Land` : 23.695 kb , `PolygonLand` : 23.626 kb
 
- Updated Contract size 

>  `Land` : 23.453 kb , `PolygonLand` : 23.576 kb