### PR TITLE
fix: N-04 Typographical Errors

### DIFF
--- a/packages/land/contracts/Land.md
+++ b/packages/land/contracts/Land.md
@@ -39,7 +39,7 @@ The land contract support the following roles:
 - minters: a list of addresses that can mint lands.
 - super operators: a list of addresses that are automatically approved to
   transfer tokens between users.
-- meta transaction processor: an address that can transfer lands in behalf of
+- meta transaction processor: an address that can transfer lands on behalf of
   other users and used to implement meta-transactions. On the L2 contract this
   role is the ERC2771 meta transaction forwarder.
 

--- a/packages/land/contracts/common/ERC721BaseToken.sol
+++ b/packages/land/contracts/common/ERC721BaseToken.sol
@@ -334,7 +334,7 @@ abstract contract ERC721BaseToken is IERC721, IERC721BatchOps, IERC721Errors, IE
 
     /// @notice Subtract tokens to the owner balance
     /// @param who the owner of the token
-    /// @param val how much to add to the owner's balance
+    /// @param val how much to subtract from the owner's balance
     /// @dev we can use unchecked because there is a limited number of lands 408x408
     function _subNumNFTPerAddress(address who, uint256 val) internal {
         unchecked {

--- a/packages/land/contracts/common/ERC721BaseToken.sol
+++ b/packages/land/contracts/common/ERC721BaseToken.sol
@@ -87,7 +87,7 @@ abstract contract ERC721BaseToken is IERC721, IERC721BatchOps, IERC721Errors, IE
         }
     }
 
-    /// @notice Transfer a token between 2 addresses letting the receiver knows of the transfer.
+    /// @notice Transfer a token between 2 addresses letting the receiver know of the transfer.
     /// @param from The sender of the token.
     /// @param to The recipient of the token.
     /// @param tokenId The id of the token.
@@ -324,8 +324,8 @@ abstract contract ERC721BaseToken is IERC721, IERC721BatchOps, IERC721Errors, IE
 
     /// @notice Add tokens to the owner balance
     /// @param who the owner of the token
-    /// @param val how must to add to the owner balance
-    /// @dev we can use unchecked becase there is a limited number of lands 408x408
+    /// @param val how much to add to the owner's balance
+    /// @dev we can use unchecked because there is a limited number of lands 408x408
     function _addNumNFTPerAddress(address who, uint256 val) internal {
         unchecked {
             _writeNumNFTPerAddress(who, _readNumNFTPerAddress(who) + val);
@@ -334,15 +334,15 @@ abstract contract ERC721BaseToken is IERC721, IERC721BatchOps, IERC721Errors, IE
 
     /// @notice Subtract tokens to the owner balance
     /// @param who the owner of the token
-    /// @param val how must to subtract to the owner balance
-    /// @dev we can use unchecked becase there is a limited number of lands 408x408
+    /// @param val how much to add to the owner's balance
+    /// @dev we can use unchecked because there is a limited number of lands 408x408
     function _subNumNFTPerAddress(address who, uint256 val) internal {
         unchecked {
             _writeNumNFTPerAddress(who, _readNumNFTPerAddress(who) - val);
         }
     }
 
-    /// @notice Move balance between to users
+    /// @notice Move balance between two users
     /// @param from address to subtract from
     /// @param to address to add from
     /// @param quantity how many tokens to move
@@ -388,7 +388,7 @@ abstract contract ERC721BaseToken is IERC721, IERC721BatchOps, IERC721Errors, IE
     /// @return true if the operator has access
     function _isOperatorForAll(address owner, address operator) internal view virtual returns (bool);
 
-    /// @notice Let an operator to access to all the tokens of a owner
+    /// @notice Provides an operator access to all the tokens of an owner
     /// @param owner that enabled the operator
     /// @param operator address to check if it was enabled
     /// @param enabled if true give access to the operator, else disable it

--- a/packages/land/contracts/common/LandBase.sol
+++ b/packages/land/contracts/common/LandBase.sol
@@ -165,7 +165,7 @@ abstract contract LandBase is
         _batchTransferFrom(from, to, ids, data, false);
     }
 
-    /// @notice Transfer a token between 2 addresses letting the receiver knows of the transfer
+    /// @notice Transfer a token between 2 addresses letting the receiver know of the transfer
     /// @param from The sender of the token
     /// @param to The recipient of the token
     /// @param tokenId The id of the token
@@ -173,7 +173,7 @@ abstract contract LandBase is
         _safeTransferFrom(from, to, tokenId, "");
     }
 
-    /// @notice Transfer a token between 2 addresses letting the receiver knows of the transfer
+    /// @notice Transfer a token between 2 addresses letting the receiver know of the transfer
     /// @param from The sender of the token
     /// @param to The recipient of the token
     /// @param tokenId The id of the token

