### PR TITLE
Emit WaveMint event with waveIndex

### DIFF
--- a/packages/avatar/contracts/nft-collection/INFTCollection.sol
+++ b/packages/avatar/contracts/nft-collection/INFTCollection.sol
@@ -5,7 +5,6 @@ pragma solidity 0.8.26;
 import {IERC20} from "@openzeppelin/contracts-5.0.2/token/ERC20/IERC20.sol";
 import {IERC20Metadata} from "@openzeppelin/contracts-5.0.2/token/ERC20/extensions/IERC20Metadata.sol";
 
-
 /**
  * @title INFTCollection
  * @author The Sandbox
@@ -49,6 +48,22 @@ interface INFTCollection {
         uint256 waveMaxTokensToBuy,
         uint256 waveSingleTokenPrice,
         uint256 waveIndex
+    );
+
+    /**
+     * @notice Event emitted when a wave mint is completed
+     * @param tokenId the token id
+     * @param wallet the wallet address of the receiver
+     * @param waveIndex the wave index
+     * @param walletMintCount the amount of tokens minted by the wallet
+     * @param waveTotalMinted the total tokens count minted in the wave
+     */
+    event WaveMint(
+        uint256 tokenId,
+        address indexed wallet,
+        uint256 waveIndex,
+        uint256 walletMintCount,
+        uint256 waveTotalMinted
     );
 
     /**
@@ -96,7 +111,6 @@ interface INFTCollection {
      */
     event Personalized(address indexed operator, uint256 indexed tokenId, uint256 indexed personalizationMask);
 
-
     /**
      * @notice Event emitted when a token personalization was made.
      * @param operator the sender of the transaction
@@ -104,7 +118,6 @@ interface INFTCollection {
      * @param feeNumerator percentage of the royalties in feeDenominator units
      */
     event DefaultRoyaltySet(address indexed operator, address indexed receiver, uint96 feeNumerator);
-
 
     /**
      * @notice Event emitted when default royalties are reset
@@ -119,8 +132,12 @@ interface INFTCollection {
      * @param receiver the receiver of the royalties
      * @param feeNumerator percentage of the royalties in feeDenominator units
      */
-    event TokenRoyaltySet(address indexed operator, uint256 indexed tokenId, address indexed receiver, uint96 feeNumerator);
-
+    event TokenRoyaltySet(
+        address indexed operator,
+        uint256 indexed tokenId,
+        address indexed receiver,
+        uint96 feeNumerator
+    );
 
     /**
      * @notice Event emitted when default royalties are reset
@@ -188,5 +205,4 @@ interface INFTCollection {
      * @param amount amount to be checked if can be minted
      */
     error CannotMint(address wallet, uint256 amount);
-
 }

--- a/packages/avatar/test/avatar/nft-collection/NFTCollection.mint.test.ts
+++ b/packages/avatar/test/avatar/nft-collection/NFTCollection.mint.test.ts
@@ -355,6 +355,7 @@ describe('NFTCollection mint', function () {
       expect(await contract.getSignatureType(222)).to.be.eq(4);
       expect(await contract.getSignatureType(223)).to.be.eq(4);
     });
+
     it('should emit WaveMint event when waveMint is called', async function () {
       const {
         collectionContractAsOwner: contract,

--- a/packages/avatar/test/avatar/nft-collection/NFTCollection.mint.test.ts
+++ b/packages/avatar/test/avatar/nft-collection/NFTCollection.mint.test.ts
@@ -1,8 +1,8 @@
 import {expect} from 'chai';
 
-import {setupNFTCollectionContract} from './NFTCollection.fixtures';
-import {ZeroAddress} from 'ethers';
 import {loadFixture} from '@nomicfoundation/hardhat-network-helpers';
+import {ZeroAddress} from 'ethers';
+import {setupNFTCollectionContract} from './NFTCollection.fixtures';
 
 describe('NFTCollection mint', function () {
   describe('backward compatible mint', function () {
@@ -354,6 +354,86 @@ describe('NFTCollection mint', function () {
 
       expect(await contract.getSignatureType(222)).to.be.eq(4);
       expect(await contract.getSignatureType(223)).to.be.eq(4);
+    });
+    it('should emit WaveMint event when waveMint is called', async function () {
+      const {
+        collectionContractAsOwner: contract,
+        waveMintSign,
+        sandContract,
+        randomWallet,
+        maxSupply,
+      } = await loadFixture(setupNFTCollectionContract);
+      const unitPrice = 10;
+      await sandContract.donateTo(randomWallet, unitPrice * 5);
+      await contract.setupWave(maxSupply, maxSupply, unitPrice);
+
+      expect(await sandContract.balanceOf(randomWallet)).to.be.eq(
+        unitPrice * 5
+      );
+      const encodedData = contract.interface.encodeFunctionData('waveMint', [
+        await randomWallet.getAddress(),
+        1,
+        0,
+        222,
+        await waveMintSign(randomWallet, 1, 0, 222),
+      ]);
+
+      await sandContract
+        .connect(randomWallet)
+        .approveAndCall(contract, unitPrice, encodedData);
+
+      const waveMintEvents = await contract.queryFilter(
+        contract.filters.WaveMint()
+      );
+
+      const walletTotalMinted = await contract.waveOwnerToClaimedCounts(
+        0,
+        randomWallet
+      );
+      const waveTotalMinted = await contract.waveTotalMinted(0);
+
+      expect(waveMintEvents).to.have.lengthOf(1);
+      expect(waveMintEvents[0].args.tokenId).to.be.eq(1);
+      expect(waveMintEvents[0].args.wallet).to.be.eq(randomWallet);
+      expect(waveMintEvents[0].args.waveIndex).to.be.eq(0);
+      expect(waveMintEvents[0].args.walletMintCount).to.be.eq(
+        walletTotalMinted
+      );
+      expect(waveMintEvents[0].args.waveTotalMinted).to.be.eq(waveTotalMinted);
+    });
+
+    it('should emit WaveMint event when mint is called', async function () {
+      const {
+        collectionContractAsOwner: contract,
+        mintSign,
+        sandContract,
+        randomWallet,
+        maxSupply,
+      } = await loadFixture(setupNFTCollectionContract);
+      const unitPrice = 10;
+      await sandContract.donateTo(randomWallet, unitPrice * 5);
+      await contract.setupWave(maxSupply, maxSupply, unitPrice);
+
+      const encodedData = contract.interface.encodeFunctionData('mint', [
+        await randomWallet.getAddress(),
+        1,
+        222,
+        await mintSign(randomWallet, 222),
+      ]);
+      await sandContract
+        .connect(randomWallet)
+        .approveAndCall(contract, unitPrice, encodedData);
+
+      const mintEvents = await contract.queryFilter(
+        contract.filters.WaveMint()
+      );
+
+      expect(mintEvents).to.have.lengthOf(1);
+      expect(mintEvents[0].args.tokenId).to.be.eq(1);
+      expect(mintEvents[0].args.wallet).to.be.eq(randomWallet);
+      expect(mintEvents[0].args.waveIndex).to.be.eq(0);
+      expect(mintEvents[0].args.walletMintCount).to.be.eq(1);
+      expect(mintEvents[0].args.waveTotalMinted).to.be.eq(1);
     });
 
     describe('wrong args', function () {


### PR DESCRIPTION
## Description

This PR adds a new event `WaveMint` that emits additional data after token is minted, including the waveIndex which will be used to assign correct metadata.

Added few test scenarios to make sure the event is emitted correctly.