### PR TITLE
Add v2 version of the functions with makeRecipient

### DIFF
--- a/packages/marketplace/contracts/Exchange.sol
+++ b/packages/marketplace/contracts/Exchange.sol
@@ -81,6 +81,12 @@ contract Exchange is
     }
 
     /// @notice Match orders and transact.
+    /// @param matchedOrders A list of left/right orders that match each other.
+    function matchOrdersV2(ExchangeMatchV2[] calldata matchedOrders) external whenNotPaused {
+        _matchOrdersV2(_msgSender(), matchedOrders);
+    }
+
+    /// @notice Match orders and transact.
     /// @param sender The original sender of the transaction.
     /// @param matchedOrders A list of left/right orders that match each other.
     /// @dev This method supports ERC1776 native meta transactions.
@@ -92,12 +98,32 @@ contract Exchange is
         _matchOrders(sender, matchedOrders);
     }
 
+    /// @notice Match orders and transact.
+    /// @param sender The original sender of the transaction.
+    /// @param matchedOrders A list of left/right orders that match each other.
+    /// @dev This method supports ERC1776 native meta transactions.
+    function matchOrdersFromV2(
+        address sender,
+        ExchangeMatchV2[] calldata matchedOrders
+    ) external onlyRole(ERC1776_OPERATOR_ROLE) whenNotPaused {
+        require(sender != address(0), "invalid sender");
+        _matchOrdersV2(sender, matchedOrders);
+    }
+
     /// @notice Cancel an order.
     /// @param order The order to be canceled.
     /// @param orderKeyHash Used as a checksum to avoid mistakes in the order values.
     function cancel(LibOrder.Order calldata order, bytes32 orderKeyHash) external {
         require(_msgSender() == order.maker, "not maker");
         _cancel(order, orderKeyHash);
+    }
+
+    /// @notice Cancel an order.
+    /// @param order The order to be canceled.
+    /// @param orderKeyHash Used as a checksum to avoid mistakes in the order values.
+    function cancelV2(LibOrder.OrderV2 calldata order, bytes32 orderKeyHash) external {
+        require(_msgSender() == order.maker, "not maker");
+        _cancelV2(order, orderKeyHash);
     }
 
     /// @notice Set the royalty registry.

--- a/packages/marketplace/contracts/interfaces/IOrderValidator.sol
+++ b/packages/marketplace/contracts/interfaces/IOrderValidator.sol
@@ -13,4 +13,10 @@ interface IOrderValidator {
     /// @param signature Signature of order
     /// @param sender Order sender
     function validate(LibOrder.Order memory order, bytes memory signature, address sender) external view;
+
+    /// @notice Verifies order
+    /// @param order Order to be validated
+    /// @param signature Signature of order
+    /// @param sender Order sender
+    function validateV2(LibOrder.OrderV2 memory order, bytes memory signature, address sender) external view;
 }

--- a/packages/marketplace/test/utils/order.ts
+++ b/packages/marketplace/test/utils/order.ts
@@ -1,6 +1,5 @@
 // An order represents something offered (asset + who offers) plus what we want in exchange (asset + optionally for whom or everybody)
 // SEE: LibOrder.sol
