### PR TITLE
[LazyMinting] Signature expiration

### DIFF
--- a/packages/asset/contracts/AssetCreate.sol
+++ b/packages/asset/contracts/AssetCreate.sol
@@ -70,12 +70,12 @@ contract AssetCreate is
     /// @notice Lazy mint signature typehash
     bytes32 public constant LAZY_MINT_TYPEHASH =
         keccak256(
-            "LazyMint(address caller,address creator,uint16 nonce,uint8 tier,uint256 amount,uint256 unitPrice,address paymentToken,string metadataHash,uint256 maxSupply)"
+            "LazyMint(address caller,address creator,uint16 nonce,uint8 tier,uint256 amount,uint256 unitPrice,address paymentToken,string metadataHash,uint256 maxSupply,uint256 expirationTime)"
         );
     /// @notice Lazy mint batch signature typehash
     bytes32 public constant LAZY_MINT_BATCH_TYPEHASH =
         keccak256(
-            "LazyMintBatch(address caller,address[] creators,uint16 nonce,uint8[] tiers,uint256[] amounts,uint256[] unitPrices,address[] paymentTokens,string[] metadataHashes,uint256[] maxSupplies)"
+            "LazyMintBatch(address caller,address[] creators,uint16 nonce,uint8[] tiers,uint256[] amounts,uint256[] unitPrices,address[] paymentTokens,string[] metadataHashes,uint256[] maxSupplies,uint256 expirationTime)"
         );
 
     /// @custom:oz-upgrades-unsafe-allow constructor
@@ -279,8 +279,10 @@ contract AssetCreate is
                     mintData.unitPrice,
                     mintData.paymentToken,
                     mintData.metadataHash,
-                    mintData.maxSupply
-                )
+                    mintData.maxSupply,
+                    mintData.expirationTime
+                ),
+                mintData.expirationTime
             ),
             "AssetCreate: Invalid signature"
         );
@@ -353,8 +355,10 @@ contract AssetCreate is
                     mintData.unitPrices,
                     mintData.paymentTokens,
                     mintData.metadataHashes,
-                    mintData.maxSupplies
-                )
+                    mintData.maxSupplies,
+                    mintData.expirationTime
+                ),
+                mintData.expirationTime
             ),
             "AssetCreate: Invalid signature"
         );
@@ -590,6 +594,7 @@ contract AssetCreate is
     /// @param amount The amount of copies to mint
     /// @param metadataHash The metadata hash of the asset
     /// @param maxSupply The max supply of the asset
+    /// @param expirationTime The expiration timestamp of the signature
     function _hashLazyMint(
         address caller,
         address creator,
@@ -599,7 +604,8 @@ contract AssetCreate is
         uint256 unitPrice,
         address paymentToken,
         string memory metadataHash,
-        uint256 maxSupply
+        uint256 maxSupply,
+        uint256 expirationTime
     ) private view returns (bytes32 digest) {
         digest = _hashTypedDataV4(
             keccak256(
@@ -613,7 +619,8 @@ contract AssetCreate is
                     unitPrice,
                     paymentToken,
                     keccak256((abi.encodePacked(metadataHash))),
-                    maxSupply
+                    maxSupply,
+                    expirationTime
                 )
             )
         );
@@ -628,6 +635,7 @@ contract AssetCreate is
     /// @param paymentTokens The payment tokens of the assets
     /// @param metadataHashes The metadata hashes of the assets
     /// @param maxSupplies The max supplies of the assets
+    /// @param expirationTime The expiration timestamp of the signature
     function _hashLazyBatchMint(
         address caller,
         address[] memory creators,
@@ -637,7 +645,8 @@ contract AssetCreate is
         uint256[] memory unitPrices,
         address[] memory paymentTokens,
         string[] memory metadataHashes,
-        uint256[] memory maxSupplies
+        uint256[] memory maxSupplies,
+        uint256 expirationTime
     ) private view returns (bytes32 digest) {
         digest = _hashTypedDataV4(
             keccak256(
@@ -651,7 +660,8 @@ contract AssetCreate is
                     keccak256(abi.encodePacked(unitPrices)),
                     keccak256(abi.encodePacked(paymentTokens)),
                     _encodeHashes(metadataHashes),
-                    keccak256(abi.encodePacked(maxSupplies))
+                    keccak256(abi.encodePacked(maxSupplies)),
+                    expirationTime
                 )
             )
         );

--- a/packages/asset/contracts/AssetCreate.sol
+++ b/packages/asset/contracts/AssetCreate.sol
@@ -459,6 +459,14 @@ contract AssetCreate is
         _setTrustedForwarder(trustedForwarder);
     }
 