--- a/packages/land/contracts/common/LandBaseToken.sol
+++ b/packages/land/contracts/common/LandBaseToken.sol
@@ -306,11 +306,11 @@ abstract contract LandBaseToken is IErrors, ILandToken, ERC721BaseToken {
     /// @param size The size of the quad being minted and transferred
     /// @param x The x-coordinate of the top-left corner of the quad being minted.
     /// @param y The y-coordinate of the top-left corner of the quad being minted.
-    /// @dev It recursively checks child quad of every size(excluding Lands of 1x1 size) are minted or not.
+    /// @dev It recursively checks whether child quad of every size (excluding Lands of 1x1 size) are minted or not.
     /// @dev Quad which are minted are pushed into quadMinted to also check if every Land of size 1x1 in
-    /// @dev the parent quad is minted or not. While checking if the every child Quad and Land is minted it
-    /// @dev also checks and clear the owner for quads which are minted. Finally it checks if the new owner
-    /// @dev if is a contract can handle ERC721 tokens or not and transfers the parent quad to new owner.
+    /// @dev the parent quad is minted or not. While checking if every child Quad and Land is minted it
+    /// @dev also checks and clears the owner for quads which are minted. Finally it checks if the new owner
+    /// @dev is a contract, can handle ERC-721 tokens, and transfers the parent quad to new owner.
     function _mintAndTransferQuad(
         address msgSender,
         address to,
@@ -340,13 +340,13 @@ abstract contract LandBaseToken is IErrors, ILandToken, ERC721BaseToken {
             );
         }
 
-        // Lopping around the Quad in land struct to generate ids of 1x1 land token and checking if they are owned by msg.sender
+        // Looping around the Quad in land struct to generate ids of 1x1 land token and checking if they are owned by msg.sender
         for (uint256 i = 0; i < size * size; i++) {
             uint256 _id = _idInPath(i, size, x, y);
             // checking land with token id "_id" is in the quadMinted array.
             bool isAlreadyMinted = _isQuadMinted(quadMinted, Land({x: _getX(_id), y: _getY(_id), size: 1}), index);
             if (isAlreadyMinted) {
-                // if land is in the quadMinted array there just emitting transfer event
+                // if land is in the quadMinted array, emit transfer event
                 emit Transfer(msgSender, to, _id);
             } else {
                 if (_getOwnerAddress(_id) == msgSender) {
@@ -354,7 +354,7 @@ abstract contract LandBaseToken is IErrors, ILandToken, ERC721BaseToken {
                     landMinted += 1;
                     emit Transfer(msgSender, to, _id);
                 } else {
-                    // else is checked if owned by the msgSender or not. If it is not owned by msgSender it should not have an owner.
+                    // else check if owned by the msgSender or not. If it is not owned by msgSender it should not have an owner.
                     if (_readOwnerData(_id) != 0) {
                         revert AlreadyMinted(_id);
                     }
@@ -433,7 +433,7 @@ abstract contract LandBaseToken is IErrors, ILandToken, ERC721BaseToken {
         uint256 toX = land.x + land.size;
         uint256 toY = land.y + land.size;
 
-        //Lopping around the Quad in land struct to check if the child quad are minted or not
+        // Looping around the Quad in land struct to check if the child quad are minted or not
         for (uint256 xi = land.x; xi < toX; xi += quadCompareSize) {
             for (uint256 yi = land.y; yi < toY; yi += quadCompareSize) {
                 //checking if the child Quad is minted or not. i.e Checks if the quad is in the quadMinted array.
@@ -560,7 +560,7 @@ abstract contract LandBaseToken is IErrors, ILandToken, ERC721BaseToken {
                     idsToTransfer[transferIndex] = id;
                     transferIndex++;
                 } else {
-                    // else it is not owned by any one and and pushed in teh idsToMint array
+                    // else it is not owned by any one and and pushed in the idsToMint array
                     idsToMint[mintIndex] = id;
                     mintIndex++;
                 }

--- a/packages/land/contracts/registry/LandMetadataBase.sol
+++ b/packages/land/contracts/registry/LandMetadataBase.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.23;
 
 import {AccessControlEnumerableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/extensions/AccessControlEnumerableUpgradeable.sol";
 
-/// @title LandMetadataRegistry
+/// @title LandMetadataBase
 /// @author The Sandbox
 /// @custom:security-contact contact-blockchain@sandbox.game
 /// @notice Store information about the lands (premiumness and neighborhood)


### PR DESCRIPTION
## Description
Throughout the codebase, several instances of typographical errors were found:

In the [documentation](https://github.com/thesandboxgame/sandbox-smart-contracts/blob/3911872e4438cd9a1c2d8552896123ce2b2d6438/packages/land/contracts/Land.md#roles) about the meta transaction processor role, "in behalf of other users" should be "on behalf of other users".
In [line 90](https://github.com/thesandboxgame/sandbox-smart-contracts/blob/3911872e4438cd9a1c2d8552896123ce2b2d6438/packages/land/contracts/common/ERC721BaseToken.sol#L90) of ERC721BaseToken.sol, "knows" should be "know".
In [line 327](https://github.com/thesandboxgame/sandbox-smart-contracts/blob/3911872e4438cd9a1c2d8552896123ce2b2d6438/packages/land/contracts/common/ERC721BaseToken.sol#L327) and [line 337](https://github.com/thesandboxgame/sandbox-smart-contracts/blob/3911872e4438cd9a1c2d8552896123ce2b2d6438/packages/land/contracts/common/ERC721BaseToken.sol#L337) of ERC721BaseToken.sol, "how must to add to the owner balance" should be "how much to add to the owner's balance".
In [line 328](https://github.com/thesandboxgame/sandbox-smart-contracts/blob/3911872e4438cd9a1c2d8552896123ce2b2d6438/packages/land/contracts/common/ERC721BaseToken.sol#L328) and [line 338](https://github.com/thesandboxgame/sandbox-smart-contracts/blob/3911872e4438cd9a1c2d8552896123ce2b2d6438/packages/land/contracts/common/ERC721BaseToken.sol#L339) of ERC721BaseToken.sol, "becase" should be "because".
In [line 345](https://github.com/thesandboxgame/sandbox-smart-contracts/blob/3911872e4438cd9a1c2d8552896123ce2b2d6438/packages/land/contracts/common/ERC721BaseToken.sol#L345) of ERC721BaseToken.sol, "between to users" should be "between two users".
In [line 391](https://github.com/thesandboxgame/sandbox-smart-contracts/blob/3911872e4438cd9a1c2d8552896123ce2b2d6438/packages/land/contracts/common/ERC721BaseToken.sol#L391) of ERC721BaseToken.sol, "Let an operator to access to all the tokens of a owner" should be "Provides an operator access to all the tokens of an owner".
In [line 168](https://github.com/thesandboxgame/sandbox-smart-contracts/blob/3911872e4438cd9a1c2d8552896123ce2b2d6438/packages/land/contracts/common/LandBase.sol#L168) and [line 176](https://github.com/thesandboxgame/sandbox-smart-contracts/blob/3911872e4438cd9a1c2d8552896123ce2b2d6438/packages/land/contracts/common/LandBase.sol#L176) of LandBase.sol, "knows" should be "know".
In [line 309](https://github.com/thesandboxgame/sandbox-smart-contracts/blob/3911872e4438cd9a1c2d8552896123ce2b2d6438/packages/land/contracts/common/LandBaseToken.sol#L309) of LandBaseToken.sol, "recursively checks child quad" should be "recursively checks whether child quad".
In [line 311](https://github.com/thesandboxgame/sandbox-smart-contracts/blob/3911872e4438cd9a1c2d8552896123ce2b2d6438/packages/land/contracts/common/LandBaseToken.sol#L311) of LandBaseToken.sol, "if the every child" should be "if every child".
In [line 312](https://github.com/thesandboxgame/sandbox-smart-contracts/blob/3911872e4438cd9a1c2d8552896123ce2b2d6438/packages/land/contracts/common/LandBaseToken.sol#L312) of LandBaseToken.sol, "checks and clear" should be "checks and clears".
In [line 313](https://github.com/thesandboxgame/sandbox-smart-contracts/blob/3911872e4438cd9a1c2d8552896123ce2b2d6438/packages/land/contracts/common/LandBaseToken.sol#L313) of LandBaseToken.sol, "if is a contract can handle ERC721 tokens or not and transfers..." should be "is a contract, can handle ERC-721 tokens, and transfers...".
In [line 349](https://github.com/thesandboxgame/sandbox-smart-contracts/blob/3911872e4438cd9a1c2d8552896123ce2b2d6438/packages/land/contracts/common/LandBaseToken.sol#L349) of LandBaseToken.sol, "array there just emitting transfer event" should be "array, emit transfer event".
In [line 357](https://github.com/thesandboxgame/sandbox-smart-contracts/blob/3911872e4438cd9a1c2d8552896123ce2b2d6438/packages/land/contracts/common/LandBaseToken.sol#L357) of LandBaseToken.sol, "else is checked if owned by the msgSender" should be "else check if owned by the msgSender".
In [line 343](https://github.com/thesandboxgame/sandbox-smart-contracts/blob/3911872e4438cd9a1c2d8552896123ce2b2d6438/packages/land/contracts/common/LandBaseToken.sol#L343) and [line 436](https://github.com/thesandboxgame/sandbox-smart-contracts/blob/3911872e4438cd9a1c2d8552896123ce2b2d6438/packages/land/contracts/common/LandBaseToken.sol#L436) of LandBaseToken.sol, "lopping" should be "looping".
In [line 563](https://github.com/thesandboxgame/sandbox-smart-contracts/blob/3911872e4438cd9a1c2d8552896123ce2b2d6438/packages/land/contracts/common/LandBaseToken.sol#L563) of LandBaseToken.sol, "teh" should be "the".
In [line 6](https://github.com/thesandboxgame/sandbox-smart-contracts/blob/3911872e4438cd9a1c2d8552896123ce2b2d6438/packages/land/contracts/registry/LandMetadataBase.sol#L6) of LandMetadataBase.sol, "LandMetadataRegistry" should be "LandMetadataBase"
To improve the overall readability of the codebase, consider fixing any typographical errors.