### PR TITLE
fix: N-06 Redundant Code

### DIFF
--- a/packages/land/contracts/common/LandBaseToken.sol
+++ b/packages/land/contracts/common/LandBaseToken.sol
@@ -734,8 +734,8 @@ abstract contract LandBaseToken is IErrors, ILandToken, ERC721BaseToken {
 
     /// @notice return the owner of a quad given his size and coordinates or zero if is not minted yet.
     /// @param size The size of the quad
-    /// @param x The bottom left x coordinate of the quad
-    /// @param y The bottom left y coordinate of the quad
+    /// @param x coordinate inside the quad
+    /// @param y coordinate inside the quad
     /// @return the address of the owner
     function _ownerOfQuad(uint256 size, uint256 x, uint256 y) internal view returns (address) {
         (uint256 layer, uint256 parentSize, ) = _getQuadLayer(size);
@@ -772,7 +772,7 @@ abstract contract LandBaseToken is IErrors, ILandToken, ERC721BaseToken {
             owner = address(uint160(owner1x1));
             operatorEnabled = (owner1x1 & OPERATOR_FLAG) == OPERATOR_FLAG;
         } else {
-            owner = _ownerOfQuad(3, (x * 3) / 3, (y * 3) / 3);
+            owner = _ownerOfQuad(3, x, y);
             operatorEnabled = false;
         }
     }

--- a/packages/land/contracts/common/OperatorFiltererUpgradeable.sol
+++ b/packages/land/contracts/common/OperatorFiltererUpgradeable.sol
@@ -33,8 +33,7 @@ abstract contract OperatorFiltererUpgradeable is Context {
     /// @notice Used in transfer from operations to check if the sender of the token is allowed to call this contract
     /// @param from the sender of the token
     modifier onlyAllowedOperator(address from) virtual {
-        IOperatorFilterRegistry registry = _readOperatorFilterRegistry();
-        // Allow spending tokens from addresses with balance
+        // Allow spending tokens from addresses with balance (from == _msgSender())
         // Note that this still allows listings and marketplaces with escrow to transfer tokens if transferred
         // from an EOA.
         if (from != _msgSender()) {

--- a/packages/land/contracts/registry/LandMetadataBase.sol
+++ b/packages/land/contracts/registry/LandMetadataBase.sol
@@ -1,13 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.23;
 
-import {AccessControlEnumerableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/extensions/AccessControlEnumerableUpgradeable.sol";
-
 /// @title LandMetadataBase
 /// @author The Sandbox
 /// @custom:security-contact contact-blockchain@sandbox.game
 /// @notice Store information about the lands (premiumness and neighborhood)
-abstract contract LandMetadataBase is AccessControlEnumerableUpgradeable {
+abstract contract LandMetadataBase {
     /// @notice the base token id used for a batch operation is wrong
     /// @param tokenId the id of the token
     error InvalidBaseTokenId(uint256 tokenId);


### PR DESCRIPTION
## Description
Throughout the codebase, some instances of redundant code were found:

Within the _ownerAndOperatorEnabledOf function of the LandBaseToken contract, the [multiplication and division by 3](https://github.com/thesandboxgame/sandbox-smart-contracts/blob/3911872e4438cd9a1c2d8552896123ce2b2d6438/packages/land/contracts/common/LandBaseToken.sol#L772) is unnecessary.
The [registry variable is assigned](https://github.com/thesandboxgame/sandbox-smart-contracts/blob/3911872e4438cd9a1c2d8552896123ce2b2d6438/packages/land/contracts/common/OperatorFiltererUpgradeable.sol#L32) within the onlyAllowedOperator modifier but it is not used.
The LandMetadataBase contract unnecessarily [inherits the AccessControlEnumerableUpgradeable contract](https://github.com/thesandboxgame/sandbox-smart-contracts/blob/3911872e4438cd9a1c2d8552896123ce2b2d6438/packages/land/contracts/registry/LandMetadataBase.sol#L10).
To reduce unnecessary gas consumption and improve code readability, consider removing any redundant code.