### PR TITLE
fix: N-02 Lack of a Security Contact

### DIFF
--- a/packages/land/contracts/interfaces/IERC173.sol
+++ b/packages/land/contracts/interfaces/IERC173.sol
@@ -3,6 +3,7 @@
 pragma solidity ^0.8.0;
 
 /// @title ERC-173 Contract Ownership Standard
+/// @custom:security-contact contact-blockchain@sandbox.game
 /// @dev See https://github.com/ethereum/EIPs/blob/master/EIPS/eip-173.md
 ///  Note: the ERC-165 identifier for this interface is 0x7f5828d0
 interface IERC173 {


### PR DESCRIPTION
## Description
The [IERC173 interface](https://github.com/thesandboxgame/sandbox-smart-contracts/blob/3911872e4438cd9a1c2d8552896123ce2b2d6438/packages/land/contracts/interfaces/IERC173.sol) does not have a security contact.

Consider adding a NatSpec comment containing a security contact above the interface definition. Using the @custom:security-contact convention is recommended as it has been adopted by the [OpenZeppelin Wizard](https://wizard.openzeppelin.com/) and the [ethereum-lists](https://github.com/ethereum-lists/contracts#tracking-new-deployments).