### PR TITLE
fix: L-03 Misleading Error Message

### DIFF
--- a/packages/land/contracts/common/LandBaseToken.sol
+++ b/packages/land/contracts/common/LandBaseToken.sol
@@ -257,7 +257,7 @@ abstract contract LandBaseToken is IErrors, ILandToken, ERC721BaseToken {
             uint256 id1x1 = _getQuadId(LAYER_1x1, x, y);
             address owner = _ownerOf(id1x1);
             if (owner == address(0)) {
-                revert InvalidCoordinates(size, x, y);
+                revert NotOwner(x, y);
             }
             if (owner != from) {
                 revert ERC721InvalidOwner(from);

--- a/packages/land/test/common/TransferQuad.behavior.ts
+++ b/packages/land/test/common/TransferQuad.behavior.ts
@@ -110,8 +110,8 @@ export function shouldCheckTransferQuad(setupLand, Contract: string) {
     it('should revert when token does not exist', async function () {
       const {LandAsAdmin, deployer, landAdmin} = await loadFixture(setupLand);
       await expect(LandAsAdmin.transferQuad(landAdmin, deployer, 1, 0, 0, '0x'))
-        .to.be.revertedWithCustomError(LandAsAdmin, 'InvalidCoordinates')
-        .withArgs(1, 0, 0);
+        .to.be.revertedWithCustomError(LandAsAdmin, 'NotOwner')
+        .withArgs(0, 0);
     });
 
     it('should revert for transfer Quad of zero size', async function () {
@@ -344,8 +344,8 @@ export function shouldCheckTransferQuad(setupLand, Contract: string) {
           await expect(
             LandContract.transferQuad(other, deployer, 1, 0, 0, bytes),
           )
-            .to.be.revertedWithCustomError(LandAsOther, 'InvalidCoordinates')
-            .withArgs(1, 0, 0);
+            .to.be.revertedWithCustomError(LandAsOther, 'NotOwner')
+            .withArgs(0, 0);
         });
 
         it('should not transfer burned quads', async function () {
@@ -396,8 +396,8 @@ export function shouldCheckTransferQuad(setupLand, Contract: string) {
           await expect(
             LandContract.transferQuad(deployer, other, 1, 0, 0, bytes),
           )
-            .to.be.revertedWithCustomError(LandContract, 'InvalidCoordinates')
-            .withArgs(1, 0, 0);
+            .to.be.revertedWithCustomError(LandContract, 'NotOwner')
+            .withArgs(0, 0);
         });
 
         it('should not transfer burned quads', async function () {

--- a/packages/land/test/polygon/PolygonLand.test.ts
+++ b/packages/land/test/polygon/PolygonLand.test.ts
@@ -253,8 +253,8 @@ describe('PolygonLand.sol', function () {
         await expect(
           LandAsOther.transferQuad(landHolder, landReceiver, size, x, y, bytes),
         )
-          .to.be.revertedWithCustomError(LandAsOther, 'InvalidCoordinates')
-          .withArgs(size, x, y);
+          .to.be.revertedWithCustomError(LandAsOther, 'NotOwner')
+          .withArgs(x, y);
       });
 
       it('should revert transfer of quad if a sub quad is burned', async function () {


### PR DESCRIPTION
## Description
The _transferQuad function in the LandBaseToken contract [reverts](https://github.com/thesandboxgame/sandbox-smart-contracts/blob/3911872e4438cd9a1c2d8552896123ce2b2d6438/packages/land/contracts/common/LandBaseToken.sol#L259-L261) with an InvalidCoordinates error message if the land owner is the zero address. This might cause confusion as the same error message is also [triggered](https://github.com/thesandboxgame/sandbox-smart-contracts/blob/3911872e4438cd9a1c2d8552896123ce2b2d6438/packages/land/contracts/common/LandBaseToken.sol#L241-L248) when incorrect coordinates are entered.

Consider using the NotOwner error message instead to provide greater clarity.