### PR TITLE
feat: move getApproved to common

### DIFF
--- a/packages/land/contracts/mainnet/ERC721BaseToken.sol
+++ b/packages/land/contracts/mainnet/ERC721BaseToken.sol
@@ -25,19 +25,6 @@ abstract contract ERC721BaseToken is ERC721BaseTokenCommon {
     }
 
     /**
-     * @param id Token id
-     * @return owner Address of the token's owner
-     * @return operatorEnabled Is he an operator
-     */
-    function _ownerAndOperatorEnabledOf(
-        uint256 id
-    ) internal view virtual returns (address owner, bool operatorEnabled) {
-        uint256 data = _getOwnerData(id);
-        owner = address(uint160(data));
-        operatorEnabled = (data / 2 ** 255) == 1;
-    }
-
-    /**
      * @param owner The address giving the approval
      * @param operator The address receiving the approval
      * @param id The id of the token
@@ -79,21 +66,6 @@ abstract contract ERC721BaseToken is ERC721BaseTokenCommon {
         require(owner != address(0), "token does not exist");
         require(owner == msgSender || _isApprovedForAll(owner, msgSender), "not authorized to approve");
         _approveFor(owner, operator, id);
-    }
-
-    /**
-     * @notice Get the approved operator for a specific token
-     * @param id The id of the token
-     * @return The address of the operator
-     */
-    function getApproved(uint256 id) external view returns (address) {
-        (address owner, bool operatorEnabled) = _ownerAndOperatorEnabledOf(id);
-        require(owner != address(0), "token does not exist");
-        if (operatorEnabled) {
-            return _getOperator(id);
-        } else {
-            return address(0);
-        }
     }
 
     /**

--- a/packages/land/contracts/mainnet/LandBaseToken.sol
+++ b/packages/land/contracts/mainnet/LandBaseToken.sol
@@ -677,16 +677,6 @@ abstract contract LandBaseToken is ERC721BaseToken {
         }
     }
 
-    /// @param id quad id
-    /// @return address of the owner
-    function _ownerOf(uint256 id) internal view override returns (address) {
-        require(id & LAYER == 0, "Invalid token id");
-        (uint256 size, uint256 x, uint256 y) = _getQuadById(id);
-        require(x % size == 0, "x coordinate: Invalid token id");
-        require(y % size == 0, "y coordinate: Invalid token id");
-        return _ownerOfQuad(size, x, y);
-    }
-
     /// @param id token id
     /// @return owner owner of the token
     /// @return operatorEnabled is operator enabled

--- a/packages/land/contracts/polygon/ERC721BaseToken.sol
+++ b/packages/land/contracts/polygon/ERC721BaseToken.sol
@@ -99,19 +99,6 @@ abstract contract ERC721BaseToken is ERC721BaseTokenCommon {
         _setApprovalForAll(_msgSender(), operator, approved);
     }
 
-    /// @notice Get the approved operator for a specific token.
-    /// @param id The id of the token.
-    /// @return The address of the operator.
-    function getApproved(uint256 id) external view override returns (address) {
-        (address owner, bool operatorEnabled) = _ownerAndOperatorEnabledOf(id);
-        require(owner != address(0), "NONEXISTENT_TOKEN");
-        if (operatorEnabled) {
-            return _getOperator(id);
-        } else {
-            return address(0);
-        }
-    }
-
     /// @notice Transfer a token between 2 addresses letting the receiver knows of the transfer.
     /// @param from The sender of the token.
     /// @param to The recipient of the token.
@@ -197,22 +184,6 @@ abstract contract ERC721BaseToken is ERC721BaseTokenCommon {
         // record as non owner but keep track of last owner
         _subNumNFTPerAddress(from, 1);
         emit Transfer(from, address(0), id);
-    }
-
-    /// @dev Get the owner and operatorEnabled status of a token.
-    /// @param id The token to query.
-    /// @return owner The owner of the token.
-    /// @return operatorEnabled Whether or not operators are enabled for this token.
-    function _ownerAndOperatorEnabledOf(
-        uint256 id
-    ) internal view virtual returns (address owner, bool operatorEnabled) {
-        uint256 data = _getOwnerData(id);
-        if ((data & BURNED_FLAG) == BURNED_FLAG) {
-            owner = address(0);
-        } else {
-            owner = address(uint160(data));
-        }
-        operatorEnabled = (data & OPERATOR_FLAG) == OPERATOR_FLAG;
     }
 
     /// @dev Check whether a transfer is a meta Transaction or not.

--- a/packages/land/contracts/polygon/PolygonLandBaseToken.sol
+++ b/packages/land/contracts/polygon/PolygonLandBaseToken.sol
@@ -697,18 +697,6 @@ abstract contract PolygonLandBaseToken is IPolygonLand, ERC721BaseToken {
         }
     }
 
-    function _ownerOf(uint256 id) internal view override returns (address) {
-        require(id & LAYER == 0, "Invalid token id");
-        (uint256 size, uint256 x, uint256 y) = _getQuadById(id);
-        require(x % size == 0, "x coordinate: Invalid token id");
-        require(y % size == 0, "y coordinate: Invalid token id");
-        if (size == 1) {
-            uint256 owner1x1 = _getOwnerData(id);
-            return (owner1x1 & BURNED_FLAG) == BURNED_FLAG ? address(0) : _ownerOfQuad(size, x, y);
-        }
-        return _ownerOfQuad(size, x, y);
-    }
-
     function _ownerAndOperatorEnabledOf(
         uint256 id
     ) internal view override returns (address owner, bool operatorEnabled) {

--- a/packages/land/test/common/ERC721.behavior.ts
+++ b/packages/land/test/common/ERC721.behavior.ts
@@ -48,16 +48,16 @@ export function shouldCheckForERC721(
 
       it('tx getApproved a non existing NFT fails', async function () {
         const {LandAsOwner} = await loadFixture(setupLand);
-        await expect(LandAsOwner.getApproved(1000000000)).to.be.revertedWith(
-          errorMessages.NONEXISTENT_TOKEN,
-        );
+        await expect(
+          LandAsOwner.getApproved(1000000000),
+        ).to.be.revertedWithCustomError(LandAsOwner, 'ERC721NonexistentToken');
       });
 
       it('call getApproved a non existing NFT fails', async function () {
         const {LandAsOwner} = await loadFixture(setupLand);
         await expect(
           LandAsOwner.getApproved.staticCall(1000000000),
-        ).to.be.revertedWith(errorMessages.NONEXISTENT_TOKEN);
+        ).to.be.revertedWithCustomError(LandAsOwner, 'ERC721NonexistentToken');
       });
     });
 


### PR DESCRIPTION
## Description
https://internal-jira.atlassian.net/browse/LR-59

There is a slightly difference in _ownerAndOperatorEnabledOf of mainnet we now obey the burned flag and return address(0).

Unified _ownerOf and _ownerAndOperatorEnabledOf (calling one from the other) so we don't need to override the two functions.

