### PR TITLE
feat: refactor from checks in common, public=>external

### DIFF
--- a/packages/land/contracts/Land.sol
+++ b/packages/land/contracts/Land.sol
@@ -66,10 +66,10 @@ contract Land is LandBase, Initializable, WithMetadataRegistry, WithRoyalties, W
      * @notice Transfer a token between 2 addresses letting the receiver knows of the transfer
      * @param from The send of the token
      * @param to The recipient of the token
-     * @param id The id of the token
+     * @param tokenId The id of the token
      */
-    function safeTransferFrom(address from, address to, uint256 id) external override onlyAllowedOperator(from) {
-        super.safeTransferFrom(from, to, id, "");
+    function safeTransferFrom(address from, address to, uint256 tokenId) external override onlyAllowedOperator(from) {
+        _safeTransferFrom(from, to, tokenId, "");
     }
 
     /**
@@ -92,14 +92,14 @@ contract Land is LandBase, Initializable, WithMetadataRegistry, WithRoyalties, W
      * @notice Approve an operator to spend tokens on the sender behalf
      * @param sender The address giving the approval
      * @param operator The address receiving the approval
-     * @param id The id of the token
+     * @param tokenId The id of the token
      */
     function approveFor(
         address sender,
         address operator,
-        uint256 id
-    ) public override onlyAllowedOperatorApproval(operator) {
-        super.approveFor(sender, operator, id);
+        uint256 tokenId
+    ) external override onlyAllowedOperatorApproval(operator) {
+        _approveFor(sender, operator, tokenId);
     }
 
     /**
@@ -107,8 +107,11 @@ contract Land is LandBase, Initializable, WithMetadataRegistry, WithRoyalties, W
      * @param operator The address receiving the approval
      * @param approved The determination of the approval
      */
-    function setApprovalForAll(address operator, bool approved) public override onlyAllowedOperatorApproval(operator) {
-        super._setApprovalForAll(_msgSender(), operator, approved);
+    function setApprovalForAll(
+        address operator,
+        bool approved
+    ) external override onlyAllowedOperatorApproval(operator) {
+        _setApprovalForAll(_msgSender(), operator, approved);
     }
 
     /**
@@ -122,52 +125,53 @@ contract Land is LandBase, Initializable, WithMetadataRegistry, WithRoyalties, W
         address operator,
         bool approved
     ) external override onlyAllowedOperatorApproval(operator) {
-        super._setApprovalForAll(sender, operator, approved);
+        _setApprovalForAll(sender, operator, approved);
     }
 
     /**
      * @notice Approve an operator to spend tokens on the sender behalf
      * @param operator The address receiving the approval
-     * @param id The id of the token
+     * @param tokenId The id of the token
      */
-    function approve(address operator, uint256 id) public override onlyAllowedOperatorApproval(operator) {
-        super.approve(operator, id);
+    function approve(address operator, uint256 tokenId) external override onlyAllowedOperatorApproval(operator) {
+        _approveFor(_msgSender(), operator, tokenId);
     }
 
     /**
      * @notice Transfer a token between 2 addresses
      * @param from The sender of the token
      * @param to The recipient of the token
-     * @param id The id of the token
+     * @param tokenId The id of the token
+     * @dev we decided to use safeTransferFrom even for this method as a security measure
      */
-    function transferFrom(address from, address to, uint256 id) public override onlyAllowedOperator(from) {
-        super.transferFrom(from, to, id);
+    function transferFrom(address from, address to, uint256 tokenId) external override onlyAllowedOperator(from) {
+        _transferFrom(from, to, tokenId);
     }
 
     /**
      * @notice Transfer a token between 2 addresses letting the receiver knows of the transfer
      * @param from The sender of the token
      * @param to The recipient of the token
-     * @param id The id of the token
+     * @param tokenId The id of the token
      * @param data Additional data
      */
     function safeTransferFrom(
         address from,
         address to,
-        uint256 id,
+        uint256 tokenId,
         bytes memory data
-    ) public override onlyAllowedOperator(from) {
-        super.safeTransferFrom(from, to, id, data);
+    ) external override onlyAllowedOperator(from) {
+        _safeTransferFrom(from, to, tokenId, data);
     }
 
     /**
      * @notice Return the URI of a specific token
-     * @param id The id of the token
+     * @param tokenId The id of the token
      * @return The URI of the token
      */
-    function tokenURI(uint256 id) public view returns (string memory) {
-        require(_ownerOf(id) != address(0), "Land: Id does not exist");
-        return string(abi.encodePacked("https://api.sandbox.game/lands/", uint2str(id), "/metadata.json"));
+    function tokenURI(uint256 tokenId) external view returns (string memory) {
+        require(_ownerOf(tokenId) != address(0), "Land: Id does not exist");
+        return string(abi.encodePacked("https://api.sandbox.game/lands/", uint2str(tokenId), "/metadata.json"));
     }
 
     /**

--- a/packages/land/contracts/PolygonLand.sol
+++ b/packages/land/contracts/PolygonLand.sol
@@ -73,59 +73,60 @@ contract PolygonLand is PolygonLandBase, WithMetadataRegistry, WithRoyalties, Wi
      * @notice Approve an operator to spend tokens on the sender behalf
      * @param sender The address giving the approval
      * @param operator The address receiving the approval
-     * @param id The id of the token
+     * @param tokenId The id of the token
      */
     function approveFor(
         address sender,
         address operator,
-        uint256 id
-    ) public override onlyAllowedOperatorApproval(operator) {
-        super.approveFor(sender, operator, id);
+        uint256 tokenId
+    ) external override onlyAllowedOperatorApproval(operator) {
+        _approveFor(sender, operator, tokenId);
     }
 
     /**
      * @notice Approve an operator to spend tokens on the sender behalf
      * @param operator The address receiving the approval
-     * @param id The id of the token
+     * @param tokenId The id of the token
      */
-    function approve(address operator, uint256 id) public override onlyAllowedOperatorApproval(operator) {
-        super.approve(operator, id);
+    function approve(address operator, uint256 tokenId) external override onlyAllowedOperatorApproval(operator) {
+        _approveFor(_msgSender(), operator, tokenId);
     }
 
     /**
      * @notice Transfer a token between 2 addresses
      * @param from The sender of the token
      * @param to The recipient of the token
-     * @param id The id of the token
+     * @param tokenId The id of the token
+     * @dev we decided to use safeTransferFrom even for this method as a security measure
      */
-    function transferFrom(address from, address to, uint256 id) public override onlyAllowedOperator(from) {
-        super.transferFrom(from, to, id);
+    function transferFrom(address from, address to, uint256 tokenId) external override onlyAllowedOperator(from) {
+        _transferFrom(from, to, tokenId);
     }
 
     /**
      * @notice Transfer a token between 2 addresses letting the receiver knows of the transfer
      * @param from The sender of the token
      * @param to The recipient of the token
-     * @param id The id of the token
+     * @param tokenId The id of the token
      * @param data Additional data
      */
     function safeTransferFrom(
         address from,
         address to,
-        uint256 id,
+        uint256 tokenId,
         bytes memory data
-    ) public override onlyAllowedOperator(from) {
-        super.safeTransferFrom(from, to, id, data);
+    ) external override onlyAllowedOperator(from) {
+        _safeTransferFrom(from, to, tokenId, data);
     }
 
     /**
      * @notice Transfer a token between 2 addresses letting the receiver knows of the transfer
      * @param from The send of the token
      * @param to The recipient of the token
-     * @param id The id of the token
+     * @param tokenId The id of the token
      */
-    function safeTransferFrom(address from, address to, uint256 id) public override onlyAllowedOperator(from) {
-        super.safeTransferFrom(from, to, id);
+    function safeTransferFrom(address from, address to, uint256 tokenId) external override onlyAllowedOperator(from) {
+        _safeTransferFrom(from, to, tokenId, "");
     }
 
     /**
@@ -133,8 +134,11 @@ contract PolygonLand is PolygonLandBase, WithMetadataRegistry, WithRoyalties, Wi
      * @param operator The address receiving the approval
      * @param approved The determination of the approval
      */
-    function setApprovalForAll(address operator, bool approved) public override onlyAllowedOperatorApproval(operator) {
-        super._setApprovalForAll(_msgSender(), operator, approved);
+    function setApprovalForAll(
+        address operator,
+        bool approved
+    ) external override onlyAllowedOperatorApproval(operator) {
+        _setApprovalForAll(_msgSender(), operator, approved);
     }
 
     /**
@@ -147,8 +151,8 @@ contract PolygonLand is PolygonLandBase, WithMetadataRegistry, WithRoyalties, Wi
         address sender,
         address operator,
         bool approved
-    ) public override onlyAllowedOperatorApproval(operator) {
-        super._setApprovalForAll(sender, operator, approved);
+    ) external override onlyAllowedOperatorApproval(operator) {
+        _setApprovalForAll(sender, operator, approved);
     }
 
     /**

--- a/packages/land/contracts/mainnet/ERC721BaseToken.sol
+++ b/packages/land/contracts/mainnet/ERC721BaseToken.sol
@@ -14,30 +14,6 @@ abstract contract ERC721BaseToken is ERC721BaseTokenCommon {
     using AddressUpgradeable for address;
 
     /**
-     * @notice Transfer a token between 2 addresses letting the receiver knows of the transfer
-     * @param from The sender of the token
-     * @param to The recipient of the token
-     * @param id The id of the token
-     * @param data Additional data
-     */
-    function safeTransferFrom(address from, address to, uint256 id, bytes memory data) public virtual {
-        _transferFrom(from, to, id);
-        if (to.isContract()) {
-            require(_checkOnERC721Received(_msgSender(), from, to, id, data), "ERC721_TRANSFER_REJECTED");
-        }
-    }
-
-    /**
-     * @notice Transfer a token between 2 addresses letting the receiver knows of the transfer
-     * @param from The send of the token
-     * @param to The recipient of the token
-     * @param id The id of the token
-     */
-    function safeTransferFrom(address from, address to, uint256 id) external virtual {
-        safeTransferFrom(from, to, id, "");
-    }
-
-    /**
      * @notice Transfer many tokens between 2 addresses
      * @param from The sender of the token
      * @param to The recipient of the token
@@ -57,7 +33,7 @@ abstract contract ERC721BaseToken is ERC721BaseTokenCommon {
      */
     function _batchTransferFrom(address from, address to, uint256[] memory ids, bytes memory data, bool safe) internal {
         address msgSender = _msgSender();
-        bool authorized = msgSender == from || _isApprovedForAll(from, msgSender);
+        bool authorized = msgSender == from || _isApprovedForAllOrSuperOperator(from, msgSender);
 
         require(from != address(0), "from is zero address");
         require(to != address(0), "can't send to zero address");

--- a/packages/land/contracts/mainnet/LandBaseToken.sol
+++ b/packages/land/contracts/mainnet/LandBaseToken.sol
@@ -96,7 +96,7 @@ abstract contract LandBaseToken is ERC721BaseToken {
         require(from != address(0), "from is zero address");
         require(to != address(0), "can't send to zero address");
         if (msg.sender != from) {
-            require(_isApprovedForAll(from, msg.sender), "not authorized to transferQuad");
+            require(_isApprovedForAllOrSuperOperator(from, msg.sender), "not authorized to transferQuad");
         }
         _transferQuad(from, to, size, x, y);
         _transferNumNFTPerAddress(from, to, size * size);
@@ -123,7 +123,7 @@ abstract contract LandBaseToken is ERC721BaseToken {
         require(sizes.length == xs.length, "sizes's and x's are different");
         require(xs.length == ys.length, "x's and y's are different");
         if (msg.sender != from) {
-            require(_isApprovedForAll(from, msg.sender), "not authorized");
+            require(_isApprovedForAllOrSuperOperator(from, msg.sender), "not authorized");
         }
         uint256 numTokensTransferred = 0;
         for (uint256 i = 0; i < sizes.length; i++) {

--- a/packages/land/contracts/polygon/ERC721BaseToken.sol
+++ b/packages/land/contracts/polygon/ERC721BaseToken.sol
@@ -11,14 +11,6 @@ import {ERC721BaseTokenCommon} from "../common/ERC721BaseTokenCommon.sol";
 abstract contract ERC721BaseToken is ERC721BaseTokenCommon {
     using AddressUpgradeable for address;
 
-    /// @notice Transfer a token between 2 addresses letting the receiver know of the transfer.
-    /// @param from The sender of the token.
-    /// @param to The recipient of the token.
-    /// @param id The id of the token.
-    function safeTransferFrom(address from, address to, uint256 id) public virtual override {
-        safeTransferFrom(from, to, id, "");
-    }
-
     /// @notice Transfer many tokens between 2 addresses.
     /// @param from The sender of the token.
     /// @param to The recipient of the token.
@@ -43,22 +35,10 @@ abstract contract ERC721BaseToken is ERC721BaseTokenCommon {
         _batchTransferFrom(from, to, ids, data, true);
     }
 
-    /// @notice Transfer a token between 2 addresses letting the receiver knows of the transfer.
-    /// @param from The sender of the token.
-    /// @param to The recipient of the token.
-    /// @param id The id of the token.
-    /// @param data Additional data.
-    function safeTransferFrom(address from, address to, uint256 id, bytes memory data) public virtual override {
-        _transferFrom(from, to, id);
-        if (to.isContract()) {
-            require(_checkOnERC721Received(_msgSender(), from, to, id, data), "ERC721_TRANSFER_REJECTED");
-        }
-    }
-
     /// @dev See batchTransferFrom.
     function _batchTransferFrom(address from, address to, uint256[] memory ids, bytes memory data, bool safe) internal {
         address msgSender = _msgSender();
-        bool authorized = msgSender == from || _isApprovedForAll(from, msgSender);
+        bool authorized = msgSender == from || _isApprovedForAllOrSuperOperator(from, msgSender);
 
         require(from != address(0), "NOT_FROM_ZEROADDRESS");
         require(to != address(0), "NOT_TO_ZEROADDRESS");

--- a/packages/land/contracts/polygon/PolygonLandBaseToken.sol
+++ b/packages/land/contracts/polygon/PolygonLandBaseToken.sol
@@ -56,7 +56,7 @@ abstract contract PolygonLandBaseToken is IPolygonLand, ERC721BaseToken {
         require(xs.length == ys.length, "x's and y's are different");
         address msgSender = _msgSender();
         if (msgSender != from) {
-            require(_isApprovedForAll(from, msgSender), "not authorized");
+            require(_isApprovedForAllOrSuperOperator(from, msgSender), "not authorized");
         }
         uint256 numTokensTransferred = 0;
         for (uint256 i = 0; i < sizes.length; i++) {
@@ -108,7 +108,7 @@ abstract contract PolygonLandBaseToken is IPolygonLand, ERC721BaseToken {
         require(to != address(0), "can't send to zero address");
         address msgSender = _msgSender();
         if (msgSender != from) {
-            require(_isApprovedForAll(from, msgSender), "not authorized to transferQuad");
+            require(_isApprovedForAllOrSuperOperator(from, msgSender), "not authorized to transferQuad");
         }
         _transferQuad(from, to, size, x, y);
         _transferNumNFTPerAddress(from, to, size * size);

--- a/packages/land/test/common/ERC721.behavior.ts
+++ b/packages/land/test/common/ERC721.behavior.ts
@@ -15,7 +15,7 @@ export function shouldCheckForERC721(
 
         await expect(
           LandAsOwner.transferFrom(deployer, other1, 10000000),
-        ).to.be.revertedWith(errorMessages.NONEXISTENT_TOKEN);
+        ).to.be.revertedWithCustomError(LandAsOwner, 'ERC721NonexistentToken');
       });
 
       it('tx balanceOf a zero owner fails', async function () {
@@ -617,7 +617,7 @@ export function shouldCheckForERC721(
         await LandAsOwner.transferFrom(landOwner, other, tokenIds[0]);
         await expect(
           LandAsOwner.approve(other, tokenIds[0]),
-        ).to.be.revertedWith(errorMessages.UNAUTHORIZED_APPROVAL);
+        ).to.be.revertedWithCustomError(LandAsOwner, 'ERC721InvalidOwner');
       });
 
       it('approving allows transfer from the approved party', async function () {

--- a/packages/land/test/mainnet/land.test.ts
+++ b/packages/land/test/mainnet/land.test.ts
@@ -131,14 +131,14 @@ describe('Land.sol', function () {
     const id = getId(1, 0, 0);
     await expect(
       LandAsOther.approveFor(deployer, other1, id),
-    ).to.be.revertedWith('OWNER_NOT_SENDER');
+    ).to.be.revertedWithCustomError(LandAsOther, 'ERC721InvalidOwner');
   });
 
   it('it should revert for setApprovalForAllFor of zero address', async function () {
     const {LandAsOther, other1} = await loadFixture(setupLand);
     await expect(
       LandAsOther.setApprovalForAllFor(ZeroAddress, other1, true),
-    ).to.be.revertedWith('Invalid sender address');
+    ).to.be.revertedWithCustomError(LandAsOther, 'ERC721InvalidSender');
   });
 
   it('should revert approveFor of operator is ZeroAddress', async function () {
@@ -148,7 +148,7 @@ describe('Land.sol', function () {
     const id = getId(1, 0, 0);
     await expect(
       LandAsOther.approveFor(ZeroAddress, other1, id),
-    ).to.be.revertedWith('OWNER_NOT_SENDER');
+    ).to.be.revertedWithCustomError(LandAsOther, 'ERC721InvalidSender');
   });
 
   it('it should revert setApprovalForAllFor for unauthorized sender', async function () {
@@ -163,9 +163,9 @@ describe('Land.sol', function () {
       await loadFixture(setupLand);
     await LandAsMinter.mintQuad(other, 1, 0, 0, '0x');
     const id = getId(1, 2, 2);
-    await expect(LandAsOther.approve(deployer, id)).to.be.revertedWith(
-      'NONEXISTENT_TOKEN',
-    );
+    await expect(
+      LandAsOther.approve(deployer, id),
+    ).to.be.revertedWithCustomError(LandAsOther, 'ERC721NonexistentToken');
   });
 
   it('should revert approveFor for unauthorized sender', async function () {
@@ -175,7 +175,7 @@ describe('Land.sol', function () {
     const id = getId(1, 0, 0);
     await expect(
       LandAsOther.approveFor(deployer, other1, id),
-    ).to.be.revertedWith('OWNER_NOT_SENDER');
+    ).to.be.revertedWithCustomError(LandAsOther, 'ERC721InvalidOwner');
   });
 
   it('should revert when id is not minted', async function () {

--- a/packages/land/test/polygon/PolygonLand.test.ts
+++ b/packages/land/test/polygon/PolygonLand.test.ts
@@ -120,7 +120,7 @@ describe('PolygonLand.sol', function () {
     const id = getId(1, 0, 0);
     await expect(
       LandAsOther.approveFor(ZeroAddress, MockMarketPlace3, id),
-    ).to.be.revertedWith('OWNER_NOT_SENDER');
+    ).to.be.revertedWithCustomError(LandAsOther, 'ERC721InvalidSender');
   });
 
   it('should revert approveFor for unauthorized user', async function () {
@@ -130,7 +130,7 @@ describe('PolygonLand.sol', function () {
     const id = getId(1, 0, 0);
     await expect(
       LandAsOther.approveFor(other1, MockMarketPlace3, id),
-    ).to.be.revertedWith('OWNER_NOT_SENDER');
+    ).to.be.revertedWithCustomError(LandAsOther, 'ERC721InvalidOwner');
   });
 
   it('should revert approveFor zero owner of tokenId', async function () {
@@ -140,16 +140,17 @@ describe('PolygonLand.sol', function () {
     const tokenId = 2 + 2 * GRID_SIZE;
     await expect(
       LandAsOther.approveFor(other, MockMarketPlace3, tokenId),
-    ).to.be.revertedWith('OWNER_NOT_SENDER');
+    ).to.be.revertedWithCustomError(LandAsOther, 'ERC721NonexistentToken');
   });
 
   it('should revert approve for zero address owner of token', async function () {
     const {LandAsOther, MockMarketPlace3} = await loadFixture(setupPolygonLand);
     const GRID_SIZE = 408;
     const tokenId = 2 + 2 * GRID_SIZE;
+    console.log(await MockMarketPlace3.getAddress());
     await expect(
       LandAsOther.approve(MockMarketPlace3, tokenId),
-    ).to.be.revertedWith('NONEXISTENT_TOKEN');
+    ).to.be.revertedWithCustomError(LandAsOther, 'ERC721NonexistentToken');
   });
 
   it('should revert approve for ZeroAddress spender', async function () {
@@ -157,16 +158,16 @@ describe('PolygonLand.sol', function () {
       await loadFixture(setupPolygonLand);
     await LandAsMinter.mintQuad(other, 1, 0, 0, '0x');
     const id = getId(1, 0, 0);
-    await expect(LandAsOther1.approve(MockMarketPlace3, id)).to.be.revertedWith(
-      'UNAUTHORIZED_APPROVAL',
-    );
+    await expect(
+      LandAsOther1.approve(MockMarketPlace3, id),
+    ).to.be.revertedWithCustomError(LandAsOther1, 'ERC721InvalidOwner');
   });
 
   it('should revert setApprovalForAllFor for ZeroAddress', async function () {
     const {LandAsOther, MockMarketPlace3} = await loadFixture(setupPolygonLand);
     await expect(
       LandAsOther.setApprovalForAllFor(ZeroAddress, MockMarketPlace3, true),
-    ).to.be.revertedWith('Invalid sender address');
+    ).to.be.revertedWithCustomError(LandAsOther, 'ERC721InvalidSender');
   });
 
   it('should revert setApprovalForAllFor for unauthorized users', async function () {
@@ -187,7 +188,7 @@ describe('PolygonLand.sol', function () {
     const id = getId(1, 0, 0);
     await expect(
       LandContract.approveFor(deployer, deployer, id),
-    ).to.be.revertedWith('OWNER_NOT_SENDER');
+    ).to.be.revertedWithCustomError(LandContract, 'ERC721InvalidOwner');
   });
 
   it('subscription can not be zero address', async function () {


### PR DESCRIPTION
## Description
https://internal-jira.atlassian.net/browse/LR-59

- move safeTransferFrom to common
- _approveFor does all the checks internally and takes the sender instead of the owner
- added a helper function _doTransfer so _transferFrom and _safeTransferFrom can share code
- convert public -> external and add virtual
- rename id => tokenId, _isApprovedForAll => _isApprovedForAllOrSuperOperator
- fix the tests

