### PR TITLE
fix: L-02 Documentation Errors in Land Metadata

### DIFF
--- a/packages/land/contracts/LandMetadataRegistry.md
+++ b/packages/land/contracts/LandMetadataRegistry.md
@@ -34,28 +34,28 @@ change the metadata for any token.
 
 # Implementation
 
-- Each land type (premiumness + neighborhood) takes 8 bits (1 byte)
-- We pack 32 land types in a 32 byte EVM word, so we use 5202 EVM words for the
+- Each land type (premiumness + neighborhood) takes 16 bits (2 byte)
+- We pack 16 land types in a 32 byte EVM word, so we use 10404 EVM words for the
   whole map.
 
 ## Land type
 
-- Key of the map: tokenId / 32
-- Value of the map: in each 256 bits we store 32 land types
-- Index inside each word: tokenId mod 32
+- Key of the map: tokenId / 16
+- Value of the map: in each 256 bits we store 16 land types
+- Index inside each word: tokenId mod 16
 
 ### Land Type
 
 Land Type is stored in a mapping: `mapping(uint256 key => uint256 value)`. Where
-key is tokenId / 32 and values is the land type.
+key is tokenId / 16 and values is the land type.
 
-| Land Type: 8 bits                              |
-| ---------------------------------------------- |
-| 1 bit Premiumness + 7 bits Neighborhood number |
+| Land Type: 16 bits                              |
+| ----------------------------------------------- |
+| 1 bit Premiumness + 15 bits Neighborhood number |
 
 ### EVM WORD
 
-| Land type 1 | Land type 2 | Land type 3 | Land type 4 | Land type 5 | …   | Land type 28 | Land type 29 | Land type 30 | Land type 31 | Land type 32 |
+| Land type 1 | Land type 2 | Land type 3 | Land type 4 | Land type 5 | …   | Land type 12 | Land type 13 | Land type 14 | Land type 15 | Land type 16 |
 | ----------- | ----------- | ----------- | ----------- | ----------- | --- | ------------ | ------------ | ------------ | ------------ | ------------ |
 
 ### Neighborhood Name
