### PR TITLE
fix: rm unused config overrides for deleted contracts

### DIFF
--- a/packages/core/hardhat.config.ts
+++ b/packages/core/hardhat.config.ts
@@ -68,44 +68,6 @@ const config: HardhatUserConfig = {
         },
       },
     ],
-    overrides: {
-      'src/solc_0.8/polygon/child/asset/PolygonAssetV2.sol': {
-        version: '0.8.2',
-        settings: {
-          optimizer: {
-            enabled: true,
-            runs: 0,
-          },
-        },
-      },
-      'src/solc_0.8/asset/AssetV2.sol': {
-        version: '0.8.2',
-        settings: {
-          optimizer: {
-            enabled: true,
-            runs: 100,
-          },
-        },
-      },
-      'src/solc_0.8/polygon/child/asset/PolygonAssetERC1155.sol:PolygonAssetERC1155': {
-        version: '0.8.2',
-        settings: {
-          optimizer: {
-            enabled: true,
-            runs: 0,
-          },
-        },
-      },
-      'src/solc_0.8/assetERC1155/AssetERC1155.sol:AssetERC1155': {
-        version: '0.8.2',
-        settings: {
-          optimizer: {
-            enabled: true,
-            runs: 0,
-          },
-        },
-      },
-    },
   },
   namedAccounts: {
     deployer: {


### PR DESCRIPTION
Remove unused optimizer runs overrides from hardhat.config in `packages/core` for deleted contracts