+    /// @notice Set the auth validator contract address
+    /// @param _authValidator The auth validator contract address to set
+    function setAuthValidator(address _authValidator) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        require(_authValidator.isContract(), "AssetCreate: Invalid contract");
+        authValidator = AuthSuperValidator(_authValidator);
+        emit AuthValidatorSet(_authValidator);
+    }
+
     /// @notice Get the asset contract address
     /// @return assetContractAddress The asset contract address
     function getAssetContract() external view returns (address assetContractAddress) {

--- a/packages/asset/contracts/AuthSuperValidator.sol
+++ b/packages/asset/contracts/AuthSuperValidator.sol
@@ -48,7 +48,11 @@ contract AuthSuperValidator is AccessControl {
     /// @param signature Signature hash
     /// @param digest Digest hash
     /// @return bool
-    function verify(bytes memory signature, bytes32 digest, uint256 expirationTime) public view returns (bool) {
+    function verify(
+        bytes memory signature,
+        bytes32 digest,
+        uint256 expirationTime
+    ) public view returns (bool) {
         require(block.timestamp <= expirationTime, "AuthSuperValidator: Expired");
         return verify(signature, digest);
     }

--- a/packages/asset/contracts/AuthSuperValidator.sol
+++ b/packages/asset/contracts/AuthSuperValidator.sol
@@ -48,12 +48,8 @@ contract AuthSuperValidator is AccessControl {
     /// @param signature Signature hash
     /// @param digest Digest hash
     /// @return bool
-    function verify(
-        bytes memory signature,
-        bytes32 digest,
-        uint256 expirationTime
-    ) public view returns (bool) {
-        require(block.timestamp <= expirationTime, "AuthSuperValidator: Signature expired");
+    function verify(bytes memory signature, bytes32 digest, uint256 expirationTime) public view returns (bool) {
+        require(block.timestamp <= expirationTime, "AuthSuperValidator: Expired");
         return verify(signature, digest);
     }
 

--- a/packages/asset/contracts/AuthSuperValidator.sol
+++ b/packages/asset/contracts/AuthSuperValidator.sol
@@ -43,6 +43,20 @@ contract AuthSuperValidator is AccessControl {
         return recoveredSigner == signer;
     }
 
+    /// @notice Takes the signature and the digest and returns if the signer has a backend signer role assigned and the signature is not expired
+    /// @dev Multipurpose function that can be used to verify signatures with different digests and expiration times
+    /// @param signature Signature hash
+    /// @param digest Digest hash
+    /// @return bool
+    function verify(
+        bytes memory signature,
+        bytes32 digest,
+        uint256 expirationTime
+    ) public view returns (bool) {
+        require(block.timestamp <= expirationTime, "AuthSuperValidator: Signature expired");
+        return verify(signature, digest);
+    }
+
     /// @notice Prevents the DEFAULT_ADMIN_ROLE from being renounced
     /// @dev This function overrides the default renounceRole function to prevent the DEFAULT_ADMIN_ROLE from being renounced
     /// @param role Role to renounce

--- a/packages/asset/contracts/interfaces/IAssetCreate.sol
+++ b/packages/asset/contracts/interfaces/IAssetCreate.sol
@@ -13,6 +13,7 @@ interface IAssetCreate {
         string metadataHash;
         uint256 maxSupply;
         address creator;
+        uint256 expirationTime;
     }
 
     struct LazyMintBatchData {
@@ -24,6 +25,7 @@ interface IAssetCreate {
         string[] metadataHashes;
         uint256[] maxSupplies;
         address[] creators;
+        uint256 expirationTime;
     }
 
     event TrustedForwarderChanged(address indexed newTrustedForwarderAddress);

--- a/packages/asset/contracts/interfaces/IAssetCreate.sol
+++ b/packages/asset/contracts/interfaces/IAssetCreate.sol
@@ -80,4 +80,5 @@ interface IAssetCreate {
     event LazyMintFeeSet(uint256 indexed newLazyMintFee);
     event LazyMintFeeReceiverSet(address indexed newLazyMintFeeReceived);
     event ExchangeContractSet(address indexed exchangeContract);
+    event AuthValidatorSet(address indexed authValidator);
 }

--- a/packages/asset/test/AssetCreate.test.ts
+++ b/packages/asset/test/AssetCreate.test.ts
@@ -3859,7 +3859,6 @@ describe('AssetCreate (/packages/asset/contracts/AssetCreate.sol)', function () 
           MockERC20Contract,
           AssetCreateContractAsUser,
           getCurrentBlockTimestamp,
-          sampleExchangeOrderData,
         } = await runCreateTestSetup();
 
         const asset1 = {
@@ -4773,7 +4772,7 @@ describe('AssetCreate (/packages/asset/contracts/AssetCreate.sol)', function () 
           unitPrices: assets.map((a) => a.sandPrice),
           paymentTokens: assets.map(() => MockERC20Contract.address),
           metadataHashes: assets.map((a) => a.metadataHash),
-          maxSupplies: assets.map((a) => 10),
+          maxSupplies: assets.map(() => 10),
           creators: assets.map((a) => a.creator),
           expirationTime: (await getCurrentBlockTimestamp()) + 1000,
         };

--- a/packages/asset/test/AssetCreate.test.ts
+++ b/packages/asset/test/AssetCreate.test.ts
@@ -2327,7 +2327,7 @@ describe('AssetCreate (/packages/asset/contracts/AssetCreate.sol)', function () 
             Object.values(mintData),
             []
           )
-        ).to.be.revertedWith('AuthSuperValidator: Signature expired');
+        ).to.be.revertedWith('AuthSuperValidator: Expired');
       });
       it('should not allow minting with invalid signature - invalid tier', async function () {
         const {

--- a/packages/asset/test/AuthSuperValidator.test.ts
+++ b/packages/asset/test/AuthSuperValidator.test.ts
@@ -2,7 +2,7 @@ import {ethers} from 'ethers';
 import {expect} from 'chai';
 import runSetup from './fixtures/authValidatorFixture';
 
-describe('AuthSuperValidator, (/packages/asset/contracts/AuthSuperValidator.sol)', function () {
+describe.only('AuthSuperValidator, (/packages/asset/contracts/AuthSuperValidator.sol)', function () {
   describe('General', function () {
     it('should assign DEFAULT_ADMIN_ROLE to the admin address from the constructor', async function () {
       const {authValidatorAdmin, AuthValidatorContract} = await runSetup();
@@ -109,11 +109,64 @@ describe('AuthSuperValidator, (/packages/asset/contracts/AuthSuperValidator.sol)
         authValidatorAdmin.address,
         backendSigner
       );
-      const isValid = await AuthValidatorContractAsAdmin.verify(
-        signature,
-        digest
-      );
+      const isValid = await AuthValidatorContractAsAdmin[
+        'verify(bytes,bytes32)'
+      ](signature, digest);
       expect(isValid).to.equal(true);
+    });
+    it("should not revert when signature hasn't expired", async function () {
+      const {
+        AuthValidatorContractAsAdmin,
+        backendSigner,
+        authValidatorAdmin,
+        createMockSignature,
+        createMockDigest,
+        getCurrentBlockTimestamp,
+      } = await runSetup();
+      await AuthValidatorContractAsAdmin.setSigner(
+        authValidatorAdmin.address,
+        backendSigner.address
+      );
+
+      const digest = createMockDigest(backendSigner.address);
+      const {signature} = await createMockSignature(
+        authValidatorAdmin.address,
+        backendSigner
+      );
+      await expect(
+        AuthValidatorContractAsAdmin['verify(bytes,bytes32,uint256)'](
+          signature,
+          digest,
+          (await getCurrentBlockTimestamp()) + 10
+        )
+      ).to.not.be.reverted;
+    });
+    it('should revert when signature has expired', async function () {
+      const {
+        AuthValidatorContractAsAdmin,
+        backendSigner,
+        authValidatorAdmin,
+        createMockSignature,
+        createMockDigest,
+        getCurrentBlockTimestamp,
+      } = await runSetup();
+      await AuthValidatorContractAsAdmin.setSigner(
+        authValidatorAdmin.address,
+        backendSigner.address
+      );
+
+      const digest = createMockDigest(backendSigner.address);
+      const {signature} = await createMockSignature(
+        authValidatorAdmin.address,
+        backendSigner
+      );
+      await expect(
+        AuthValidatorContractAsAdmin['verify(bytes,bytes32,uint256)'](
+          signature,
+          digest,
+          (await getCurrentBlockTimestamp()) - 10
+        )
+      ).to.be.revertedWith('AuthSuperValidator: Expired');
     });
     it('should revert when signature is not valid', async function () {
       const {
@@ -134,10 +187,9 @@ describe('AuthSuperValidator, (/packages/asset/contracts/AuthSuperValidator.sol)
         authValidatorAdmin.address,
         backendSigner
       );
-      const isValid = await AuthValidatorContractAsAdmin.verify(
-        signature,
-        digest
-      );
+      const isValid = await AuthValidatorContractAsAdmin[
+        'verify(bytes,bytes32)'
+      ](signature, digest);
       expect(isValid).to.equal(false);
     });
     it('should revert when there is no signer assigned for a given contract address', async function () {
@@ -152,7 +204,7 @@ describe('AuthSuperValidator, (/packages/asset/contracts/AuthSuperValidator.sol)
         backendSigner
       );
       await expect(
-        AuthValidatorContractAsAdmin.verify(signature, digest)
+        AuthValidatorContractAsAdmin['verify(bytes,bytes32)'](signature, digest)
       ).to.be.revertedWith('AuthSuperValidator: No signer');
     });
   });

--- a/packages/asset/test/AuthSuperValidator.test.ts
+++ b/packages/asset/test/AuthSuperValidator.test.ts
@@ -2,7 +2,7 @@ import {ethers} from 'ethers';
 import {expect} from 'chai';
 import runSetup from './fixtures/authValidatorFixture';
 
-describe.only('AuthSuperValidator, (/packages/asset/contracts/AuthSuperValidator.sol)', function () {
+describe('AuthSuperValidator, (/packages/asset/contracts/AuthSuperValidator.sol)', function () {
   describe('General', function () {
     it('should assign DEFAULT_ADMIN_ROLE to the admin address from the constructor', async function () {
       const {authValidatorAdmin, AuthValidatorContract} = await runSetup();

--- a/packages/asset/test/fixtures/authValidatorFixture.ts
+++ b/packages/asset/test/fixtures/authValidatorFixture.ts
@@ -16,6 +16,11 @@ const runSetup = async () => {
     authValidatorAdmin
   );
 
+  const getCurrentBlockTimestamp = async () => {
+    const block = await ethers.provider.getBlock('latest');
+    return block.timestamp;
+  };
+
   const MockContractFactory = await ethers.getContractFactory('MockAsset');
   const MockContract = await MockContractFactory.connect(deployer).deploy();
   await MockContract.deployed();
@@ -29,6 +34,7 @@ const runSetup = async () => {
     deployer,
     createMockDigest,
     createMockSignature,
+    getCurrentBlockTimestamp,
   };
 };
 

--- a/packages/deploy/deploy/400_asset/403_deploy_asset_create.ts
+++ b/packages/deploy/deploy/400_asset/403_deploy_asset_create.ts
@@ -18,7 +18,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   await deploy('AssetCreate', {
     from: deployer,
     contract:
-      '@sandbox-smart-contracts/asset/contracts/AssetCreate.sol:AssetCreate',
+      '@sandbox-smart-contracts/asset@1.1.0/contracts/AssetCreate.sol:AssetCreate',
     proxy: {
       owner: upgradeAdmin,
       proxyContract: 'OpenZeppelinTransparentProxy',

--- a/packages/deploy/deploy/400_asset/404_deploy_asset_reveal.ts
+++ b/packages/deploy/deploy/400_asset/404_deploy_asset_reveal.ts
@@ -44,4 +44,5 @@ func.dependencies = [
   'Asset_deploy',
   'AuthSuperValidator_deploy',
   'TRUSTED_FORWARDER_V2',
+  'AuthSuperValidator_v2', // use updated AuthSuperValidator
 ];

--- a/packages/deploy/deploy/400_asset/408_upgrade_asset_create.ts
+++ b/packages/deploy/deploy/400_asset/408_upgrade_asset_create.ts
@@ -25,8 +25,4 @@ const func: DeployFunction = async function (
 };
 export default func;
 func.tags = ['AssetCreate_upgrade', 'L2'];
-func.dependencies = [
-  'AssetCreate_deploy',
-  'AssetCreate_setup',
-  'Exchange_deploy',
-];
+func.dependencies = ['Exchange_deploy'];

--- a/packages/deploy/deploy/400_asset/409_deploy_updated_auth_validator.ts
+++ b/packages/deploy/deploy/400_asset/409_deploy_updated_auth_validator.ts
@@ -9,10 +9,10 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   await deploy('AuthSuperValidator', {
     from: deployer,
     contract:
-      '@sandbox-smart-contracts/asset@1.1.0/contracts/AuthSuperValidator.sol:AuthSuperValidator',
+      '@sandbox-smart-contracts/asset/contracts/AuthSuperValidator.sol:AuthSuperValidator',
     args: [assetAdmin],
     log: true,
   });
 };
 export default func;
-func.tags = ['AuthSuperValidator', 'AuthSuperValidator_deploy', 'L2'];
+func.tags = ['AuthSuperValidator_v2', 'L2'];

--- a/packages/deploy/hardhat.config.ts
+++ b/packages/deploy/hardhat.config.ts
@@ -14,6 +14,13 @@ import './tasks/importedPackages';
 // Package name : solidity source code path
 const importedPackages = {
   '@sandbox-smart-contracts/avatar': 'contracts/',
+  '@sandbox-smart-contracts/asset@1.1.0': [
+    'contracts/Asset.sol',
+    'contracts/AssetCreate.sol',
+    'contracts/AssetReveal.sol',
+    'contracts/Catalyst.sol',
+    'contracts/AuthSuperValidator.sol',
+  ],
   '@sandbox-smart-contracts/asset': [
     'contracts/Asset.sol',
     'contracts/AssetCreate.sol',

--- a/packages/deploy/package.json
+++ b/packages/deploy/package.json
@@ -16,6 +16,7 @@
   "private": true,
   "dependencies": {
     "@sandbox-smart-contracts/asset": "1.2.0",
+    "@sandbox-smart-contracts/asset@1.1.0": "npm:@sandbox-smart-contracts/asset@1.1.0",
     "@sandbox-smart-contracts/avatar": "*",
     "@sandbox-smart-contracts/core": "*",
     "@sandbox-smart-contracts/dependency-operator-filter": "1.0.1",

--- a/packages/deploy/test/asset/AssetCreate.test.ts
+++ b/packages/deploy/test/asset/AssetCreate.test.ts
@@ -142,7 +142,7 @@ describe('Asset Create', function () {
           [...Object.values(mintData)],
           []
         )
-      ).to.be.revertedWith('AuthSuperValidator: Signature expired');
+      ).to.be.revertedWith('AuthSuperValidator: Expired');
     });
     it('allows users to lazy mint when they have all necessary catalysts - direct', async function () {
       const {

--- a/packages/deploy/test/asset/AssetCreate.test.ts
+++ b/packages/deploy/test/asset/AssetCreate.test.ts
@@ -111,6 +111,39 @@ describe('Asset Create', function () {
         treasury
       );
     });
+    it('reverts when signature is expired', async function () {
+      const {
+        user,
+        creator,
+        SandContract,
+        createSingleLazyMintSignature,
+        AssetCreateContract,
+        getCurrentTimestamp,
+      } = await setupAssetCreateTests();
+
+      const mintData: LazyMintData = {
+        caller: user,
+        tier: BigInt(2),
+        amount: BigInt(1),
+        unitPrice: BigInt(1),
+        paymentToken: await SandContract.getAddress(),
+        metadataHash: '0x',
+        maxSupply: BigInt(1),
+        creator,
+        expirationTime: BigInt(await getCurrentTimestamp()) - 1000n,
+      };
+
+      const signature = await createSingleLazyMintSignature(mintData);
+
+      await expect(
+        AssetCreateContract.lazyCreateAsset(
+          user,
+          signature,
+          [...Object.values(mintData)],
+          []
+        )
+      ).to.be.revertedWith('AuthSuperValidator: Signature expired');
+    });
     it('allows users to lazy mint when they have all necessary catalysts - direct', async function () {
       const {
         user,

--- a/packages/deploy/test/asset/AssetCreate.test.ts
+++ b/packages/deploy/test/asset/AssetCreate.test.ts
@@ -120,6 +120,7 @@ describe('Asset Create', function () {
         createSingleLazyMintSignature,
         AssetCreateContract,
         CatalystContractAsAdmin,
+        getCurrentTimestamp,
       } = await setupAssetCreateTests();
 
       const mintData: LazyMintData = {
@@ -131,6 +132,7 @@ describe('Asset Create', function () {
         metadataHash: '0x',
         maxSupply: BigInt(1),
         creator,
+        expirationTime: BigInt(await getCurrentTimestamp()) + 1000n,
       };
 
       const signature = await createSingleLazyMintSignature(mintData);
@@ -162,6 +164,7 @@ describe('Asset Create', function () {
         createSingleLazyMintSignature,
         AssetCreateContract,
         CatalystContractAsAdmin,
+        getCurrentTimestamp,
       } = await setupAssetCreateTests();
 
       const mintData: LazyMintData = {
@@ -173,6 +176,7 @@ describe('Asset Create', function () {
         metadataHash: '0x',
         maxSupply: BigInt(1),
         creator,
+        expirationTime: BigInt(await getCurrentTimestamp()) + 1000n,
       };
 
       // Mint catalysts to user
@@ -205,6 +209,7 @@ describe('Asset Create', function () {
         ExchangeContract,
         OrderValidatorContract,
         tsbCatSellerSigner,
+        getCurrentTimestamp,
       } = await setupAssetCreateTests();
 
       const mintData: LazyMintData = {
@@ -216,6 +221,7 @@ describe('Asset Create', function () {
         metadataHash: '0x',
         maxSupply: BigInt(10),
         creator,
+        expirationTime: BigInt(await getCurrentTimestamp()) + 1000n,
       };
 
       const signature = await createSingleLazyMintSignature(mintData);
@@ -266,6 +272,7 @@ describe('Asset Create', function () {
         ExchangeContract,
         OrderValidatorContract,
         tsbCatSellerSigner,
+        getCurrentTimestamp,
       } = await setupAssetCreateTests();
 
       const mintData: LazyMintData = {
@@ -277,6 +284,7 @@ describe('Asset Create', function () {
         metadataHash: '0x',
         maxSupply: BigInt(10),
         creator,
+        expirationTime: BigInt(await getCurrentTimestamp()) + 1000n,
       };
 
       const signature = await createSingleLazyMintSignature(mintData);
@@ -322,6 +330,7 @@ describe('Asset Create', function () {
         createBatchLazyMintSignature,
         AssetCreateContract,
         CatalystContractAsAdmin,
+        getCurrentTimestamp,
       } = await setupAssetCreateTests();
 
       const mintData: LazyMintBatchData = {
@@ -333,6 +342,7 @@ describe('Asset Create', function () {
         metadataHashes: ['0x'],
         maxSupplies: [BigInt(1)],
         creators: [creator],
+        expirationTime: BigInt(await getCurrentTimestamp()) + 1000n,
       };
 
       const signature = await createBatchLazyMintSignature(mintData);
@@ -375,6 +385,7 @@ describe('Asset Create', function () {
         createBatchLazyMintSignature,
         AssetCreateContract,
         CatalystContractAsAdmin,
+        getCurrentTimestamp,
       } = await setupAssetCreateTests();
 
       const mintData: LazyMintBatchData = {
@@ -386,6 +397,7 @@ describe('Asset Create', function () {
         metadataHashes: ['0x'],
         maxSupplies: [BigInt(1)],
         creators: [creator],
+        expirationTime: BigInt(await getCurrentTimestamp()) + 1000n,
       };
 
       // Mint catalysts to user
@@ -430,6 +442,7 @@ describe('Asset Create', function () {
         ExchangeContract,
         OrderValidatorContract,
         tsbCatSellerSigner,
+        getCurrentTimestamp,
       } = await setupAssetCreateTests();
 
       const mintData: LazyMintBatchData = {
@@ -441,6 +454,7 @@ describe('Asset Create', function () {
         metadataHashes: ['0x'],
         maxSupplies: [BigInt(10)],
         creators: [creator],
+        expirationTime: BigInt(await getCurrentTimestamp()) + 1000n,
       };
 
       const signature = await createBatchLazyMintSignature(mintData);
@@ -492,6 +506,7 @@ describe('Asset Create', function () {
         ExchangeContract,
         OrderValidatorContract,
         tsbCatSellerSigner,
+        getCurrentTimestamp,
       } = await setupAssetCreateTests();
 
       const mintData: LazyMintBatchData = {
@@ -503,6 +518,7 @@ describe('Asset Create', function () {
         metadataHashes: ['0x'],
         maxSupplies: [BigInt(10)],
         creators: [creator],
+        expirationTime: BigInt(await getCurrentTimestamp()) + 1000n,
       };
 
       const signature = await createBatchLazyMintSignature(mintData);
@@ -549,6 +565,7 @@ describe('Asset Create', function () {
         createBatchLazyMintSignature,
         AssetCreateContract,
         CatalystContractAsAdmin,
+        getCurrentTimestamp,
       } = await setupAssetCreateTests();
 
       const mintData: LazyMintBatchData = {
@@ -564,6 +581,7 @@ describe('Asset Create', function () {
         metadataHashes: ['0x1', '0x2', '0x3'],
         maxSupplies: [BigInt(1), BigInt(1), BigInt(1)],
         creators: [creator, creator, creator],
+        expirationTime: BigInt(await getCurrentTimestamp()) + 1000n,
       };
 
       const signature = await createBatchLazyMintSignature(mintData);
@@ -606,6 +624,7 @@ describe('Asset Create', function () {
         createBatchLazyMintSignature,
         AssetCreateContract,
         CatalystContractAsAdmin,
+        getCurrentTimestamp,
       } = await setupAssetCreateTests();
 
       const mintData: LazyMintBatchData = {
@@ -621,6 +640,7 @@ describe('Asset Create', function () {
         metadataHashes: ['0x1', '0x2', '0x3'],
         maxSupplies: [BigInt(1), BigInt(1), BigInt(1)],
         creators: [creator, creator, creator],
+        expirationTime: BigInt(await getCurrentTimestamp()) + 1000n,
       };
 
       // Mint catalysts to user
@@ -665,6 +685,7 @@ describe('Asset Create', function () {
         ExchangeContract,
         OrderValidatorContract,
         tsbCatSellerSigner,
+        getCurrentTimestamp,
       } = await setupAssetCreateTests();
 
       const mintData: LazyMintBatchData = {
@@ -680,6 +701,7 @@ describe('Asset Create', function () {
         metadataHashes: ['0x1', '0x2', '0x3'],
         maxSupplies: [BigInt(10), BigInt(10), BigInt(10)],
         creators: [creator, creator, creator],
+        expirationTime: BigInt(await getCurrentTimestamp()) + 1000n,
       };
 
       const signature = await createBatchLazyMintSignature(mintData);
@@ -732,6 +754,7 @@ describe('Asset Create', function () {
         createBatchLazyMintSignature,
         AssetCreateContract,
         CatalystContractAsAdmin,
+        getCurrentTimestamp,
       } = await setupAssetCreateTests();
 
       const randomHashes = Array(10)
@@ -747,6 +770,7 @@ describe('Asset Create', function () {
         metadataHashes: randomHashes,
         maxSupplies: Array(10).fill(BigInt(1)),
         creators: Array(10).fill(creator),
+        expirationTime: BigInt(await getCurrentTimestamp()) + 1000n,
       };
 
       const signature = await createBatchLazyMintSignature(mintData);
@@ -789,6 +813,7 @@ describe('Asset Create', function () {
         createBatchLazyMintSignature,
         AssetCreateContract,
         CatalystContractAsAdmin,
+        getCurrentTimestamp,
       } = await setupAssetCreateTests();
 
       const randomHashes = Array(10)
@@ -804,6 +829,7 @@ describe('Asset Create', function () {
         metadataHashes: randomHashes,
         maxSupplies: Array(10).fill(BigInt(1)),
         creators: Array(10).fill(creator),
+        expirationTime: BigInt(await getCurrentTimestamp()) + 1000n,
       };
 
       // Mint catalysts to user
@@ -848,6 +874,7 @@ describe('Asset Create', function () {
         ExchangeContract,
         OrderValidatorContract,
         tsbCatSellerSigner,
+        getCurrentTimestamp,
       } = await setupAssetCreateTests();
 
       const randomHashes = Array(10)
@@ -863,6 +890,7 @@ describe('Asset Create', function () {
         metadataHashes: randomHashes,
         maxSupplies: Array(10).fill(BigInt(10)),
         creators: Array(10).fill(creator),
+        expirationTime: BigInt(await getCurrentTimestamp()) + 1000n,
       };
 
       const signature = await createBatchLazyMintSignature(mintData);

--- a/packages/deploy/test/asset/assetCreateFixture.ts
+++ b/packages/deploy/test/asset/assetCreateFixture.ts
@@ -56,6 +56,10 @@ const setupAssetCreateTests = deployments.createFixture(
       parseEther('1000')
     );
 
+    const getCurrentTimestamp = async () => {
+      return (await ethers.provider.getBlock('latest'))!.timestamp;
+    };
+
     // Mint 100 of each catalyst to lazyMintingCatSeller
     for (let i = 1; i <= 5; i++) {
       await CatalystContractAsAdmin.mint(
@@ -95,6 +99,7 @@ const setupAssetCreateTests = deployments.createFixture(
       user: lazyMintingTestAccount1,
       userSigner,
       creator: lazyMintingTestAccount2,
+      getCurrentTimestamp,
     };
   }
 );

--- a/packages/deploy/test/asset/assetCreateFixture.ts
+++ b/packages/deploy/test/asset/assetCreateFixture.ts
@@ -57,7 +57,7 @@ const setupAssetCreateTests = deployments.createFixture(
     );
 
     const getCurrentTimestamp = async () => {
-      return (await ethers.provider.getBlock('latest'))!.timestamp;
+      return (await ethers.provider.getBlock('latest'))?.timestamp || 0;
     };
 
     // Mint 100 of each catalyst to lazyMintingCatSeller

--- a/packages/deploy/utils/lazyMinting.ts
+++ b/packages/deploy/utils/lazyMinting.ts
@@ -18,6 +18,7 @@ export type LazyMintData = {
   metadataHash: string;
   maxSupply: bigint;
   creator: string;
+  expirationTime: bigint;
 };
 
 export type LazyMintBatchData = {
@@ -29,6 +30,7 @@ export type LazyMintBatchData = {
   metadataHashes: string[];
   maxSupplies: bigint[];
   creators: string[];
+  expirationTime: bigint;
 };
 
 export type Order = {
@@ -213,6 +215,7 @@ export const createLazyMintSignature = async (
     metadataHash,
     maxSupply,
     creator,
+    expirationTime,
   } = data;
   const nonce = await AssetCreateContract.signatureNonces(caller);
 
@@ -232,6 +235,7 @@ export const createLazyMintSignature = async (
         {name: 'paymentToken', type: 'address'},
         {name: 'metadataHash', type: 'string'},
         {name: 'maxSupply', type: 'uint256'},
+        {name: 'expirationTime', type: 'uint256'},
       ],
     },
     domain: {
@@ -250,6 +254,7 @@ export const createLazyMintSignature = async (
       paymentToken,
       metadataHash,
       maxSupply,
+      expirationTime,
     },
   };
 
@@ -275,6 +280,7 @@ export const createMultipleLazyMintSignature = async (
     paymentTokens,
     metadataHashes,
     maxSupplies,
+    expirationTime,
   } = data;
   const nonce = await AssetCreateContract.signatureNonces(caller);
   const backendAuthWallet = new ethers.Wallet(
@@ -293,6 +299,7 @@ export const createMultipleLazyMintSignature = async (
         {name: 'paymentTokens', type: 'address[]'},
         {name: 'metadataHashes', type: 'string[]'},
         {name: 'maxSupplies', type: 'uint256[]'},
+        {name: 'expirationTime', type: 'uint256'},
       ],
     },
     domain: {
@@ -311,6 +318,7 @@ export const createMultipleLazyMintSignature = async (
       paymentTokens,
       metadataHashes,
       maxSupplies,
+      expirationTime,
     },
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2492,6 +2492,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sandbox-smart-contracts/asset@1.1.0@npm:@sandbox-smart-contracts/asset@1.1.0":
+  version: 1.1.0
+  resolution: "@sandbox-smart-contracts/asset@npm:1.1.0"
+  dependencies:
+    "@manifoldxyz/libraries-solidity": ^1.0.4
+    "@manifoldxyz/royalty-registry-solidity": ^2.0.3
+    "@openzeppelin/contracts": 4.9.3
+    "@openzeppelin/contracts-upgradeable": 4.9.3
+    "@sandbox-smart-contracts/dependency-metatx": 1.0.1
+    "@sandbox-smart-contracts/dependency-operator-filter": 1.0.1
+    "@sandbox-smart-contracts/dependency-royalty-management": 1.0.2
+  checksum: 7743dcd914c2a8965a928999833ed836e9f122ef0e382014ef339b405e253f93da67aea73140c4314021c0d4829326b0283da2cfe11041c188b461422fd800d6
+  languageName: node
+  linkType: hard
+
 "@sandbox-smart-contracts/asset@1.2.0, @sandbox-smart-contracts/asset@workspace:packages/asset":
   version: 0.0.0-use.local
   resolution: "@sandbox-smart-contracts/asset@workspace:packages/asset"
@@ -2809,6 +2824,7 @@ __metadata:
     "@openzeppelin/hardhat-upgrades": ^2.5.0
     "@openzeppelin/upgrades-core": ^1.32.3
     "@sandbox-smart-contracts/asset": 1.2.0
+    "@sandbox-smart-contracts/asset@1.1.0": "npm:@sandbox-smart-contracts/asset@1.1.0"
     "@sandbox-smart-contracts/avatar": "*"
     "@sandbox-smart-contracts/core": "*"
     "@sandbox-smart-contracts/dependency-operator-filter": 1.0.1


### PR DESCRIPTION
## Description

This PR adds an overload to `verify` function in `AuthSuperValidator` that also accepts the `expirationTime`.
The value is compared against current block timestamp and if its larger than the `expirationTime` the verification fails.

This change will require `AuthSuperValidator` to be deployed together with lazy minting feature implementation in `AssetCreate`.