### PR TITLE
Marketplace Sales Whitelists

### DIFF
--- a/packages/marketplace/contracts/Exchange.sol
+++ b/packages/marketplace/contracts/Exchange.sol
@@ -37,6 +37,14 @@ contract Exchange is
     /// @return Hash for PAUSER_ROLE.
     bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
 
+    /// @notice Role for TSB owned addresses that list TSB owned assets for sale, forces primary sales conditions.
+    /// @return Hash for TSB_SELLER_ROLE.
+    bytes32 public constant TSB_SELLER_ROLE = keccak256("TSB_SELLER_ROLE");
+
+    /// @notice Role for addresses that should be whitelisted from any marketplace fees including royalties.
+    /// @return Hash for FEE_WHITELIST_ROLE.
+    bytes32 public constant FEE_WHITELIST_ROLE = keccak256("FEE_WHITELIST_ROLE");
+
     /// @dev This protects the implementation contract from being initialized.
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -156,11 +164,18 @@ contract Exchange is
         _unpause();
     }
 
-    /// @dev Check if fees & royalties should be skipped for users with the EXCHANGE_ADMIN_ROLE.
+    /// @dev Check if fees & royalties should be skipped for users with the FEE_WHITELIST_ROLE.
     /// @param from Address to check.
     /// @return True if fees should be skipped, false otherwise.
     function _mustSkipFees(address from) internal view override returns (bool) {
-        return hasRole(EXCHANGE_ADMIN_ROLE, from);
+        return hasRole(FEE_WHITELIST_ROLE, from);
+    }
+
+    /// @dev Check if the address is a TSB seller, which forces primary sales conditions regardless if the seller is the creator of the token.
+    /// @param from Address to check.
+    /// @return True if the address is a TSB seller, false otherwise.
+    function _isTSBSeller(address from) internal view override returns (bool) {
+        return hasRole(TSB_SELLER_ROLE, from);
     }
 
     function _msgSender()

