### PR TITLE
[LazyMinting] Do not index creator arrays

### DIFF
--- a/packages/asset/contracts/interfaces/IAssetCreate.sol
+++ b/packages/asset/contracts/interfaces/IAssetCreate.sol
@@ -71,7 +71,7 @@ interface IAssetCreate {
     );
     event AssetBatchLazyMinted(
         address indexed recipient,
-        address[] indexed creators,
+        address[] creators,
         uint256[] tokenIds,
         uint8[] tiers,
         uint256[] amounts,


### PR DESCRIPTION
## Description

Indexing an array causes issues in the blockchain listeners and is not required in this event so we want to remove it.
Since this change does not touch the logic of the contract we want to make this change without audit.
