### PR TITLE
Purchase cats when there is order info

### DIFF
--- a/packages/asset/contracts/AssetCreate.sol
+++ b/packages/asset/contracts/AssetCreate.sol
@@ -20,7 +20,6 @@ import {IAssetCreate} from "./interfaces/IAssetCreate.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IExchange, ExchangeMatch} from "./interfaces/IExchange.sol";
-import {IERC1155} from "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
 
 /// @title AssetCreate
 /// @author The Sandbox

--- a/packages/asset/contracts/AssetCreate.sol
+++ b/packages/asset/contracts/AssetCreate.sol
@@ -419,11 +419,7 @@ contract AssetCreate is
             availableToMint[tokenId] -= mintData.amount;
         }
 
-        // if user does not have enough catalyst purchase remaining ones from the marketplace contract
-        uint256 catalystBalance = IERC1155(address(catalystContract)).balanceOf(mintData.caller, mintData.tier);
-
-        if (catalystBalance < mintData.amount) {
-            require(matchedOrders.length > 0, "AssetCreate: No order data");
+        if (matchedOrders.length > 0) {
             exchangeContract.matchOrdersFrom(mintData.caller, matchedOrders);
         }
         // burn catalyst of a given tier
@@ -505,11 +501,7 @@ contract AssetCreate is
                 require(availableToMint[tokenIds[i]] >= mintData.amounts[i], "AssetCreate: Max supply reached");
                 availableToMint[tokenIds[i]] -= mintData.amounts[i];
             }
-            if (
-                IERC1155(address(catalystContract)).balanceOf(mintData.caller, mintData.tiers[i]) < mintData.amounts[i]
-            ) {
-                require(matchedOrdersArray.length > 0, "AssetCreate: No order data");
-                require(matchedOrdersArray[i].length > 0, "AssetCreate: No order data");
+            if (matchedOrdersArray.length > i && matchedOrdersArray[i].length > 0) {
                 exchangeContract.matchOrdersFrom(mintData.caller, matchedOrdersArray[i]);
             }
             distributePayment(


### PR DESCRIPTION
## Description

There was a change requested so that we are able to force catalyst buy from the market even if the user has enough catalysts in the wallet for the lazy mint to happen.

Now we check if order information is provided, if yes we will always try to make the purchase regardless of the amount of catalysts held by user.