--- a/packages/marketplace/contracts/TransferManager.sol
+++ b/packages/marketplace/contracts/TransferManager.sol
@@ -110,7 +110,7 @@ abstract contract TransferManager is Initializable, ITransferManager {
         // Transfer NFT or left side if FeeSide.NONE
         _transfer(nftSide.asset, nftSide.account, paymentSide.recipient);
         // Transfer ERC20 or right side if FeeSide.NONE
-        if (feeSide == LibAsset.FeeSide.NONE || _mustSkipFees(paymentSide.account)) {
+        if (feeSide == LibAsset.FeeSide.NONE || _mustSkipFees(nftSide.account)) {
             _transfer(paymentSide.asset, paymentSide.account, nftSide.recipient);
         } else {
             _doTransfersWithFeesAndRoyalties(paymentSide, nftSide);
@@ -166,7 +166,7 @@ abstract contract TransferManager is Initializable, ITransferManager {
     function _doTransfersWithFeesAndRoyalties(DealSide memory paymentSide, DealSide memory nftSide) internal {
         uint256 fees;
         uint256 remainder = paymentSide.asset.value;
-        if (_isPrimaryMarket(nftSide)) {
+        if (_isTSBSeller(nftSide.account) || _isPrimaryMarket(nftSide)) {
             fees = protocolFeePrimary;
             // No royalties
         } else {
@@ -353,6 +353,10 @@ abstract contract TransferManager is Initializable, ITransferManager {
     /// @notice Function deciding if the fees are applied or not, to be override
     /// @param from Address to check
     function _mustSkipFees(address from) internal virtual returns (bool);
+
+    /// @notice Function deciding if the seller is a TSB seller, to be override
+    /// @param from Address to check
+    function _isTSBSeller(address from) internal virtual returns (bool);
 
     // slither-disable-next-line unused-state
     uint256[49] private __gap;

--- a/packages/marketplace/docs/Exchange.md
+++ b/packages/marketplace/docs/Exchange.md
@@ -328,7 +328,7 @@ The contract supports the ERC2771 standard to enable meta transactions.
 
 The protocol is secured with the Open Zeppelin access control component.
 
-4 roles are defined:
+6 roles are defined:
 
 - `DEFAULT_ADMIN_ROLE`: handle the roles & users and the technical settings
   (trusted forwarder, order validator contract addresses)
@@ -337,6 +337,10 @@ The protocol is secured with the Open Zeppelin access control component.
 - `ERC1776_OPERATOR_ROLE`: allow an operator to execute an exchange on behalf of
   a sender
 - `PAUSER_ROLE`: allow to control the pausing of the contract
+- `TSB_SELLER_ROLE` - allows bypassing primary market check for TSB owned seller
+  accounts
+- `FEE_WHITELIST_ROLE` - allows bypassing all fees for whitelisted accounts
+  (seller side only)
 
 ### ERC1776
 

--- a/packages/marketplace/test/exchange/MatchOrdersWithRoyalties.behavior.ts
+++ b/packages/marketplace/test/exchange/MatchOrdersWithRoyalties.behavior.ts
@@ -1,16 +1,16 @@
+import {loadFixture} from '@nomicfoundation/hardhat-network-helpers';
 import {expect} from 'chai';
 import {deployFixtures} from '../fixtures/index.ts';
-import {loadFixture} from '@nomicfoundation/hardhat-network-helpers';
 import {
+  Asset,
   AssetERC20,
   AssetERC721,
   FeeRecipientsData,
   LibPartData,
-  Asset,
 } from '../utils/assets.ts';
 
-import {hashKey, OrderDefault, signOrder, Order} from '../utils/order.ts';
-import {ZeroAddress, Contract, Signer} from 'ethers';
+import {Contract, Signer, ZeroAddress} from 'ethers';
+import {Order, OrderDefault, hashKey, signOrder} from '../utils/order.ts';
 
 // eslint-disable-next-line mocha/no-exports
 export function shouldMatchOrdersWithRoyalty() {
@@ -40,7 +40,8 @@ export function shouldMatchOrdersWithRoyalty() {
       orderRight: Order,
       makerSig: string,
       takerSig: string,
-      EXCHANGE_ADMIN_ROLE: string;
+      TSB_SELLER_ROLE: string,
+      FEE_WHITELIST_ROLE: string;
 
     beforeEach(async function () {
       ({
@@ -63,7 +64,8 @@ export function shouldMatchOrdersWithRoyalty() {
         admin: receiver1,
         user: receiver2,
         deployer: royaltyReceiver,
-        EXCHANGE_ADMIN_ROLE,
+        TSB_SELLER_ROLE,
+        FEE_WHITELIST_ROLE,
       } = await loadFixture(deployFixtures));
 
       await ERC20Contract.mint(taker.getAddress(), 10000000000);
@@ -571,7 +573,7 @@ export function shouldMatchOrdersWithRoyalty() {
       );
     });
 
-    it('should execute a complete match order without fee and royalties for privileged seller', async function () {
+    it('should execute a complete match order without royalties but with primary market fees for address with TSB_SELLER_ROLE', async function () {
       await ERC721WithRoyaltyV2981.mint(maker.getAddress(), 1, [
         await FeeRecipientsData(maker.getAddress(), 10000),
       ]);
@@ -589,8 +591,98 @@ export function shouldMatchOrdersWithRoyalty() {
 
       // grant exchange admin role to seller
       await ExchangeContractAsDeployer.connect(admin).grantRole(
-        EXCHANGE_ADMIN_ROLE,
-        taker.getAddress()
+        TSB_SELLER_ROLE,
+        maker.getAddress()
+      );
+
+      ERC721Asset = await AssetERC721(ERC721WithRoyaltyV2981, 1);
+      orderLeft = await OrderDefault(
+        maker,
+        ERC721Asset,
+        ZeroAddress,
+        ERC20Asset,
+        1,
+        0,
+        0
+      );
+      orderRight = await OrderDefault(
+        taker,
+        ERC20Asset,
+        ZeroAddress,
+        ERC721Asset,
+        1,
+        0,
+        0
+      );
+      makerSig = await signOrder(orderLeft, maker, OrderValidatorAsAdmin);
+      takerSig = await signOrder(orderRight, taker, OrderValidatorAsAdmin);
+
+      expect(
+        await ExchangeContractAsUser.fills(hashKey(orderLeft))
+      ).to.be.equal(0);
+      expect(
+        await ExchangeContractAsUser.fills(hashKey(orderRight))
+      ).to.be.equal(0);
+      expect(await ERC721WithRoyaltyV2981.ownerOf(1)).to.be.equal(
+        await maker.getAddress()
+      );
+      expect(await ERC20Contract.balanceOf(taker.getAddress())).to.be.equal(
+        10000000000
+      );
+
+      await ExchangeContractAsUser.matchOrders([
+        {
+          orderLeft,
+          signatureLeft: makerSig,
+          orderRight,
+          signatureRight: takerSig,
+        },
+      ]);
+      expect(
+        await ExchangeContractAsUser.fills(hashKey(orderLeft))
+      ).to.be.equal(10000000000);
+      expect(
+        await ExchangeContractAsUser.fills(hashKey(orderRight))
+      ).to.be.equal(1);
+      expect(await ERC721WithRoyaltyV2981.ownerOf(1)).to.be.equal(
+        await taker.getAddress()
+      );
+
+      // PRIMARY protocol fee paid
+      expect(
+        await ERC20Contract.balanceOf(defaultFeeReceiver.getAddress())
+      ).to.be.equal(123000000);
+
+      // no royalties paid
+      expect(await ERC20Contract.balanceOf(deployer.getAddress())).to.be.equal(
+        0
+      );
+
+      expect(await ERC20Contract.balanceOf(maker.getAddress())).to.be.equal(
+        10000000000 - 123000000
+      );
+    });
+
+    it('should execute a complete match order without any fees for address with FEE_WHITELIST_ROLE', async function () {
+      await ERC721WithRoyaltyV2981.mint(maker.getAddress(), 1, [
+        await FeeRecipientsData(maker.getAddress(), 10000),
+      ]);
+
+      await ERC721WithRoyaltyV2981.connect(maker).approve(
+        await ExchangeContractAsUser.getAddress(),
+        1
+      );
+
+      // set up receiver
+      await ERC721WithRoyaltyV2981.setRoyaltiesReceiver(
+        1,
+        deployer.getAddress()
+      );
+
+      // grant exchange admin role to seller
+      await ExchangeContractAsDeployer.connect(admin).grantRole(
+        FEE_WHITELIST_ROLE,
+        maker.getAddress()
       );
 
       ERC721Asset = await AssetERC721(ERC721WithRoyaltyV2981, 1);

--- a/packages/marketplace/test/fixtures/index.ts
+++ b/packages/marketplace/test/fixtures/index.ts
@@ -1,8 +1,8 @@
-import {ethers} from 'hardhat';
 import {ZeroAddress} from 'ethers';
+import {ethers} from 'hardhat';
 
-import {exchangeSetup} from './exchange';
 import {mockAssetsSetup} from './assets';
+import {exchangeSetup} from './exchange';
 
 export async function deployFixturesWithoutWhitelist() {
   const [deployer, admin, user, defaultFeeReceiver, user1, user2, user3] =
@@ -14,6 +14,8 @@ export async function deployFixturesWithoutWhitelist() {
 
   const {ExchangeContractAsAdmin} = exchange;
 
+  const TSB_SELLER_ROLE = await ExchangeContractAsAdmin.TSB_SELLER_ROLE();
+  const FEE_WHITELIST_ROLE = await ExchangeContractAsAdmin.FEE_WHITELIST_ROLE();
   const EXCHANGE_ADMIN_ROLE =
     await ExchangeContractAsAdmin.EXCHANGE_ADMIN_ROLE();
   const DEFAULT_ADMIN_ROLE = await ExchangeContractAsAdmin.DEFAULT_ADMIN_ROLE();
@@ -25,6 +27,8 @@ export async function deployFixturesWithoutWhitelist() {
     ...exchange,
     ...mockAssets,
     EXCHANGE_ADMIN_ROLE,
+    TSB_SELLER_ROLE,
+    FEE_WHITELIST_ROLE,
     DEFAULT_ADMIN_ROLE,
     ERC1776_OPERATOR_ROLE,
     PAUSER_ROLE,


### PR DESCRIPTION
## Description


1. This PR aims to fix the issue of whitelisting buyers instead of sellers with from paying any fees on the marketplace, by replacing the side of the check

```solidity
       if (feeSide == LibAsset.FeeSide.NONE || _mustSkipFees(paymentSide.account)) {
   >>> if (feeSide == LibAsset.FeeSide.NONE || _mustSkipFees(nftSide.account)) {
```

For the above we have previously used the `EXCHANGE_ADMIN_ROLE`, but since that role can be used for other potentially dangerous actions like pausing the contract, I have decided to create a new role for the fee whitelist called  `FEE_WHITELIST_ROLE`.

2. We also want to add the possibility to sell assets as primary sale (without royalty) if TSB is selling own assets, previously the primary market sales were only happening for contracts that support the `IRoyaltyUGC` interface. 

There was a new `TSB_SELLER_ROLE` role added that can also allow specific sellers to list items as if they were primary market sales.

