### PR TITLE
add: code inspector config

### DIFF
--- a/defender.config.json
+++ b/defender.config.json
@@ -1,0 +1,9 @@
+{
+    "contract_inspector": {
+        "enabled": true,
+        "scan_directories": ["packages/land", "packages/marketplace"]
+    },
+    "dependency_checker": {
+        "enabled": false
+    }
+}


### PR DESCRIPTION
## Description
Add defender config to enable OZ Defender's Code Inspector to run on defined packages