### PR TITLE
fix: N-05 Incorrect Documentation

### DIFF
--- a/packages/land/contracts/common/LandBase.sol
+++ b/packages/land/contracts/common/LandBase.sol
@@ -36,7 +36,7 @@ abstract contract LandBase is
         _disableInitializers();
     }
 
-    /// @notice Initializes the contract with the meta-transaction contract, admin & royalty-manager
+    /// @notice Initializes the contract admin
     /// @param admin Admin of the contract
     function initialize(address admin) external initializer {
         // We must be able to initialize the admin if this is a fresh deploy, but we want to

--- a/packages/land/contracts/common/LandBaseToken.sol
+++ b/packages/land/contracts/common/LandBaseToken.sol
@@ -393,7 +393,7 @@ abstract contract LandBaseToken is IErrors, ILandToken, ERC721BaseToken {
                 revert AlreadyMinted(id);
             }
         } else {
-            // when the size is smaller than the quadCompare size the owner of all the smaller quads with size
+            // when the size is greater than the quadCompare size the owner of all the greater quads with size
             // quadCompare size in the quad to be minted are checked if they are minted or not
             uint256 toX = x + size;
             uint256 toY = y + size;

--- a/packages/land/contracts/common/OperatorFiltererUpgradeable.sol
+++ b/packages/land/contracts/common/OperatorFiltererUpgradeable.sol
@@ -30,7 +30,6 @@ abstract contract OperatorFiltererUpgradeable is Context {
 
     modifier onlyAllowedOperator(address from) virtual {
         IOperatorFilterRegistry registry = _readOperatorFilterRegistry();
-        // Check registry code length to facilitate testing in environments without a deployed registry.
         // Allow spending tokens from addresses with balance
         // Note that this still allows listings and marketplaces with escrow to transfer tokens if transferred
         // from an EOA.


### PR DESCRIPTION
## Description
Throughout the codebase, a few instances of incorrect docstrings and inline comments were found:

The comments of the [_checkQuadIsNotMinted](https://github.com/thesandboxgame/sandbox-smart-contracts/blob/3911872e4438cd9a1c2d8552896123ce2b2d6438/packages/land/contracts/common/LandBaseToken.sol#L396) function incorrectly state that "when the size is smaller...".
The docstring for the [initialize](https://github.com/thesandboxgame/sandbox-smart-contracts/blob/3911872e4438cd9a1c2d8552896123ce2b2d6438/packages/land/contracts/common/LandBase.sol#L39) function incorrectly says that it initializes "meta-transaction contract, admin & royalty-manager", whereas it only initializes the admin.
The [docstring in line 33](https://github.com/thesandboxgame/sandbox-smart-contracts/blob/3911872e4438cd9a1c2d8552896123ce2b2d6438/packages/land/contracts/common/OperatorFiltererUpgradeable.sol#L33) of the OperatorFiltererUpgradeable contract is unnecessary as the registry code length is not checked unless the caller is not the from address.
To improve the readability of the codebase, consider fixing any incorrect or outdated docstrings and comments.a