### PR TITLE
fix: fix the version of land pacakge used in deploy

### DIFF
--- a/packages/deploy/package.json
+++ b/packages/deploy/package.json
@@ -23,7 +23,7 @@
     "@sandbox-smart-contracts/dependency-royalty-management": "1.0.2",
     "@sandbox-smart-contracts/faucets": "0.0.1",
     "@sandbox-smart-contracts/giveaway": "0.0.3",
-    "@sandbox-smart-contracts/land": "0.0.3",
+    "@sandbox-smart-contracts/land": "1.0.0-rc.0",
     "@sandbox-smart-contracts/marketplace": "1.0.1"
   },
   "files": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2831,7 +2831,7 @@ __metadata:
     "@sandbox-smart-contracts/dependency-royalty-management": 1.0.2
     "@sandbox-smart-contracts/faucets": 0.0.1
     "@sandbox-smart-contracts/giveaway": 0.0.3
-    "@sandbox-smart-contracts/land": 0.0.3
+    "@sandbox-smart-contracts/land": 1.0.0-rc.0
     "@sandbox-smart-contracts/marketplace": 1.0.1
     "@typechain/ethers-v5": ^11.0.0
     "@typechain/hardhat": ^8.0.0
@@ -2997,14 +2997,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@sandbox-smart-contracts/land@npm:0.0.3":
-  version: 0.0.3
-  resolution: "@sandbox-smart-contracts/land@npm:0.0.3"
-  checksum: ba5cfbee73b782fd70af992ebeedec3f94144e8bfa99785b29420bc50aabe43630c52ffafbb2644228669ba88718b8e0f74beaef567af1acbcc612adf42fa5b8
-  languageName: node
-  linkType: hard
-
-"@sandbox-smart-contracts/land@workspace:packages/land":
+"@sandbox-smart-contracts/land@1.0.0-rc.0, @sandbox-smart-contracts/land@workspace:packages/land":
   version: 0.0.0-use.local
   resolution: "@sandbox-smart-contracts/land@workspace:packages/land"
   dependencies:


### PR DESCRIPTION
## Description
currently yarn deployfails on the deploy package, here is the reason:
We merged Ayush PR which depends on land v0.0.3.
In practice the latest code from the local directory was taken, because the land version wasn't update yet so it is still v0.0.3, so instead of taking the [npmjs.com](http://npmjs.com/) version it takes the local one.
We released (and published) a new version of the land package to NPM. This changed the local version on master.
Now yarn deploy is broken because it takes the right v0.0.3 from [npmjs.com](http://npmjs.com/).
Another reason to move the deploy package out of our repo (edited)