@@ -80,7 +80,7 @@ To update the metadata during an initial import or for a quad (see:
    metadata in EVM words ( see: [Implementation](#implementation) ).
 2. Calculate the new raw EVM words by changing only the right bytes of metadata
    that needs to be updated, taking into account that each EVM word contains
-   metadata for 32 tokens.
+   metadata for 16 tokens.
 3. Call `batchSetMetadata` to overwrite the metadata.
 
 The `updateMetadata` function in the following script is an example on how to do
@@ -155,7 +155,7 @@ export async function updateMetadata(
 function BITS_PER_LAND() external view returns (uint256)
 ```
 
-bits (8) of information stored for each land
+bits (16) of information stored for each land
 
 #### Returns
 
@@ -195,7 +195,7 @@ amount of land information that can be stored in one EVM word
 function LAND_MASK() external view returns (uint256)
 ```
 
-used to mask the 8 bits of information stored per land
+used to mask the 16 bits of information stored per land
 
 #### Returns
 
@@ -251,7 +251,7 @@ value returned when the neighborhood is not set yet.
 function batchGetMetadata(uint256[] tokenIds) external view returns (struct LandMetadataRegistry.BatchSetData[])
 ```
 
-return the metadata of 32 lands at once
+return the metadata of 16 lands at once
 
 _used to debug, extracting a lot of information that must be unpacked at once._
 

--- a/packages/land/contracts/LandMetadataRegistry.sol
+++ b/packages/land/contracts/LandMetadataRegistry.sol
@@ -19,9 +19,9 @@ contract LandMetadataRegistry is IErrors, ILandMetadataRegistry, AccessControlEn
     }
 
     struct BatchSetData {
-        // baseTokenId the token id floor 32
+        // baseTokenId the token id floor LANDS_PER_WORD
         uint256 baseTokenId;
-        // metadata: premiumness << 8 | neighborhoodId
+        // metadata: premiumness << (BITS_PER_LAND-1) | neighborhoodId
         uint256 metadata;
     }
 
@@ -125,7 +125,7 @@ contract LandMetadataRegistry is IErrors, ILandMetadataRegistry, AccessControlEn
         }
     }
 
-    /// @notice set the metadata for 32 lands at the same time in batch
+    /// @notice set the metadata for LANDS_PER_WORD lands at the same time in batch
     /// @param data token id and metadata
     /// @dev use with care, we can set to the metadata for some lands to unknown (zero)
     function batchSetMetadata(BatchSetData[] calldata data) external onlyAdmin {
@@ -183,7 +183,7 @@ contract LandMetadataRegistry is IErrors, ILandMetadataRegistry, AccessControlEn
         return _getNeighborhoodName(neighborhoodId);
     }
 
-    /// @notice return the metadata of 32 lands at once
+    /// @notice return the metadata of LANDS_PER_WORD lands at once
     /// @param tokenIds the token ids
     /// @return the raw metadata for a series of tokenIds
     /// @dev used to debug, extracting a lot of information that must be unpacked at once.

--- a/packages/land/contracts/registry/LandMetadataBase.sol
+++ b/packages/land/contracts/registry/LandMetadataBase.sol
@@ -20,9 +20,9 @@ abstract contract LandMetadataBase is AccessControlEnumerableUpgradeable {
     string public constant UNKNOWN_NEIGHBORHOOD = "unknown";
     /// @notice amount of land information that can be stored in one EVM word
     uint256 public constant LANDS_PER_WORD = 16;
-    /// @notice bits (8) of information stored for each land, for example: 16
+    /// @notice bits of information stored for each land: for example: 16
     uint256 public constant BITS_PER_LAND = 256 / LANDS_PER_WORD;
-    /// @notice used to mask the 8 bits of information stored per land, for example: 0xFFFF
+    /// @notice used to mask the bits of information stored per land, for example: 0xFFFF
     uint256 public constant LAND_MASK = (1 << BITS_PER_LAND) - 1;
     /// @notice mask used to extract the premium bit, for example: 0x8000
     uint256 public constant PREMIUM_MASK = 1 << (BITS_PER_LAND - 1);
@@ -30,7 +30,7 @@ abstract contract LandMetadataBase is AccessControlEnumerableUpgradeable {
     uint256 public constant NEIGHBORHOOD_MASK = PREMIUM_MASK - 1;
 
     struct LandMetadataStorage {
-        /// @dev tokenId / 32 => premiumness + neighborhood metadata
+        /// @dev tokenId / LANDS_PER_WORD => premiumness + neighborhood metadata
         /// @dev zero means no metadata definition
         mapping(uint256 tokenId => uint256 metadataType) _metadata;
         /// @dev neighborhood number to string mapping
@@ -61,7 +61,7 @@ abstract contract LandMetadataBase is AccessControlEnumerableUpgradeable {
     }
 
     /// @notice get the packed metadata for a single land
-    /// @param tokenId the base token id floor 32
+    /// @param tokenId the base token id floor LANDS_PER_WORD
     /// @return neighborhoodId the number that identifies the neighborhood
     /// @return premium true if is premium
     function _getMetadataForTokenId(uint256 tokenId) internal view returns (uint256 neighborhoodId, bool premium) {
@@ -71,16 +71,16 @@ abstract contract LandMetadataBase is AccessControlEnumerableUpgradeable {
         premium = (metadata & PREMIUM_MASK) != 0;
     }
 
-    /// @notice set the packed metadata for 32 lands at once
-    /// @param tokenId the base token id floor 32
-    /// @param metadata the packed metadata for 32 lands
+    /// @notice set the packed metadata for LANDS_PER_WORD lands at once
+    /// @param tokenId the base token id floor LANDS_PER_WORD
+    /// @param metadata the packed metadata for LANDS_PER_WORD lands
     function _setMetadata(uint256 tokenId, uint256 metadata) internal {
         LandMetadataStorage storage $ = _getLandMetadataStorage();
         $._metadata[_getKey(tokenId)] = metadata;
     }
 
-    /// @notice return the packed metadata for 32 lands at once
-    /// @param tokenId the base token id floor 32
+    /// @notice return the packed metadata for LANDS_PER_WORD lands at once
+    /// @param tokenId the base token id floor LANDS_PER_WORD
     function _getMetadata(uint256 tokenId) internal view returns (uint256) {
         LandMetadataStorage storage $ = _getLandMetadataStorage();
         return $._metadata[_getKey(tokenId)];
@@ -110,7 +110,7 @@ abstract contract LandMetadataBase is AccessControlEnumerableUpgradeable {
         return (tokenId % LANDS_PER_WORD) * BITS_PER_LAND;
     }
 
-    /// @notice return the tokenId floor 32
+    /// @notice return the tokenId floor LANDS_PER_WORD
     /// @param tokenId the token id
     function _getKey(uint256 tokenId) internal pure returns (uint256) {
         return LANDS_PER_WORD * (tokenId / LANDS_PER_WORD);
@@ -123,7 +123,7 @@ abstract contract LandMetadataBase is AccessControlEnumerableUpgradeable {
         if (neighborhoodId == 0) {
             revert InvalidNeighborhoodId(neighborhoodId);
         }
-        // NEIGHBORHOOD_MASK (32767) is left out to use as escape char if needed.
+        // the last id: NEIGHBORHOOD_MASK is left out to use as escape char if needed in the future.
         if (neighborhoodId >= NEIGHBORHOOD_MASK) {
             revert InvalidNeighborhoodId(neighborhoodId);
         }


### PR DESCRIPTION
## Description
The metadata for each LAND is stored in a separate contract named LandMetadataRegistry. Each Land token ID's metadata includes a neighborhood ID and an indicator to show whether the land is premium. In addition, every neighborhood ID can be associated with a neighborhood name. The underlying logic for storing token metadata is encapsulated in a base contract, LandMetadataBase, which LandMetadataRegistry inherits from. The metadata for a token ID is compacted with other IDs into words, using a base token ID for access. Each token ID utilizes 16 bits of information, allowing the metadata for 16 lands to be stored in each word. To extract specific data for a token ID, the contract implements logic to unpack the data.

An issue has arisen due to outdated documentation in the aforementioned contracts. It inaccurately states that LAND information occupies 8 bits and each word stores data for 32 LANDs. Specific examples include, but are not limited to:

[Line 74](https://github.com/thesandboxgame/sandbox-smart-contracts/blob/3911872e4438cd9a1c2d8552896123ce2b2d6438/packages/land/contracts/registry/LandMetadataBase.sol#L74) in the LandMetadataBase contract.
[Line 24](https://github.com/thesandboxgame/sandbox-smart-contracts/blob/3911872e4438cd9a1c2d8552896123ce2b2d6438/packages/land/contracts/LandMetadataRegistry.sol#L24) in the LandMetadataRegistry contract.
This discrepancy in documentation, even though the calculations are accurate based on the value of [LANDS_PER_WORD](https://github.com/thesandboxgame/sandbox-smart-contracts/blob/3911872e4438cd9a1c2d8552896123ce2b2d6438/packages/land/contracts/registry/LandMetadataBase.sol#L22), could lead to confusion and the setting of incorrect values. As such, consider updating the documentation throughout both the LandMetadataBase and LandMetadataRegistry contracts to prevent these issues.