### PR TITLE
fix: L-01 Ownership of Land and PolygonLand

### DIFF
--- a/packages/land/contracts/common/LandBase.sol
+++ b/packages/land/contracts/common/LandBase.sol
@@ -22,7 +22,7 @@ import {LandBaseToken} from "./LandBaseToken.sol";
 /// @notice LAND contract
 /// @dev LAND contract implements ERC721, quads, metadata, royalties and marketplace filtering functionalities.
 /// @dev The contract also implements EIP173 because it is needed by some marketplaces. The owner() doesn't have
-/// @dev any privileged roles within the contract. It can be is set by the admin to any value.
+/// @dev any privileged roles within the contract. It can be set by the admin to any value.
 abstract contract LandBase is
     LandBaseToken,
     Initializable,

--- a/packages/land/contracts/common/LandBase.sol
+++ b/packages/land/contracts/common/LandBase.sol
@@ -20,7 +20,9 @@ import {LandBaseToken} from "./LandBaseToken.sol";
 /// @author The Sandbox
 /// @custom:security-contact contact-blockchain@sandbox.game
 /// @notice LAND contract
-/// @dev LAND contract implements ERC721, quad and marketplace filtering functionalities
+/// @dev LAND contract implements ERC721, quads, metadata, royalties and marketplace filtering functionalities.
+/// @dev The contract also implements EIP173 because it is needed by some marketplaces. The owner() doesn't have
+/// @dev any privileged roles within the contract. It can be is set by the admin to any value.
 abstract contract LandBase is
     LandBaseToken,
     Initializable,
@@ -98,6 +100,9 @@ abstract contract LandBase is
 
     /// @notice Set the address of the new owner of the contract
     /// @param newOwner address of new owner
+    /// @dev This owner doesn't have any privileged role within this contract
+    /// @dev It is set by the admin to comply with EIP173 which is needed by some marketplaces
+    /// @dev Even when set to address(0) ownership is never permanently renounced the admin can always set any value
     function transferOwnership(address newOwner) external onlyAdmin {
         _transferOwnership(newOwner);
     }


### PR DESCRIPTION
## Description
The Land and PolygonLand contracts inherit from the [LandBase contract](https://github.com/thesandboxgame/sandbox-smart-contracts/blob/3911872e4438cd9a1c2d8552896123ce2b2d6438/packages/land/contracts/common/LandBase.sol) that supports the [IERC173 interface](https://github.com/thesandboxgame/sandbox-smart-contracts/blob/3911872e4438cd9a1c2d8552896123ce2b2d6438/packages/land/contracts/common/LandBase.sol#L214) and implements the [transferOwnership function](https://github.com/thesandboxgame/sandbox-smart-contracts/blob/3911872e4438cd9a1c2d8552896123ce2b2d6438/packages/land/contracts/common/LandBase.sol#L101). The owners of these contracts are not set at the time of initialization. Instead, they are set by the admin of the contracts by calling the transferOwnership function. Thus, the ownership stays with address(0) unless set otherwise.

Moreover, the transferOwnership function allows the input _newOwner address to be the zero address which is compliant with [EIP-173 specification](https://eips.ethereum.org/EIPS/eip-173#specification). The EIP states that address(0) can be passed as the value of _newOwner address to renounce any ownership. In the case of the Sandbox's implementation, the renunciation of ownership is not permanent. The admin can reassign this ownership after renunciation by calling transferOwnership function with a non-zero address. Although the owner of these contracts does not have any privileged roles within the Sandbox codebase, ownership was introduced to support integration with external protocols and marketplaces which require this feature. Setting the owner as address(0) could result in possible integration issues or missing royalty payments.

Consider revisiting the design decision of allowing zero address to be the owner. If it is desired to have zero address as the owner of the contract, consider documenting the implications of the design and stating that the ownership is never permanently renounced.