### PR TITLE
Add upgrade script for asset create

### DIFF
--- a/packages/deploy/deploy/400_asset/408_upgrade_asset_create.ts
+++ b/packages/deploy/deploy/400_asset/408_upgrade_asset_create.ts
@@ -1,0 +1,32 @@
+import {DeployFunction} from 'hardhat-deploy/types';
+import {HardhatRuntimeEnvironment} from 'hardhat/types';
+
+const func: DeployFunction = async function (
+  hre: HardhatRuntimeEnvironment
+): Promise<void> {
+  const {deployments, getNamedAccounts} = hre;
+  const {deploy, catchUnknownSigner} = deployments;
+
+  const {deployer, upgradeAdmin} = await getNamedAccounts();
+
+  await catchUnknownSigner(
+    deploy('AssetCreate', {
+      from: deployer,
+      log: true,
+      contract:
+        '@sandbox-smart-contracts/asset/contracts/AssetCreate.sol:AssetCreate',
+      proxy: {
+        owner: upgradeAdmin,
+        proxyContract: 'OpenZeppelinTransparentProxy',
+        upgradeIndex: 1,
+      },
+    })
+  );
+};
+export default func;
+func.tags = ['AssetCreate_upgrade', 'L2'];
+func.dependencies = [
+  'AssetCreate_deploy',
+  'AssetCreate_setup',
+  'Exchange_deploy',
+];

--- a/packages/deploy/deploy/400_asset/409_lazy_minting_setup.ts
+++ b/packages/deploy/deploy/400_asset/409_lazy_minting_setup.ts
@@ -9,7 +9,6 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const exchangeContract = await deployments.get('Exchange');
 
   const LAZY_MINTING_FEE_BPS = 0;
-  const LAZY_MINTING_FEE_RECIVER = treasury;
 
   const mintingFee = await read('AssetCreate', 'lazyMintFeeInBps');
   if (Number(mintingFee) !== LAZY_MINTING_FEE_BPS) {
@@ -27,17 +26,17 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   }
 
   const mintingFeeReceiver = await read('AssetCreate', 'lazyMintFeeReceiver');
-  if (mintingFeeReceiver !== LAZY_MINTING_FEE_RECIVER) {
+  if (mintingFeeReceiver !== treasury) {
     await catchUnknownSigner(
       execute(
         'AssetCreate',
         {from: assetAdmin, log: true},
         'setLazyMintFeeReceiver',
-        LAZY_MINTING_FEE_RECIVER
+        treasury
       )
     );
     log(
-      `[AssetCreate-Lazy Minting] Lazy minting fee receiver set to ${LAZY_MINTING_FEE_RECIVER}`
+      `[AssetCreate-Lazy Minting] Lazy minting fee receiver set to ${treasury}`
     );
   }
 

--- a/packages/deploy/deploy/400_asset/409_lazy_minting_setup.ts
+++ b/packages/deploy/deploy/400_asset/409_lazy_minting_setup.ts
@@ -1,0 +1,63 @@
+import {HardhatRuntimeEnvironment} from 'hardhat/types';
+import {DeployFunction} from 'hardhat-deploy/types';
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const {deployments, getNamedAccounts} = hre;
+  const {execute, log, read, catchUnknownSigner} = deployments;
+  const {assetAdmin, treasury} = await getNamedAccounts();
+
+  const exchangeContract = await deployments.get('Exchange');
+
+  const LAZY_MINTING_FEE_BPS = 0;
+  const LAZY_MINTING_FEE_RECIVER = treasury;
+
+  const mintingFee = await read('AssetCreate', 'lazyMintFeeInBps');
+  if (Number(mintingFee) !== LAZY_MINTING_FEE_BPS) {
+    await catchUnknownSigner(
+      execute(
+        'AssetCreate',
+        {from: assetAdmin, log: true},
+        'setLazyMintFee',
+        LAZY_MINTING_FEE_BPS
+      )
+    );
+    log(
+      `[AssetCreate-Lazy Minting] Lazy minting fee set to ${LAZY_MINTING_FEE_BPS}`
+    );
+  }
+
+  const mintingFeeReceiver = await read('AssetCreate', 'lazyMintFeeReceiver');
+  if (mintingFeeReceiver !== LAZY_MINTING_FEE_RECIVER) {
+    await catchUnknownSigner(
+      execute(
+        'AssetCreate',
+        {from: assetAdmin, log: true},
+        'setLazyMintFeeReceiver',
+        LAZY_MINTING_FEE_RECIVER
+      )
+    );
+    log(
+      `[AssetCreate-Lazy Minting] Lazy minting fee receiver set to ${LAZY_MINTING_FEE_RECIVER}`
+    );
+  }
+
+  const exchangeAddress = await read('AssetCreate', 'exchangeContract');
+  if (exchangeAddress !== exchangeContract.address) {
+    await catchUnknownSigner(
+      execute(
+        'AssetCreate',
+        {from: assetAdmin, log: true},
+        'setExchangeContract',
+        exchangeContract.address
+      )
+    );
+    log(
+      `[AssetCreate-Lazy Minting] Exchange address set to ${exchangeContract.address}`
+    );
+  }
+};
+
+export default func;
+
+func.tags = ['Asset', 'AssetCreate', 'AssetCreate_lazy_setup'];
+func.dependencies = ['AssetCreate_upgrade'];