-import {Asset, AssetType, hashAsset, hashAssetType} from './assets';
 import {
   AbiCoder,
   Contract,
@@ -9,10 +8,17 @@ import {
   Signer,
   ZeroAddress,
 } from 'ethers';
+import {Asset, AssetType, hashAsset, hashAssetType} from './assets';
 
 export const ORDER_TYPEHASH = keccak256(
   Buffer.from(
-    'Order(address maker,Asset makeAsset,address taker,Asset takeAsset,address makeRecipient,uint256 salt,uint256 start,uint256 end)Asset(AssetType assetType,uint256 value)AssetType(uint256 assetClass,bytes data)'
+    'Order(address maker,Asset makeAsset,address taker,Asset takeAsset,uint256 salt,uint256 start,uint256 end)Asset(AssetType assetType,uint256 value)AssetType(uint256 assetClass,bytes data)'
+  )
+);
+
+export const ORDER_TYPEHASH_V2 = keccak256(
+  Buffer.from(
+    'OrderV2(address maker,Asset makeAsset,address taker,Asset takeAsset,address makeRecipient,uint256 salt,uint256 start,uint256 end)Asset(AssetType assetType,uint256 value)AssetType(uint256 assetClass,bytes data)'
   )
 );
 
@@ -20,6 +26,16 @@ export const UINT256_MAX_VALUE =
   115792089237316195423570985008687907853269984665640564039457584007913129639935n;
 
 export type Order = {
+  maker: string;
+  makeAsset: Asset;
+  taker: string;
+  takeAsset: Asset;
+  salt: Numeric;
+  start: Numeric;
+  end: Numeric;
+};
+
+export type OrderV2 = {
   maker: string;
   makeAsset: Asset;
   taker: string;
@@ -37,9 +53,28 @@ export const OrderDefault = async (
   takeAsset: Asset,
   salt: Numeric,
   start: Numeric,
+  end: Numeric
+): Promise<Order> => ({
+  maker: await maker.getAddress(),
+  makeAsset,
+  taker:
+    taker === ZeroAddress ? ZeroAddress : await (taker as Signer).getAddress(),
+  takeAsset,
+  salt,
+  start,
+  end,
+});
+
+export const OrderDefaultV2 = async (
+  maker: {getAddress: () => Promise<string>},
+  makeAsset: Asset,
+  taker: Signer | ZeroAddress,
+  takeAsset: Asset,
+  salt: Numeric,
+  start: Numeric,
   end: Numeric,
   makeRecipient?: Address
-): Promise<Order> => ({
+): Promise<OrderV2> => ({
   maker: await maker.getAddress(),
   makeAsset,
   taker:
@@ -52,6 +87,19 @@ export const OrderDefault = async (
 });
 
 export function hashKey(order: Order): string {
+  const encoded = AbiCoder.defaultAbiCoder().encode(
+    ['address', 'address', 'bytes32', 'bytes32', 'uint256'],
+    [
+      order.maker,
+      hashAssetType(order.makeAsset.assetType),
+      hashAssetType(order.takeAsset.assetType),
+      order.salt,
+    ]
+  );
+  return keccak256(encoded);
+}
+
+export function hashKeyV2(order: OrderV2): string {
   const encoded = AbiCoder.defaultAbiCoder().encode(
     ['address', 'address', 'bytes32', 'bytes32', 'uint256'],
     [
@@ -69,6 +117,30 @@ export const getSymmetricOrder = async (
   o: Order,
   taker?: Signer
 ): Promise<Order> => {
+  const ret = {
+    ...o,
+    makeAsset: o.takeAsset,
+    taker: o.maker,
+    takeAsset: o.makeAsset,
+  };
+  if (taker) {
+    return {
+      ...ret,
+      maker: await taker.getAddress(),
+    };
+  }
+  if (o.taker === ZeroAddress) {
+    throw new Error(
+      'Original order was for anybody, the taker is needed to create the order'
+    );
+  }
+  return {...ret, maker: o.taker};
+};
+
+export const getSymmetricOrderV2 = async (
+  o: OrderV2,
+  taker?: Signer
+): Promise<OrderV2> => {
   const ret = {
     ...o,
     makeAsset: o.takeAsset,
@@ -98,13 +170,39 @@ export function hashOrder(order: Order): string {
       'bytes32',
       'address',
       'bytes32',
-      'address',
       'uint256',
       'uint256',
       'uint256',
     ],
     [
       ORDER_TYPEHASH,
+      order.maker,
+      hashAsset(order.makeAsset),
+      order.taker,
+      hashAsset(order.takeAsset),
+      order.salt,
+      order.start,
+      order.end,
+    ]
+  );
+  return keccak256(encoded);
+}
+
+export function hashOrderV2(order: OrderV2): string {
+  const encoded = AbiCoder.defaultAbiCoder().encode(
+    [
+      'bytes32',
+      'address',
+      'bytes32',
+      'address',
+      'bytes32',
+      'address',
+      'uint256',
+      'uint256',
+      'uint256',
+    ],
+    [
+      ORDER_TYPEHASH_V2,
       order.maker,
       hashAsset(order.makeAsset),
       order.taker,
@@ -145,6 +243,42 @@ export async function signOrder(
         {name: 'makeAsset', type: 'Asset'},
         {name: 'taker', type: 'address'},
         {name: 'takeAsset', type: 'Asset'},
+        {name: 'salt', type: 'uint256'},
+        {name: 'start', type: 'uint256'},
+        {name: 'end', type: 'uint256'},
+      ],
+    },
+    order
+  );
+}
+
+export async function signOrderV2(
+  order: OrderV2,
+  account: Signer,
+  verifyingContract: Contract
+) {
+  const network = await verifyingContract.runner?.provider?.getNetwork();
+  return account.signTypedData(
+    {
+      name: 'The Sandbox Marketplace',
+      version: '1.0.0',
+      chainId: network.chainId,
+      verifyingContract: await verifyingContract.getAddress(),
+    },
+    {
+      AssetType: [
+        {name: 'assetClass', type: 'uint256'},
+        {name: 'data', type: 'bytes'},
+      ],
+      Asset: [
+        {name: 'assetType', type: 'AssetType'},
+        {name: 'value', type: 'uint256'},
+      ],
+      OrderV2: [
+        {name: 'maker', type: 'address'},
+        {name: 'makeAsset', type: 'Asset'},
+        {name: 'taker', type: 'address'},
+        {name: 'takeAsset', type: 'Asset'},
         {name: 'makeRecipient', type: 'address'},
         {name: 'salt', type: 'uint256'},
         {name: 'start', type: 'uint256'},
@@ -164,6 +298,18 @@ export function isAssetEqual(x: Asset, y: Asset): boolean {
 }
 
 export function isOrderEqual(x: Order, order: Order): boolean {
+  return (
+    x.maker === order.maker &&
+    isAssetEqual(x.makeAsset, order.makeAsset) &&
+    x.taker === order.taker &&
+    isAssetEqual(x.takeAsset, order.takeAsset) &&
+    x.salt == order.salt &&
+    x.start == order.start &&
+    x.end == order.end
+  );
+}
+
+export function isOrderV2Equal(x: OrderV2, order: OrderV2): boolean {
   return (
     x.maker === order.maker &&
     isAssetEqual(x.makeAsset, order.makeAsset) &&


### PR DESCRIPTION
## Description

In order to still be able to use orders we have created in the past we need to add a V2 of most of the functions responsible for matching orders.

The previously added `makeRecipient` to LibOrder.Order upgrade would cause a mismatch between the old and new signature types.

