### PR TITLE
fix: N-01 Missing Docstrings

### DIFF
--- a/packages/land/contracts/common/LandBase.sol
+++ b/packages/land/contracts/common/LandBase.sol
@@ -114,7 +114,7 @@ abstract contract LandBase is
         _approveFor(sender, operator, tokenId);
     }
 
-    /// @notice Set the approval for an operator to manage all the tokens of the sender
+    /// @notice Set the approval for an operator to manage all the tokens of the msgSender
     /// @param operator The address receiving the approval
     /// @param approved The determination of the approval
     function setApprovalForAll(
@@ -124,7 +124,7 @@ abstract contract LandBase is
         _setApprovalForAll(_msgSender(), operator, approved);
     }
 
-    /// @notice Set the approval for an operator to manage all the tokens of the sender
+    /// @notice Set the approval for an operator to manage all the tokens of the sender (may differ from msgSender)
     /// @param sender The address giving the approval
     /// @param operator The address receiving the approval
     /// @param approved The determination of the approval

--- a/packages/land/contracts/common/LandBaseToken.sol
+++ b/packages/land/contracts/common/LandBaseToken.sol
@@ -41,6 +41,9 @@ abstract contract LandBaseToken is IErrors, ILandToken, ERC721BaseToken {
     uint256 internal constant LAYER_24x24 = 0x0400000000000000000000000000000000000000000000000000000000000000;
     /* solhint-enable const-name-snakecase */
 
+    /// @notice emitted when a minter right is changed.
+    /// @param minter address that will be given/removed minter right.
+    /// @param enabled set whether the minter is enabled or disabled.
     event Minter(address indexed minter, bool enabled);
 
     /// @dev helper struct to store arguments in memory instead of the stack.

--- a/packages/land/contracts/common/OperatorFiltererUpgradeable.sol
+++ b/packages/land/contracts/common/OperatorFiltererUpgradeable.sol
@@ -5,11 +5,11 @@ pragma solidity 0.8.23;
 import {IOperatorFilterRegistry} from "../interfaces/IOperatorFilterRegistry.sol";
 import {Context} from "@openzeppelin/contracts/utils/Context.sol";
 
-///@title OperatorFiltererUpgradeable
+/// @title OperatorFiltererUpgradeable
 /// @author The Sandbox
 /// @custom:security-contact contact-blockchain@sandbox.game
-///@notice This contract would subscribe or copy or just to the subscription provided or just register to default subscription list
-///@dev This contract is the upgradeable version of the OpenSea implementation https://github.com/ProjectOpenSea/operator-filter-registry/blob/main/src/OperatorFilterer.sol and adapted to the 0.5.9 solidity version
+/// @notice This contract would subscribe or copy or just to the subscription provided or just register to default subscription list
+/// @dev This contract is the upgradeable version of the OpenSea implementation https://github.com/ProjectOpenSea/operator-filter-registry/blob/main/src/OperatorFilterer.sol and adapted to the 0.5.9 solidity version
 abstract contract OperatorFiltererUpgradeable is Context {
     /// @notice emitted when a registry is set
     /// @param registry address of the registry to set
@@ -23,11 +23,15 @@ abstract contract OperatorFiltererUpgradeable is Context {
     /// @notice the caller is not the operator
     error OperatorNotAllowed();
 
+    /// @notice Used in approval operations to check if the operator is allowed to call this contract
+    /// @param operator The address receiving the approval
     modifier onlyAllowedOperatorApproval(address operator) virtual {
         _checkIsOperatorAllowed(address(this), operator);
         _;
     }
 
+    /// @notice Used in transfer from operations to check if the sender of the token is allowed to call this contract
+    /// @param from the sender of the token
     modifier onlyAllowedOperator(address from) virtual {
         IOperatorFilterRegistry registry = _readOperatorFilterRegistry();
         // Check registry code length to facilitate testing in environments without a deployed registry.

--- a/packages/land/contracts/interfaces/IERC173.sol
+++ b/packages/land/contracts/interfaces/IERC173.sol
@@ -6,14 +6,16 @@ pragma solidity ^0.8.0;
 /// @dev See https://github.com/ethereum/EIPs/blob/master/EIPS/eip-173.md
 ///  Note: the ERC-165 identifier for this interface is 0x7f5828d0
 interface IERC173 {
-    /// @dev This emits when ownership of a contract changes.
-    event OwnershipTransferred(address indexed _previousOwner, address indexed _newOwner);
+    /// @notice Emitted when ownership of a contract changes.
+    /// @param previousOwner the old owner
+    /// @param newOwner the new owner
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
     /// @notice Get the address of the owner
     /// @return The address of the owner.
     function owner() external view returns (address);
 
     /// @notice Set the address of the new owner of the contract
-    /// @param _newOwner The address of the new owner of the contract
-    function transferOwnership(address _newOwner) external;
+    /// @param newOwner The address of the new owner of the contract
+    function transferOwnership(address newOwner) external;
 }


### PR DESCRIPTION
## Description
Througout the codebase, several instances of missing or incomplete docstrings were found:

Within LandBaseToken.sol, in the [Minter event](https://github.com/thesandboxgame/sandbox-smart-contracts/blob/3911872e4438cd9a1c2d8552896123ce2b2d6438/packages/land/contracts/common/LandBaseToken.sol#L44), the docstring is missing.
Within OperatorFiltererUpgradeable.sol, the docstring above the [onlyAllowedOperatorApproval](https://github.com/thesandboxgame/sandbox-smart-contracts/blob/3911872e4438cd9a1c2d8552896123ce2b2d6438/packages/land/contracts/common/OperatorFiltererUpgradeable.sol#L26) and [onlyAllowedOperator](https://github.com/thesandboxgame/sandbox-smart-contracts/blob/3911872e4438cd9a1c2d8552896123ce2b2d6438/packages/land/contracts/common/OperatorFiltererUpgradeable.sol#L31) modifiers are missing.
Within IERC173.sol, in the [OwnershipTransferred event](https://github.com/thesandboxgame/sandbox-smart-contracts/blob/3911872e4438cd9a1c2d8552896123ce2b2d6438/packages/land/contracts/interfaces/IERC173.sol#L10), the _previousOwner and _newOwner parameters are not documented.
Within LandBase.sol, the differences between the [setApprovalForAll](https://github.com/thesandboxgame/sandbox-smart-contracts/blob/3911872e4438cd9a1c2d8552896123ce2b2d6438/packages/land/contracts/common/LandBase.sol#L120) and [setApprovalForAllFor](https://github.com/thesandboxgame/sandbox-smart-contracts/blob/3911872e4438cd9a1c2d8552896123ce2b2d6438/packages/land/contracts/common/LandBase.sol#L131) functions are not sufficiently documented.
Consider thoroughly documenting all functions, events, and their parameters, that are part of any contract's public API. Functions implementing sensitive functionality, even if not public, should be clearly documented as well. When writing docstrings, consider following the [Ethereum Natural Specification Format](https://solidity.readthedocs.io/en/latest/natspec-format.html) (NatSpec).