### PR TITLE
Updated bundle sell in secondary market

### DIFF
--- a/packages/marketplace/contracts/Exchange.sol
+++ b/packages/marketplace/contracts/Exchange.sol
@@ -42,7 +42,7 @@ contract Exchange is
     /// @return Hash for TSB_PRIMARY_MARKET_SELLER_ROLE.
     bytes32 public constant TSB_PRIMARY_MARKET_SELLER_ROLE = keccak256("TSB_PRIMARY_MARKET_SELLER_ROLE");
 
-    /// @notice Role for TSB owned addresses that can sell bundled assets including quad in secondary market(pay royalties and primary protocol fees).
+    /// @notice Role for TSB owned addresses that can sell bundled assets including quad in secondary market(pays royalties and primary protocol fees).
     /// @return Hash for TSB_SECONDARY_MARKET_SELLER_ROLE.
     bytes32 public constant TSB_SECONDARY_MARKET_SELLER_ROLE = keccak256("TSB_SECONDARY_MARKET_SELLER_ROLE");
 
@@ -180,7 +180,7 @@ contract Exchange is
     /// @dev Check if the address is a TSB seller, which forces primary sales conditions regardless if the seller is the creator of the token.
     /// @param from Address to check.
     /// @return True if the address is a TSB seller, false otherwise.