--- a/packages/deploy/package.json
+++ b/packages/deploy/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/thesandboxgame/sandbox-smart-contracts#readme",
   "private": true,
   "dependencies": {
-    "@sandbox-smart-contracts/asset": "1.1.0",
+    "@sandbox-smart-contracts/asset": "1.2.0",
     "@sandbox-smart-contracts/avatar": "*",
     "@sandbox-smart-contracts/core": "*",
     "@sandbox-smart-contracts/dependency-operator-filter": "1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2492,22 +2492,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sandbox-smart-contracts/asset@npm:1.1.0":
-  version: 1.1.0
-  resolution: "@sandbox-smart-contracts/asset@npm:1.1.0"
-  dependencies:
-    "@manifoldxyz/libraries-solidity": ^1.0.4
-    "@manifoldxyz/royalty-registry-solidity": ^2.0.3
-    "@openzeppelin/contracts": 4.9.3
-    "@openzeppelin/contracts-upgradeable": 4.9.3
-    "@sandbox-smart-contracts/dependency-metatx": 1.0.1
-    "@sandbox-smart-contracts/dependency-operator-filter": 1.0.1
-    "@sandbox-smart-contracts/dependency-royalty-management": 1.0.2
-  checksum: 7743dcd914c2a8965a928999833ed836e9f122ef0e382014ef339b405e253f93da67aea73140c4314021c0d4829326b0283da2cfe11041c188b461422fd800d6
-  languageName: node
-  linkType: hard
-
-"@sandbox-smart-contracts/asset@workspace:packages/asset":
+"@sandbox-smart-contracts/asset@1.2.0, @sandbox-smart-contracts/asset@workspace:packages/asset":
   version: 0.0.0-use.local
   resolution: "@sandbox-smart-contracts/asset@workspace:packages/asset"
   dependencies:
@@ -2823,7 +2808,7 @@ __metadata:
     "@nomicfoundation/hardhat-verify": ^1.1.0
     "@openzeppelin/hardhat-upgrades": ^2.5.0
     "@openzeppelin/upgrades-core": ^1.32.3
-    "@sandbox-smart-contracts/asset": 1.1.0
+    "@sandbox-smart-contracts/asset": 1.2.0
     "@sandbox-smart-contracts/avatar": "*"
     "@sandbox-smart-contracts/core": "*"
     "@sandbox-smart-contracts/dependency-operator-filter": 1.0.1


### PR DESCRIPTION
## Description

Deployment script to upgrade AssetCreate to include lazy minting.

Consists of two files:

- the actual upgrade file
- setup script that sets the necessary variables

Values to be confirmed.