### PR TITLE
feat: add a hardhat task to steal basecoin when forking

### DIFF
--- a/packages/deploy/hardhat.config.ts
+++ b/packages/deploy/hardhat.config.ts
@@ -10,6 +10,7 @@ import {
   skipDeploymentsOnLiveNetworks,
 } from './utils/hardhatConfig';
 import './tasks/importedPackages';
+import './tasks/steal';
 
 // Package name : solidity source code path
 const importedPackages = {

--- a/packages/deploy/tasks/steal.ts
+++ b/packages/deploy/tasks/steal.ts
@@ -1,0 +1,34 @@
+import {task, types} from 'hardhat/config';
+import {TASK_DEPLOY} from 'hardhat-deploy';
+
+task(TASK_DEPLOY)
+  .addOptionalParam('stealAmount', 'amount to steal', '100', types.string)
+  .addOptionalParam(
+    'steal',
+    'list of  destination users to steal funds for',
+    '',
+    types.string
+  )
+  .setAction(async (args, hre, runSuper) => {
+    const {steal, stealAmount} = args;
+    const isFork =
+      'forking' in hre.network.config && hre.network.config.forking?.enabled;
+    if (isFork && steal) {
+      const destinations = steal.split(',');
+      const value = hre.ethers.parseUnits(stealAmount, 'ether');
+      const signers = await hre.ethers.getSigners();
+      const namedAccounts = hre.getNamedAccounts
+        ? await hre.getNamedAccounts()
+        : [];
+      for (const d of destinations) {
+        console.log(
+          `transferring ${hre.ethers.formatEther(value)} eth to ${d}`
+        );
+        await signers[0].sendTransaction({
+          to: namedAccounts[d] ? namedAccounts[d] : d,
+          value,
+        });
+      }
+    }
+    return runSuper(args, hre);
+  });

--- a/packages/deploy/tasks/steal.ts
+++ b/packages/deploy/tasks/steal.ts
@@ -1,3 +1,8 @@
+// This task must be used in combination with hardhat-deploy and live network forks.
+// When forking a live network it is pretty usual to need some funds on the named accounts of the live network.
+// This task "steals" funds by transferring them from the hardhat default accounts.
+// For example: `yarn fork:deploy amoy --tags "XXX" --steal sandAdmin,deployer`
+// Will move fund to sandAdmin and deployer.
 import {task, types} from 'hardhat/config';
 import {TASK_DEPLOY} from 'hardhat-deploy';
 


### PR DESCRIPTION
## Description
Add the argument `steal` to the `deploy` task of hardhat. When running in a fork and the `steal` argument is used some eth are transferred from the first signer of hardhat to the steal accounts.
For example: `yarn fork:deploy sepolia --tags "XXX" --steal sandAdmin,deployer` will steal 200 eth from the first signer of hardhat, 100 of them will be transferred to sandAdmin  and 100 to deployer,

Optionally you can pass stealAmount to steal a value different from 100eth for each user