-    function _isTSBPrimaryMarktSeller(address from) internal view override returns (bool) {
+    function _isTSBPrimaryMarketSeller(address from) internal view override returns (bool) {
         return hasRole(TSB_PRIMARY_MARKET_SELLER_ROLE, from);
     }
 

--- a/packages/marketplace/contracts/Exchange.sol
+++ b/packages/marketplace/contracts/Exchange.sol
@@ -38,9 +38,13 @@ contract Exchange is
     /// @return Hash for PAUSER_ROLE.
     bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
 
-    /// @notice Role for TSB owned addresses that list TSB owned assets for sale, forces primary sales conditions.
-    /// @return Hash for TSB_SELLER_ROLE.
-    bytes32 public constant TSB_SELLER_ROLE = keccak256("TSB_SELLER_ROLE");
+    /// @notice Role for TSB owned addresses that list TSB owned assets for sale, forces primary sales conditions(skips royalties, pays primary protocol fees).
+    /// @return Hash for TSB_PRIMARY_MARKET_SELLER_ROLE.
+    bytes32 public constant TSB_PRIMARY_MARKET_SELLER_ROLE = keccak256("TSB_PRIMARY_MARKET_SELLER_ROLE");
+
+    /// @notice Role for TSB owned addresses that can sell bundled assets including quad in secondary market(pay royalties and primary protocol fees).
+    /// @return Hash for TSB_SECONDARY_MARKET_SELLER_ROLE.
+    bytes32 public constant TSB_SECONDARY_MARKET_SELLER_ROLE = keccak256("TSB_SECONDARY_MARKET_SELLER_ROLE");
 
     /// @notice Role for addresses that should be whitelisted from any marketplace fees including royalties.
     /// @return Hash for FEE_WHITELIST_ROLE.
@@ -176,8 +180,15 @@ contract Exchange is
     /// @dev Check if the address is a TSB seller, which forces primary sales conditions regardless if the seller is the creator of the token.
     /// @param from Address to check.
     /// @return True if the address is a TSB seller, false otherwise.
-    function _isTSBSeller(address from) internal view override returns (bool) {
-        return hasRole(TSB_SELLER_ROLE, from);
+    function _isTSBPrimaryMarktSeller(address from) internal view override returns (bool) {
+        return hasRole(TSB_PRIMARY_MARKET_SELLER_ROLE, from);
+    }
+
+    /// @dev Check if the address is a TSB Bundle Seller, which can sell bundled assets including quad in secondary market.
+    /// @param from Address to check.
+    /// @return True if the address is a TSB bundle seller, false otherwise.
+    function _isTSBSecondaryMarketSeller(address from) internal view override returns (bool) {
+        return hasRole(TSB_SECONDARY_MARKET_SELLER_ROLE, from);
     }
 
     function _msgSender()

--- a/packages/marketplace/contracts/TransferManager.sol
+++ b/packages/marketplace/contracts/TransferManager.sol
@@ -210,7 +210,7 @@ abstract contract TransferManager is Initializable, ITransferManager {
         bool isBundle = nftSide.asset.assetType.assetClass == LibAsset.AssetClass.BUNDLE;
 
         if (isBundle) {
-            if (!_isTSBPrimaryMarktSeller(nftSide.account)) {
+            if (!_isTSBPrimaryMarketSeller(nftSide.account)) {
                 remainder = _doTransfersWithFeesAndRoyaltiesForBundle(paymentSide, nftSide, nftSideRecipient);
             } else {
                 // No royalties but primary fee should be paid on the total value of the bundle
@@ -231,7 +231,7 @@ abstract contract TransferManager is Initializable, ITransferManager {
     function _calculateFeesAndRoyalties(
         DealSide memory nftSide
     ) internal returns (uint256 fees, bool shouldTransferRoyalties) {
-        if (_isTSBPrimaryMarktSeller(nftSide.account) || _isPrimaryMarket(nftSide)) {
+        if (_isTSBPrimaryMarketSeller(nftSide.account) || _isPrimaryMarket(nftSide)) {
             fees = protocolFeePrimary;
             shouldTransferRoyalties = false;
         } else {
@@ -650,7 +650,7 @@ abstract contract TransferManager is Initializable, ITransferManager {
 
     /// @notice Function deciding if the seller is a TSB seller, to be overridden
     /// @param from Address to check
-    function _isTSBPrimaryMarktSeller(address from) internal virtual returns (bool);
+    function _isTSBPrimaryMarketSeller(address from) internal virtual returns (bool);
 
     /// @notice Function deciding if the seller is a TSB bundle seller, to be overridden
     /// @param from Address to check

--- a/packages/marketplace/contracts/TransferManager.sol
+++ b/packages/marketplace/contracts/TransferManager.sol
@@ -269,11 +269,7 @@ abstract contract TransferManager is Initializable, ITransferManager {
 
         remainder = _processERC721Bundles(paymentSide, nftSide, nftSideRecipient, remainder, feePrimary, bundle);
         remainder = _processERC1155Bundles(paymentSide, nftSide, nftSideRecipient, remainder, feePrimary, bundle);
-        uint256 quadSize = bundle.quads.xs.length;
-        if (quadSize > 0) {
-            require(_isTSBSecondaryMarketSeller(nftSide.account), "not TSB secondary market seller");
-            remainder = _processQuadBundles(paymentSide, nftSideRecipient, remainder, feePrimary, quadSize, bundle);
-        }
+        remainder = _processQuadBundles(paymentSide, nftSide, nftSideRecipient, remainder, feePrimary, bundle);
         return remainder;
     }
 
@@ -338,26 +334,28 @@ abstract contract TransferManager is Initializable, ITransferManager {
 
     function _processQuadBundles(
         DealSide memory paymentSide,
+        DealSide memory nftSide,
         address nftSideRecipient,
         uint256 remainder,
         uint256 feePrimary,
-        uint256 quadSize,
         LibAsset.Bundle memory bundle
     ) internal returns (uint256) {
+        uint256 quadSize = bundle.quads.xs.length;
         for (uint256 i = 0; i < quadSize; ++i) {
             uint256 size = bundle.quads.sizes[i];
             uint256 x = bundle.quads.xs[i];
             uint256 y = bundle.quads.ys[i];
 
             uint256 tokenId = idInPath(0, size, x, y);
-            remainder = _transferFeesAndRoyaltiesForBundledAsset(
+            remainder = _processSingleAsset(
                 paymentSide,
-                address(landContract),
+                nftSide,
                 nftSideRecipient,
                 remainder,
+                feePrimary,
+                address(landContract),
                 tokenId,
-                bundle.priceDistribution.quadPrices[i],
-                feePrimary
+                bundle.priceDistribution.quadPrices[i]
             );
         }
         return remainder;

--- a/packages/marketplace/contracts/libraries/LibAsset.sol
+++ b/packages/marketplace/contracts/libraries/LibAsset.sol
@@ -83,6 +83,14 @@ library LibAsset {
     /// @param rightClass The asset class type of the right side of the trade.
     /// @return FeeSide representing which side should bear the fee, if any.
     function getFeeSide(AssetClass leftClass, AssetClass rightClass) internal pure returns (FeeSide) {
+        if (leftClass == AssetClass.BUNDLE || rightClass == AssetClass.BUNDLE) {
+            require(
+                ((leftClass == AssetClass.BUNDLE && rightClass == AssetClass.ERC20) ||
+                    (rightClass == AssetClass.BUNDLE && leftClass == AssetClass.ERC20)),
+                "exchange not allowed"
+            );
+        }
+
         if (leftClass == AssetClass.ERC20 && rightClass != AssetClass.ERC20) {
             return FeeSide.LEFT;
         }

--- a/packages/marketplace/test/exchange/MatchOrdersWithRoyalties.behavior.ts
+++ b/packages/marketplace/test/exchange/MatchOrdersWithRoyalties.behavior.ts
@@ -39,7 +39,7 @@ export function shouldMatchOrdersWithRoyalty() {
       orderRight: Order,
       makerSig: string,
       takerSig: string,
-      TSB_SELLER_ROLE: string,
+      TSB_PRIMARY_MARKET_SELLER_ROLE: string,
       FEE_WHITELIST_ROLE: string;
 
     beforeEach(async function () {
@@ -62,7 +62,7 @@ export function shouldMatchOrdersWithRoyalty() {
         admin: receiver1,
         user: receiver2,
         deployer: royaltyReceiver,
-        TSB_SELLER_ROLE,
+        TSB_PRIMARY_MARKET_SELLER_ROLE,
         FEE_WHITELIST_ROLE,
       } = await loadFixture(deployFixtures));
 
@@ -571,7 +571,7 @@ export function shouldMatchOrdersWithRoyalty() {
       );
     });
 
-    it('should execute a complete match order without royalties but with primary market fees for address with TSB_SELLER_ROLE', async function () {
+    it('should execute a complete match order without royalties but with primary market fees for address with TSB_PRIMARY_MARKET_SELLER_ROLE', async function () {
       await ERC721WithRoyaltyV2981.mint(maker.getAddress(), 1, [
         await FeeRecipientsData(maker.getAddress(), 10000),
       ]);
@@ -589,7 +589,7 @@ export function shouldMatchOrdersWithRoyalty() {
 
       // grant exchange admin role to seller
       await ExchangeContractAsDeployer.connect(admin).grantRole(
-        TSB_SELLER_ROLE,
+        TSB_PRIMARY_MARKET_SELLER_ROLE,
         maker.getAddress()
       );
 

--- a/packages/marketplace/test/exchange/WhitelistingTokens.behavior.ts
+++ b/packages/marketplace/test/exchange/WhitelistingTokens.behavior.ts
@@ -22,6 +22,7 @@ import {ZeroAddress, Contract, Signer} from 'ethers';
 export function shouldCheckForWhitelisting() {
   describe('Exchange MatchOrders for Whitelisting tokens', function () {
     let ExchangeContractAsUser: Contract,
+      ExchangeContractAsAdmin: Contract,
       OrderValidatorAsAdmin: Contract,
       ERC20Contract: Contract,
       ERC20Contract2: Contract,
@@ -40,11 +41,13 @@ export function shouldCheckForWhitelisting() {
       orderLeft: Order,
       orderRight: Order,
       makerSig: string,
-      takerSig: string;
+      takerSig: string,
+      TSB_SECONDARY_MARKET_SELLER_ROLE: string;
 
     beforeEach(async function () {
       ({
         ExchangeContractAsUser,
+        ExchangeContractAsAdmin,
         OrderValidatorAsAdmin,
         ERC20Contract,
         ERC20Contract2,
@@ -53,6 +56,7 @@ export function shouldCheckForWhitelisting() {
         ERC1155Contract,
         user1: maker,
         user2: taker,
+        TSB_SECONDARY_MARKET_SELLER_ROLE,
       } = await loadFixture(deployFixturesWithoutWhitelist));
     });
 
@@ -491,6 +495,12 @@ export function shouldCheckForWhitelisting() {
           deployer: maker, // making deployer the maker to sell in primary market
           user2: taker,
         } = await loadFixture(deployFixturesWithoutWhitelist));
+
+        // grant tsb bundle seller role to seller
+        await ExchangeContractAsAdmin.grantRole(
+          TSB_SECONDARY_MARKET_SELLER_ROLE,
+          await maker.getAddress()
+        );
 
         priceDistribution = {
           erc721Prices: [[4000000000]],

--- a/packages/marketplace/test/fixtures/index.ts
+++ b/packages/marketplace/test/fixtures/index.ts
@@ -14,7 +14,10 @@ export async function deployFixturesWithoutWhitelist() {
 
   const {ExchangeContractAsAdmin} = exchange;
 
-  const TSB_SELLER_ROLE = await ExchangeContractAsAdmin.TSB_SELLER_ROLE();
+  const TSB_PRIMARY_MARKET_SELLER_ROLE =
+    await ExchangeContractAsAdmin.TSB_PRIMARY_MARKET_SELLER_ROLE();
+  const TSB_SECONDARY_MARKET_SELLER_ROLE =
+    await ExchangeContractAsAdmin.TSB_SECONDARY_MARKET_SELLER_ROLE();
   const FEE_WHITELIST_ROLE = await ExchangeContractAsAdmin.FEE_WHITELIST_ROLE();
   const EXCHANGE_ADMIN_ROLE =
     await ExchangeContractAsAdmin.EXCHANGE_ADMIN_ROLE();
@@ -27,7 +30,8 @@ export async function deployFixturesWithoutWhitelist() {
     ...exchange,
     ...mockAssets,
     EXCHANGE_ADMIN_ROLE,
-    TSB_SELLER_ROLE,
+    TSB_PRIMARY_MARKET_SELLER_ROLE,
+    TSB_SECONDARY_MARKET_SELLER_ROLE,
     FEE_WHITELIST_ROLE,
     DEFAULT_ADMIN_ROLE,
     ERC1776_OPERATOR_ROLE,


### PR DESCRIPTION
## Description

- updated TSB seller role to `TSB_PRIMARY_MARKET_SELLER` & `TSB_SECONDARY_MARKET_SELLER`.

- updated contracts for secondary market sale for bundle.

- Allow exchange only for bundle when one side of order is ERC20 and other is Bundle.

- fixed and added test cases according to above changes.