### PR TITLE
Small changes to merge after the audit

### DIFF
--- a/packages/land/contracts/common/LandBase.sol
+++ b/packages/land/contracts/common/LandBase.sol
@@ -8,6 +8,9 @@ import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {IERC721Metadata} from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
 import {IOperatorFilterRegistry} from "../interfaces/IOperatorFilterRegistry.sol";
 import {IERC173} from "../interfaces/IERC173.sol";
+import {ILandToken} from "../interfaces/ILandToken.sol";
+import {IQuad} from "../interfaces/IQuad.sol";
+import {ILandMetadataRegistry} from "../interfaces/ILandMetadataRegistry.sol";
 import {IERC721BatchOps} from "../interfaces/IERC721BatchOps.sol";
 import {WithAdmin} from "./WithAdmin.sol";
 import {OperatorFiltererUpgradeable} from "../common/OperatorFiltererUpgradeable.sol";
@@ -217,6 +220,10 @@ abstract contract LandBase is
             interfaceId == type(IERC721Metadata).interfaceId ||
             interfaceId == type(IERC165).interfaceId ||
             interfaceId == type(IERC173).interfaceId ||
-            interfaceId == type(IERC2981).interfaceId;
+            interfaceId == type(IERC2981).interfaceId ||
+            interfaceId == type(ILandToken).interfaceId ||
+            interfaceId == type(ILandToken).interfaceId ^ type(IQuad).interfaceId ||
+            interfaceId == type(IQuad).interfaceId ||
+            interfaceId == type(ILandMetadataRegistry).interfaceId;
     }
 }

--- a/packages/land/contracts/common/WithMetadataRegistry.sol
+++ b/packages/land/contracts/common/WithMetadataRegistry.sol
@@ -11,7 +11,7 @@ import {ILandMetadataRegistry} from "../interfaces/ILandMetadataRegistry.sol";
 /// @notice Add support for the metadata registry
 abstract contract WithMetadataRegistry is IErrors {
     /// @notice value returned when the neighborhood is not set yet.
-    string public constant UNKNOWN_NEIGHBORHOOD = "unknown";
+    string private constant UNKNOWN_NEIGHBORHOOD = "unknown";
 
     /// @notice emitted when the metadata registry is set
     /// @param metadataRegistry the address of the metadata registry

--- a/packages/land/contracts/interfaces/ILandToken.sol
+++ b/packages/land/contracts/interfaces/ILandToken.sol
@@ -2,36 +2,13 @@
 
 pragma solidity ^0.8.0;
 
+import {IQuad} from "./IQuad.sol";
+
 /// @title ILandToken
 /// @author The Sandbox
 /// @custom:security-contact contact-blockchain@sandbox.game
 /// @notice Interface of the LAND token including quad methods
-interface ILandToken {
-    /// @notice transfer multiple quad (aligned to a quad tree with size 3, 6, 12 or 24 only)
-    /// @param from current owner of the quad
-    /// @param to destination
-    /// @param sizes list of sizes for each quad
-    /// @param xs list of bottom left x coordinates for each quad
-    /// @param ys list of bottom left y coordinates for each quad
-    /// @param data additional data
-    function batchTransferQuad(
-        address from,
-        address to,
-        uint256[] calldata sizes,
-        uint256[] calldata xs,
-        uint256[] calldata ys,
-        bytes calldata data
-    ) external;
-
-    /// @notice transfer one quad (aligned to a quad tree with size 3, 6, 12 or 24 only)
-    /// @param from current owner of the quad
-    /// @param to destination
-    /// @param size size of the quad
-    /// @param x The bottom left x coordinate of the quad
-    /// @param y The bottom left y coordinate of the quad
-    /// @param data additional data
-    function transferQuad(address from, address to, uint256 size, uint256 x, uint256 y, bytes calldata data) external;
-
+interface ILandToken is IQuad {
     /// @notice Mint a new quad (aligned to a quad tree with size 1, 3, 6, 12 or 24 only)
     /// @param to The recipient of the new quad
     /// @param size The size of the new quad

--- a/packages/land/contracts/interfaces/IQuad.sol
+++ b/packages/land/contracts/interfaces/IQuad.sol
@@ -1,0 +1,34 @@
+//SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+/// @title IQuad
+/// @author The Sandbox
+/// @custom:security-contact contact-blockchain@sandbox.game
+/// @notice Interface of the LAND token (quad methods)
+interface IQuad {
+    /// @notice transfer multiple quad (aligned to a quad tree with size 3, 6, 12 or 24 only)
+    /// @param from current owner of the quad
+    /// @param to destination
+    /// @param sizes list of sizes for each quad
+    /// @param xs list of bottom left x coordinates for each quad
+    /// @param ys list of bottom left y coordinates for each quad
+    /// @param data additional data
+    function batchTransferQuad(
+        address from,
+        address to,
+        uint256[] calldata sizes,
+        uint256[] calldata xs,
+        uint256[] calldata ys,
+        bytes calldata data
+    ) external;
+
+    /// @notice transfer one quad (aligned to a quad tree with size 3, 6, 12 or 24 only)
+    /// @param from current owner of the quad
+    /// @param to destination
+    /// @param size size of the quad
+    /// @param x The bottom left x coordinate of the quad
+    /// @param y The bottom left y coordinate of the quad
+    /// @param data additional data
+    function transferQuad(address from, address to, uint256 size, uint256 x, uint256 y, bytes calldata data) external;
+}

--- a/packages/land/test/common/ERC721.behavior.ts
+++ b/packages/land/test/common/ERC721.behavior.ts
@@ -857,6 +857,25 @@ export function shouldCheckForERC721(setupLand, Contract: string) {
         expect(await LandAsOwner.supportsInterface('0x2a55205a')).to.be.true;
       });
 
+      it('claim to ILandToken interface combined with IQuad interface', async function () {
+        const {LandAsOwner} = await loadFixture(setupLand);
+        expect(await LandAsOwner.supportsInterface('0xe906a607')).to.be.true;
+      });
+
+      it('claim to ILandToken interface', async function () {
+        const {LandAsOwner} = await loadFixture(setupLand);
+        expect(await LandAsOwner.supportsInterface('0x3b18763a')).to.be.true;
+      });
+      it('claim to IQuad interface', async function () {
+        const {LandAsOwner} = await loadFixture(setupLand);
+        expect(await LandAsOwner.supportsInterface('0xd21ed03d')).to.be.true;
+      });
+
+      it('claim to ILandMetadataRegistry interface', async function () {
+        const {LandAsOwner} = await loadFixture(setupLand);
+        expect(await LandAsOwner.supportsInterface('0x519cd8d9')).to.be.true;
+      });
+
       it('does not claim to support random interface', async function () {
         const {LandAsOwner} = await loadFixture(setupLand);
         expect(await LandAsOwner.supportsInterface('0x88888888')).to.be.false;


### PR DESCRIPTION
## Description
- Add a few interfaces related to quad operations and metadata registry to `suppportInteface`
- Make `UNKNOWN_NEIGHBORHOOD` constant private in the land contract so it is not exposed in the abi.
- This PR include some minor changes that we are fixing in advance as a result of some comments from the auditors. If needed they will be split in separated PRs before merging this one.