### PR TITLE
Owner limit bypass

### DIFF
--- a/packages/avatar/contracts/mocks/NFTCollectionMock.sol
+++ b/packages/avatar/contracts/mocks/NFTCollectionMock.sol
@@ -2,7 +2,6 @@
 
 pragma solidity 0.8.26;
 
-import {IERC20Metadata} from "@openzeppelin/contracts-5.0.2/token/ERC20/extensions/IERC20Metadata.sol";
 import {NFTCollection} from "../nft-collection/NFTCollection.sol";
 
 contract NFTCollectionMock is NFTCollection {

--- a/packages/avatar/contracts/mocks/NFTCollectionMock.sol
+++ b/packages/avatar/contracts/mocks/NFTCollectionMock.sol
@@ -5,7 +5,6 @@ pragma solidity 0.8.26;
 import {IERC20Metadata} from "@openzeppelin/contracts-5.0.2/token/ERC20/extensions/IERC20Metadata.sol";
 import {NFTCollection} from "../nft-collection/NFTCollection.sol";
 
-
 contract NFTCollectionMock is NFTCollection {
     struct V5VarsStorage {
         bytes32 erc721BurnMemoryUpgradable;
@@ -16,33 +15,13 @@ contract NFTCollectionMock is NFTCollection {
     }
 
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor(address _collectionOwner, address _initialTrustedForwarder)  {
+    constructor(address _collectionOwner, address _initialTrustedForwarder) {
         _transferOwnership(_collectionOwner);
         _setTrustedForwarder(_initialTrustedForwarder);
     }
 
-    function NFTCollection_init(
-        address _collectionOwner,
-        string calldata _initialBaseURI,
-        string memory _name,
-        string memory _symbol,
-        address payable _mintTreasury,
-        address _signAddress,
-        address _initialTrustedForwarder,
-        IERC20Metadata _allowedToExecuteMint,
-        uint256 _maxSupply
-    ) external {
-        __NFTCollection_init(
-            _collectionOwner,
-            _initialBaseURI,
-            _name,
-            _symbol,
-            _mintTreasury,
-            _signAddress,
-            _initialTrustedForwarder,
-            _allowedToExecuteMint,
-            _maxSupply
-        );
+    function NFTCollection_init(InitializationParams calldata params) external {
+        __NFTCollection_init(params);
     }
 
     function getV5VarsStorageStructure() external pure returns (V5VarsStorage memory ret) {

--- a/packages/avatar/contracts/nft-collection/INFTCollection.sol
+++ b/packages/avatar/contracts/nft-collection/INFTCollection.sol
@@ -30,7 +30,8 @@ interface INFTCollection {
         address mintTreasury,
         address signAddress,
         IERC20Metadata allowedToExecuteMint,
-        uint256 maxSupply
+        uint256 maxSupply,
+        uint256 maxTokensPerWallet
     );
 
     /**
@@ -55,16 +56,8 @@ interface INFTCollection {
      * @param tokenId the token id
      * @param wallet the wallet address of the receiver
      * @param waveIndex the wave index
-     * @param walletMintCount the amount of tokens minted by the wallet
-     * @param waveTotalMinted the total tokens count minted in the wave
      */
-    event WaveMint(
-        uint256 tokenId,
-        address indexed wallet,
-        uint256 waveIndex,
-        uint256 walletMintCount,
-        uint256 waveTotalMinted
-    );
+    event WaveMint(uint256 tokenId, address indexed wallet, uint256 waveIndex);
 
     /**
      * @notice Event emitted when an address was set as allowed to mint
@@ -146,6 +139,14 @@ interface INFTCollection {
     event TokenRoyaltyReset(address indexed operator, uint256 indexed tokenId);
 
     /**
+     * @notice Event emitted when the max tokens per wallet is set
+     * @param operator the sender of the transaction
+     * @param oldMaxTokensPerWallet old maximum tokens per wallet
+     * @param newMaxTokensPerWallet new maximum tokens per wallet
+     */
+    event MaxTokensPerWalletSet(address indexed operator, uint256 oldMaxTokensPerWallet, uint256 newMaxTokensPerWallet);
+
+    /**
      * @notice The operation failed because the base token uri is empty.
      * @param baseURI an URI that will be used as the base for token URI
      */
@@ -205,4 +206,25 @@ interface INFTCollection {
      * @param amount amount to be checked if can be minted
      */
     error CannotMint(address wallet, uint256 amount);
+
+    /**
+     * @notice The operation failed because the max tokens per wallet is invalid
+     * @param maxTokensPerWallet max tokens per wallet
+     */
+    error InvalidMaxTokensPerWallet(uint256 maxTokensPerWallet, uint256 maxSupply);
+
+    /**
+     * @notice The operation failed because the wave max tokens per wallet is higher than the global max tokens per wallet
+     * @param waveMaxTokensPerWallet wave max tokens per wallet
+     * @param maxTokensPerWallet global max tokens per wallet
+     */
+    error WaveMaxTokensHigherThanGlobalMax(uint256 waveMaxTokensPerWallet, uint256 maxTokensPerWallet);
+
+    /**
+     * @notice The operation failed because the global max tokens per wallet is exceeded
+     * @param amountToMint amount to mint
+     * @param mintedCount minted count
+     * @param maxTokensPerWallet global max tokens per wallet
+     */
+    error GlobalMaxTokensPerWalletExceeded(uint256 amountToMint, uint256 mintedCount, uint256 maxTokensPerWallet);
 }

--- a/packages/avatar/contracts/nft-collection/INFTCollection.sol
+++ b/packages/avatar/contracts/nft-collection/INFTCollection.sol
@@ -13,6 +13,58 @@ import {IERC20Metadata} from "@openzeppelin/contracts-5.0.2/token/ERC20/extensio
  */
 interface INFTCollection {
     /**
+     * @notice Structure to hold initialization parameters
+     * @param _collectionOwner the address that will be set as the owner of the collection
+     * @param _initialBaseURI an URI that will be used as the base for token URI
+     * @param _name name of the ERC721 token
+     * @param _symbol token symbol of the ERC721 token
+     * @param _mintTreasury collection treasury address (where the payments are sent)
+     * @param _signAddress signer address that is allowed to create mint signatures
+     * @param _initialTrustedForwarder trusted forwarder address
+     * @param _allowedToExecuteMint token address that is used for payments and that is allowed to execute mint
+     * @param _maxSupply max supply of tokens to be allowed to be minted per contract
+     * @param _maxTokensPerWallet max tokens per wallet
+     */
+    struct InitializationParams {
+        address collectionOwner;
+        string initialBaseURI;
+        string name;
+        string symbol;
+        address payable mintTreasury;
+        address signAddress;
+        address initialTrustedForwarder;
+        IERC20Metadata allowedToExecuteMint;
+        uint256 maxSupply;
+        uint256 maxTokensPerWallet;
+    }
+
+    /**
+     * @notice Structure used to mint in batch
+     * @param wallet destination address that will receive the tokens
+     * @param amount of tokens to mint
+     */
+    struct BatchMintingData {
+        address wallet;
+        uint256 amount;
+    }
+
+    /**
+     * @notice Structure used save minting wave information
+     * @param waveMaxTokensOverall max tokens to buy per wave, cumulating all addresses
+     * @param waveMaxTokensPerWallet max tokens to buy, per wallet in a given wave
+     * @param waveSingleTokenPrice price of one token mint (in the token denoted by the allowedToExecuteMint contract)
+     * @param waveTotalMinted number of total minted tokens in the current running wave
+     * @param waveOwnerToClaimedCounts mapping of [owner -> minted count]
+     */
+    struct WaveData {
+        uint256 waveMaxTokensOverall;
+        uint256 waveMaxTokensPerWallet;
+        uint256 waveSingleTokenPrice;
+        uint256 waveTotalMinted;
+        mapping(address => uint256) waveOwnerToClaimedCounts;
+    }
+
+    /**
      * @notice Event emitted when the contract was initialized.
      * @dev emitted at proxy startup, only once
      * @param baseURI an URI that will be used as the base for token URI

--- a/packages/avatar/contracts/nft-collection/NFTCollection.sol
+++ b/packages/avatar/contracts/nft-collection/NFTCollection.sol
@@ -773,6 +773,22 @@ contract NFTCollection is
     }
 
     /**
+     * @notice Set the maximum number of tokens that can be minted per wallet across all waves
+     * @param _maxTokensPerWallet new maximum tokens per wallet
+     */
+    function setMaxTokensPerWallet(uint256 _maxTokensPerWallet) external onlyOwner {
+        _setMaxTokensPerWallet(_maxTokensPerWallet);
+    }
+
+    /**
+     * @notice Get the maximum number of tokens that can be minted per wallet across all waves
+     */
+    function maxTokensPerWallet() external view returns (uint256) {
+        NFTCollectionStorage storage $ = _getNFTCollectionStorage();
+        return $.maxTokensPerWallet;
+    }
+
+    /**
      * @notice return the total amount of tokens minted till now
      */
     function totalSupply() external view returns (uint256) {
@@ -1012,22 +1028,6 @@ contract NFTCollection is
                 }
             }
         }
-    }
-
-    /**
-     * @notice Set the maximum number of tokens that can be minted per wallet across all waves
-     * @param _maxTokensPerWallet new maximum tokens per wallet
-     */
-    function setMaxTokensPerWallet(uint256 _maxTokensPerWallet) external onlyOwner {
-        _setMaxTokensPerWallet(_maxTokensPerWallet);
-    }
-
-    /**
-     * @notice Get the maximum number of tokens that can be minted per wallet across all waves
-     */
-    function maxTokensPerWallet() external view returns (uint256) {
-        NFTCollectionStorage storage $ = _getNFTCollectionStorage();
-        return $.maxTokensPerWallet;
     }
 
     /**

--- a/packages/avatar/contracts/nft-collection/NFTCollection.sol
+++ b/packages/avatar/contracts/nft-collection/NFTCollection.sol
@@ -50,58 +50,6 @@ contract NFTCollection is
     IERC4906,
     INFTCollection
 {
-    /**
-     * @notice Structure to hold initialization parameters
-     * @param _collectionOwner the address that will be set as the owner of the collection
-     * @param _initialBaseURI an URI that will be used as the base for token URI
-     * @param _name name of the ERC721 token
-     * @param _symbol token symbol of the ERC721 token
-     * @param _mintTreasury collection treasury address (where the payments are sent)
-     * @param _signAddress signer address that is allowed to create mint signatures
-     * @param _initialTrustedForwarder trusted forwarder address
-     * @param _allowedToExecuteMint token address that is used for payments and that is allowed to execute mint
-     * @param _maxSupply max supply of tokens to be allowed to be minted per contract
-     * @param _maxTokensPerWallet max tokens per wallet
-     */
-    struct InitializationParams {
-        address collectionOwner;
-        string initialBaseURI;
-        string name;
-        string symbol;
-        address payable mintTreasury;
-        address signAddress;
-        address initialTrustedForwarder;
-        IERC20Metadata allowedToExecuteMint;
-        uint256 maxSupply;
-        uint256 maxTokensPerWallet;
-    }
-
-    /**
-     * @notice Structure used to mint in batch
-     * @param wallet destination address that will receive the tokens
-     * @param amount of tokens to mint
-     */
-    struct BatchMintingData {
-        address wallet;
-        uint256 amount;
-    }
-
-    /**
-     * @notice Structure used save minting wave information
-     * @param waveMaxTokensOverall max tokens to buy per wave, cumulating all addresses
-     * @param waveMaxTokensPerWallet max tokens to buy, per wallet in a given wave
-     * @param waveSingleTokenPrice price of one token mint (in the token denoted by the allowedToExecuteMint contract)
-     * @param waveTotalMinted number of total minted tokens in the current running wave
-     * @param waveOwnerToClaimedCounts mapping of [owner -> minted count]
-     */
-    struct WaveData {
-        uint256 waveMaxTokensOverall;
-        uint256 waveMaxTokensPerWallet;
-        uint256 waveSingleTokenPrice;
-        uint256 waveTotalMinted;
-        mapping(address => uint256) waveOwnerToClaimedCounts;
-    }
-
     struct NFTCollectionStorage {
         /**
          * @notice maximum amount of tokens that can be minted

--- a/packages/avatar/contracts/nft-collection/NFTCollection.sol
+++ b/packages/avatar/contracts/nft-collection/NFTCollection.sol
@@ -51,6 +51,32 @@ contract NFTCollection is
     INFTCollection
 {
     /**
+     * @notice Structure to hold initialization parameters
+     * @param _collectionOwner the address that will be set as the owner of the collection
+     * @param _initialBaseURI an URI that will be used as the base for token URI
+     * @param _name name of the ERC721 token
+     * @param _symbol token symbol of the ERC721 token
+     * @param _mintTreasury collection treasury address (where the payments are sent)
+     * @param _signAddress signer address that is allowed to create mint signatures
+     * @param _initialTrustedForwarder trusted forwarder address
+     * @param _allowedToExecuteMint token address that is used for payments and that is allowed to execute mint
+     * @param _maxSupply max supply of tokens to be allowed to be minted per contract
+     * @param _maxTokensPerWallet max tokens per wallet
+     */
+    struct InitializationParams {
+        address collectionOwner;
+        string initialBaseURI;
+        string name;
+        string symbol;
+        address payable mintTreasury;
+        address signAddress;
+        address initialTrustedForwarder;
+        IERC20Metadata allowedToExecuteMint;
+        uint256 maxSupply;
+        uint256 maxTokensPerWallet;
+    }
+
+    /**
      * @notice Structure used to mint in batch
      * @param wallet destination address that will receive the tokens
      * @param amount of tokens to mint
@@ -82,6 +108,10 @@ contract NFTCollection is
          */
         uint256 maxSupply; // public
         /**
+         * @notice maximum amount of tokens that can be minted per wallet across all waves
+         */
+        uint256 maxTokensPerWallet;
+        /**
          * @notice treasury address where the payment for minting are sent
          */
         address mintTreasury; // public
@@ -102,6 +132,10 @@ contract NFTCollection is
          * @notice stores the personalization mask for a tokenId
          */
         mapping(uint256 => uint256) personalizationTraits;
+        /**
+         * @notice stores the number of tokens minted by an address
+         */
+        mapping(address => uint256) mintedCount;
         /**
          * @notice total amount of tokens minted till now
          */
@@ -130,92 +164,44 @@ contract NFTCollection is
 
     /**
      * @notice external entry point initialization function in accordance with the upgradable pattern
-     * @dev calls all the init functions from the base classes. Emits {ContractInitialized} event
-     * @param _collectionOwner the address that will be set as the owner of the collection
-     * @param _initialBaseURI an URI that will be used as the base for token URI
-     * @param _name name of the ERC721 token
-     * @param _symbol token symbol of the ERC721 token
-     * @param _mintTreasury collection treasury address (where the payments are sent)
-     * @param _signAddress signer address that is allowed to create mint signatures
-     * @param _initialTrustedForwarder trusted forwarder address
-     * @param _allowedToExecuteMint token address that is used for payments and that is allowed to execute mint
-     * @param _maxSupply max supply of tokens to be allowed to be minted per contract
      */
-    function initialize(
-        address _collectionOwner,
-        string calldata _initialBaseURI,
-        string memory _name,
-        string memory _symbol,
-        address payable _mintTreasury,
-        address _signAddress,
-        address _initialTrustedForwarder,
-        IERC20Metadata _allowedToExecuteMint,
-        uint256 _maxSupply
-    ) external virtual initializer {
-        __NFTCollection_init(
-            _collectionOwner,
-            _initialBaseURI,
-            _name,
-            _symbol,
-            _mintTreasury,
-            _signAddress,
-            _initialTrustedForwarder,
-            _allowedToExecuteMint,
-            _maxSupply
-        );
+    function initialize(InitializationParams calldata params) external virtual initializer {
+        __NFTCollection_init(params);
     }
 
     /**
      * @notice initialization function in accordance with the upgradable pattern
-     * @dev calls all the init functions from the base classes. Emits {ContractInitialized} event
-     * @param _collectionOwner the address that will be set as the owner of the collection
-     * @param _initialBaseURI an URI that will be used as the base for token URI
-     * @param _name name of the ERC721 token
-     * @param _symbol token symbol of the ERC721 token
-     * @param _mintTreasury collection treasury address (where the payments are sent)
-     * @param _signAddress signer address that is allowed to create mint signatures
-     * @param _initialTrustedForwarder trusted forwarder address
-     * @param _allowedToExecuteMint token address that is used for payments and that is allowed to execute mint
-     * @param _maxSupply max supply of tokens to be allowed to be minted per contract
      */
-    function __NFTCollection_init(
-        address _collectionOwner,
-        string calldata _initialBaseURI,
-        string memory _name,
-        string memory _symbol,
-        address payable _mintTreasury,
-        address _signAddress,
-        address _initialTrustedForwarder,
-        IERC20Metadata _allowedToExecuteMint,
-        uint256 _maxSupply
-    ) internal onlyInitializing {
-        if (bytes(_name).length == 0) {
-            revert InvalidName(_name);
+    function __NFTCollection_init(InitializationParams calldata params) internal onlyInitializing {
+        if (bytes(params.name).length == 0) {
+            revert InvalidName(params.name);
         }
-        if (bytes(_symbol).length == 0) {
-            revert InvalidSymbol(_symbol);
+        if (bytes(params.symbol).length == 0) {
+            revert InvalidSymbol(params.symbol);
         }
         __ReentrancyGuard_init();
         // We don't want to set the owner to _msgSender, so, we call _transferOwnership instead of __Ownable_init
-        _transferOwnership(_collectionOwner);
+        _transferOwnership(params.collectionOwner);
         __ERC2981_init();
-        _setTrustedForwarder(_initialTrustedForwarder);
-        __ERC721_init(_name, _symbol);
+        _setTrustedForwarder(params.initialTrustedForwarder);
+        __ERC721_init(params.name, params.symbol);
         __Pausable_init();
-        _setBaseURI(_initialBaseURI);
-        _setTreasury(_mintTreasury);
-        _setSignAddress(_signAddress);
-        _setAllowedExecuteMint(_allowedToExecuteMint);
-        _setMaxSupply(_maxSupply);
+        _setBaseURI(params.initialBaseURI);
+        _setTreasury(params.mintTreasury);
+        _setSignAddress(params.signAddress);
+        _setAllowedExecuteMint(params.allowedToExecuteMint);
+        _setMaxSupply(params.maxSupply);
+        _setMaxTokensPerWallet(params.maxTokensPerWallet);
 
         emit ContractInitialized(
-            _initialBaseURI,
-            _name,
-            _symbol,
-            _mintTreasury,
-            _signAddress,
-            _allowedToExecuteMint,
-            _maxSupply
+            params.initialBaseURI,
+            params.name,
+            params.symbol,
+            params.mintTreasury,
+            params.signAddress,
+            params.allowedToExecuteMint,
+            params.maxSupply,
+            params.maxTokensPerWallet
         );
     }
 
@@ -241,6 +227,9 @@ contract NFTCollection is
         ) {
             revert InvalidWaveData(_waveMaxTokensOverall, _waveMaxTokensPerWallet);
         }
+        if (_waveMaxTokensPerWallet > $.maxTokensPerWallet) {
+            revert WaveMaxTokensHigherThanGlobalMax(_waveMaxTokensPerWallet, $.maxTokensPerWallet);
+        }
         uint256 waveIndex = $.waveData.length;
         emit WaveSetup(_msgSender(), _waveMaxTokensOverall, _waveMaxTokensPerWallet, _waveSingleTokenPrice, waveIndex);
         $.waveData.push();
@@ -265,8 +254,8 @@ contract NFTCollection is
         bytes calldata signature
     ) external whenNotPaused nonReentrant {
         NFTCollectionStorage storage $ = _getNFTCollectionStorage();
-        uint256 waveCount = $.waveData.length;
-        if (waveCount == 0) {
+        uint256 wavesLength = $.waveData.length;
+        if (wavesLength == 0) {
             revert ContractNotConfigured();
         }
         if (_msgSender() != address($.allowedToExecuteMint)) {
@@ -274,7 +263,7 @@ contract NFTCollection is
         }
         _checkAndSetMintSignature(wallet, signatureId, signature);
         // pick the last wave
-        uint256 waveIndex = waveCount - 1;
+        uint256 waveIndex = wavesLength - 1;
         WaveData storage waveData = $.waveData[waveIndex];
         _doMint(waveData, wallet, amount, waveIndex);
     }
@@ -336,28 +325,19 @@ contract NFTCollection is
         if ($.waveData.length == 0) {
             revert ContractNotConfigured();
         }
-        WaveData storage waveData = _getWaveData(waveIndex);
         for (uint256 i; i < len; i++) {
             uint256 _totalSupply = $.totalSupply;
             address wallet = wallets[i].wallet;
             uint256 amount = wallets[i].amount;
-            if (!_isMintAllowed($, waveData, wallet, amount)) {
+            if (amount == 0 || $.totalSupply + amount > $.maxSupply) {
                 revert CannotMint(wallet, amount);
             }
             for (uint256 j; j < amount; j++) {
                 // @dev _mint already checks the destination wallet
                 // @dev start with tokenId = 1
                 _mint(wallet, _totalSupply + j + 1);
-                emit WaveMint(
-                    _totalSupply + j + 1,
-                    wallet,
-                    waveIndex,
-                    waveData.waveOwnerToClaimedCounts[wallet] + 1,
-                    waveData.waveTotalMinted + 1
-                );
+                emit WaveMint(_totalSupply + j + 1, wallet, waveIndex);
             }
-            waveData.waveOwnerToClaimedCounts[wallet] += amount;
-            waveData.waveTotalMinted += amount;
             $.totalSupply += amount;
         }
     }
@@ -817,6 +797,11 @@ contract NFTCollection is
      */
     function _doMint(WaveData storage waveData, address wallet, uint256 amount, uint256 waveIndex) internal {
         NFTCollectionStorage storage $ = _getNFTCollectionStorage();
+
+        if ($.mintedCount[wallet] + amount > $.maxTokensPerWallet) {
+            revert GlobalMaxTokensPerWalletExceeded(amount, $.mintedCount[wallet], $.maxTokensPerWallet);
+        }
+
         if (!_isMintAllowed($, waveData, wallet, amount)) {
             revert CannotMint(wallet, amount);
         }
@@ -829,17 +814,12 @@ contract NFTCollection is
             // @dev _safeMint already checks the destination _wallet
             // @dev start with tokenId = 1
             _safeMint(wallet, _totalSupply + i + 1);
-            emit WaveMint(
-                _totalSupply + i + 1,
-                wallet,
-                waveIndex,
-                waveData.waveOwnerToClaimedCounts[wallet] + 1,
-                waveData.waveTotalMinted + 1
-            );
+            emit WaveMint(_totalSupply + i + 1, wallet, waveIndex);
         }
         waveData.waveOwnerToClaimedCounts[wallet] += amount;
         waveData.waveTotalMinted += amount;
         $.totalSupply += amount;
+        $.mintedCount[wallet] += amount;
     }
 
     /**
@@ -1032,5 +1012,34 @@ contract NFTCollection is
                 }
             }
         }
+    }
+
+    /**
+     * @notice Set the maximum number of tokens that can be minted per wallet across all waves
+     * @param _maxTokensPerWallet new maximum tokens per wallet
+     */
+    function setMaxTokensPerWallet(uint256 _maxTokensPerWallet) external onlyOwner {
+        _setMaxTokensPerWallet(_maxTokensPerWallet);
+    }
+
+    /**
+     * @notice Get the maximum number of tokens that can be minted per wallet across all waves
+     */
+    function maxTokensPerWallet() external view returns (uint256) {
+        NFTCollectionStorage storage $ = _getNFTCollectionStorage();
+        return $.maxTokensPerWallet;
+    }
+
+    /**
+     * @notice Set the maximum number of tokens that can be minted per wallet across all waves
+     * @param _maxTokensPerWallet new maximum tokens per wallet
+     */
+    function _setMaxTokensPerWallet(uint256 _maxTokensPerWallet) internal {
+        NFTCollectionStorage storage $ = _getNFTCollectionStorage();
+        if (_maxTokensPerWallet == 0 || _maxTokensPerWallet > $.maxSupply) {
+            revert InvalidMaxTokensPerWallet(_maxTokensPerWallet, $.maxSupply);
+        }
+        emit MaxTokensPerWalletSet(_msgSender(), $.maxTokensPerWallet, _maxTokensPerWallet);
+        $.maxTokensPerWallet = _maxTokensPerWallet;
     }
 }

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -12,6 +12,7 @@
     "format": "prettier --check \"**/*.{ts,js}\"",
     "format:fix": "prettier --write \"**/*.{ts,js}\"",
     "test": "hardhat test",
+    "test:nft-collection": "hardhat test test/avatar/nft-collection/*",
     "coverage": "hardhat coverage --testfiles 'test/*.ts''test/*.js'",
     "hardhat": "hardhat",
     "size": "yarn hardhat size-contracts",

--- a/packages/avatar/test/avatar/nft-collection/NFTCollection.batch.mint.test.ts
+++ b/packages/avatar/test/avatar/nft-collection/NFTCollection.batch.mint.test.ts
@@ -1,10 +1,9 @@
-import {expect} from 'chai';
-
 import {loadFixture} from '@nomicfoundation/hardhat-network-helpers';
+import {expect} from 'chai';
 import {setupNFTCollectionContract} from './NFTCollection.fixtures';
 
 describe('NFTCollection batch mint', function () {
-  it('owner should be able batchMint without paying the price', async function () {
+  it('owner should be able batchMint without paying the price and without increasing the waveTotalMinted nor waveOwnerToClaimedCounts', async function () {
     const {
       collectionContractAsOwner: contract,
       collectionOwner,
@@ -19,22 +18,34 @@ describe('NFTCollection batch mint', function () {
     const indexWave = await contract.waveCount();
     expect(
       await contract.waveOwnerToClaimedCounts(indexWave - 1n, randomWallet)
-    ).to.be.eq(7);
+    ).to.be.eq(0);
     expect(
       await contract.waveOwnerToClaimedCounts(indexWave - 1n, collectionOwner)
-    ).to.be.eq(5);
-    expect(await contract.waveTotalMinted(indexWave - 1n)).to.be.eq(12);
+    ).to.be.eq(0);
+    expect(await contract.waveTotalMinted(indexWave - 1n)).to.be.eq(0);
     expect(await contract.totalSupply()).to.be.eq(12);
     const transferEvents = await contract.queryFilter('Transfer');
     let i = 0;
     for (; i < 7; i++) {
-      const tokenId = transferEvents[i].args.tokenId;
+      const tokenId = transferEvents[i].args[2];
       expect(await contract.ownerOf(tokenId)).to.be.eq(randomWallet);
     }
-    for (; i < 5; i++) {
-      const tokenId = transferEvents[i].args.tokenId;
+    for (; i < 12; i++) {
+      const tokenId = transferEvents[i].args[2];
       expect(await contract.ownerOf(tokenId)).to.be.eq(collectionOwner);
     }
+  });
+  it('owner should be able to batchMint irrespective of the maxTokensPerWallet', async function () {
+    const {
+      collectionContractAsOwner: contract,
+      randomWallet,
+      setupDefaultWave,
+      waveMaxTokensOverall,
+      maxTokensPerWallet,
+    } = await loadFixture(setupNFTCollectionContract);
+    await setupDefaultWave(20);
+    await contract.setupWave(waveMaxTokensOverall, maxTokensPerWallet, 2);
+    await contract.batchMint(0, [[randomWallet, maxTokensPerWallet + 1]]);
   });
 
   it('should emit WaveMint event when batchMint is called', async function () {
@@ -61,6 +72,34 @@ describe('NFTCollection batch mint', function () {
       const tokenId = waveMintEvents[i].args.tokenId;
       expect(await contract.ownerOf(tokenId)).to.be.eq(collectionOwner);
     }
+  });
+
+  it('owner should be able to batchMint over waveMaxTokensPerWallet', async function () {
+    const {
+      collectionContractAsOwner: contract,
+      waveMaxTokensOverall,
+      waveMaxTokensPerWallet,
+      randomWallet,
+    } = await loadFixture(setupNFTCollectionContract);
+
+    await contract.setupWave(waveMaxTokensOverall, waveMaxTokensPerWallet, 10);
+    await expect(
+      contract.batchMint(0, [[randomWallet, waveMaxTokensPerWallet + 1]])
+    ).to.not.be.reverted;
+  });
+
+  it('owner should be able to batchMint over waveMaxTokensOverall', async function () {
+    const {
+      collectionContractAsOwner: contract,
+      randomWallet,
+      waveMaxTokensOverall,
+      waveMaxTokensPerWallet,
+    } = await loadFixture(setupNFTCollectionContract);
+
+    await contract.setupWave(waveMaxTokensOverall, waveMaxTokensPerWallet, 20);
+    await expect(
+      contract.batchMint(0, [[randomWallet, waveMaxTokensOverall + 1]])
+    ).to.not.be.reverted;
   });
 
   it('other should not be able batchMint', async function () {
@@ -107,42 +146,18 @@ describe('NFTCollection batch mint', function () {
         .withArgs(randomWallet, 0);
     });
 
-    it('should not be able to batchMint over waveMaxTokensOverall', async function () {
-      const {collectionContractAsOwner: contract, randomWallet} =
-        await loadFixture(setupNFTCollectionContract);
-      const waveMaxTokensOverall = 100;
-      await contract.setupWave(waveMaxTokensOverall, 10, 20);
-      await expect(
-        contract.batchMint(0, [[randomWallet, waveMaxTokensOverall + 1]])
-      )
-        .to.revertedWithCustomError(contract, 'CannotMint')
-        .withArgs(randomWallet, waveMaxTokensOverall + 1);
-    });
-
-    it('should not be able to batchMint over waveMaxTokensPerWallet', async function () {
-      const {collectionContractAsOwner: contract, randomWallet} =
-        await loadFixture(setupNFTCollectionContract);
-      const waveMaxTokensPerWallet = 10;
-      await contract.setupWave(100, waveMaxTokensPerWallet, 0);
-      await expect(
-        contract.batchMint(0, [[randomWallet, waveMaxTokensPerWallet + 1]])
-      )
-        .to.revertedWithCustomError(contract, 'CannotMint')
-        .withArgs(randomWallet, waveMaxTokensPerWallet + 1);
-    });
-
     it('should not be able to batchMint over maxSupply', async function () {
       const {
         collectionContractAsOwner: contract,
         randomWallet,
         maxSupply,
       } = await loadFixture(setupNFTCollectionContract);
+      await contract.setMaxTokensPerWallet(maxSupply);
       await contract.setupWave(maxSupply, maxSupply, 0);
-      await contract.batchMint(0, [[randomWallet, maxSupply]]);
       await contract.setupWave(maxSupply, maxSupply, 0);
-      await expect(contract.batchMint(0, [[randomWallet, maxSupply]]))
+      await expect(contract.batchMint(0, [[randomWallet, maxSupply + 1]]))
         .to.revertedWithCustomError(contract, 'CannotMint')
-        .withArgs(randomWallet, maxSupply);
+        .withArgs(randomWallet, maxSupply + 1);
     });
   });
 });

--- a/packages/avatar/test/avatar/nft-collection/NFTCollection.batch.mint.test.ts
+++ b/packages/avatar/test/avatar/nft-collection/NFTCollection.batch.mint.test.ts
@@ -35,6 +35,7 @@ describe('NFTCollection batch mint', function () {
       expect(await contract.ownerOf(tokenId)).to.be.eq(collectionOwner);
     }
   });
+
   it('owner should be able to batchMint irrespective of the maxTokensPerWallet', async function () {
     const {
       collectionContractAsOwner: contract,

--- a/packages/avatar/test/avatar/nft-collection/NFTCollection.gas.usage.test.ts
+++ b/packages/avatar/test/avatar/nft-collection/NFTCollection.gas.usage.test.ts
@@ -1,11 +1,14 @@
-import {setupNFTCollectionContract} from './NFTCollection.fixtures';
 import {loadFixture} from '@nomicfoundation/hardhat-network-helpers';
 import {Wallet} from 'ethers';
+import {setupNFTCollectionContract} from './NFTCollection.fixtures';
 
 async function customDeploy() {
   const maxSupply = 100000;
   const ret = await loadFixture(setupNFTCollectionContract);
-  const collectionContract = await ret.deployWithCustomArg(8, maxSupply);
+  const collectionContract = await ret.deployWithCustomArg({
+    maxSupply,
+    maxTokensPerWallet: maxSupply,
+  });
   const collectionContractAsOwner = collectionContract.connect(
     ret.collectionOwner
   );
@@ -73,7 +76,7 @@ describe('NFTCollection gas usage @skip-on-ci @skip-on-coverage', function () {
     const {collectionContractAsOwner, randomWallet} = await loadFixture(
       customDeploy
     );
-    const amount = 1150n;
+    const amount = 10n;
     const tx = await collectionContractAsOwner.batchMint(0, [
       [randomWallet, amount],
     ]);
@@ -115,7 +118,7 @@ describe('NFTCollection gas usage @skip-on-ci @skip-on-coverage', function () {
       raffleSignWallet,
       mintSign,
     } = await loadFixture(customDeploy);
-    const amount = 1120n;
+    const amount = 1000n;
     const encodedData = contract.interface.encodeFunctionData('mint', [
       await randomWallet.getAddress(),
       amount,

--- a/packages/avatar/test/avatar/nft-collection/NFTCollection.mint.test.ts
+++ b/packages/avatar/test/avatar/nft-collection/NFTCollection.mint.test.ts
@@ -147,7 +147,6 @@ describe('NFTCollection mint', function () {
         mintSign,
         sandContract,
         randomWallet,
-        maxSupply,
         waveMaxTokensOverall,
         waveMaxTokensPerWallet,
       } = await loadFixture(setupNFTCollectionContract);
@@ -529,6 +528,7 @@ describe('NFTCollection mint', function () {
           )
           .withArgs(maxTokensPerWallet, maxTokensPerWallet, maxTokensPerWallet);
       });
+
       it('should not be able to waveMint when the caller is not allowed to execute mint', async function () {
         const {
           collectionContractAsOwner,

--- a/packages/avatar/test/avatar/nft-collection/NFTCollection.mint.test.ts
+++ b/packages/avatar/test/avatar/nft-collection/NFTCollection.mint.test.ts
@@ -13,13 +13,14 @@ describe('NFTCollection mint', function () {
         sandContract,
         randomWallet,
         treasury,
+        waveMaxTokensPerWallet,
         maxSupply,
       } = await loadFixture(setupNFTCollectionContract);
       const amount = 2;
       const unitPrice = 10;
       const price = amount * unitPrice;
       await sandContract.donateTo(randomWallet, price);
-      await contract.setupWave(maxSupply, maxSupply, unitPrice);
+      await contract.setupWave(maxSupply, waveMaxTokensPerWallet, unitPrice);
       const encodedData = contract.interface.encodeFunctionData('mint', [
         await randomWallet.getAddress(),
         amount,
@@ -78,31 +79,32 @@ describe('NFTCollection mint', function () {
         sandContract,
         randomWallet,
         randomWallet2,
-        waveMaxTokensOverall,
+        waveMaxTokensPerWallet,
       } = await loadFixture(setupNFTCollectionContract);
       await contract.setupWave(
-        waveMaxTokensOverall,
-        waveMaxTokensOverall - 1,
+        waveMaxTokensPerWallet,
+        waveMaxTokensPerWallet - 1,
         0
       );
       await sandContract.mint(
         contract,
         randomWallet,
-        waveMaxTokensOverall - 1,
+        waveMaxTokensPerWallet - 1,
         222,
         await mintSign(randomWallet, 222)
       );
+
       await expect(
         sandContract.mint(
           contract,
           randomWallet2,
-          waveMaxTokensOverall - 1,
+          waveMaxTokensPerWallet - 1,
           223,
           await mintSign(randomWallet2, 223)
         )
       )
         .to.revertedWithCustomError(contract, 'CannotMint')
-        .withArgs(randomWallet2, waveMaxTokensOverall - 1);
+        .withArgs(randomWallet2, waveMaxTokensPerWallet - 1);
     });
 
     it('should not be able to mint over maxSupply', async function () {
@@ -111,28 +113,32 @@ describe('NFTCollection mint', function () {
         mintSign,
         sandContract,
         randomWallet,
+        randomWallet2,
         maxSupply,
+        waveMaxTokensOverall,
+        waveMaxTokensPerWallet,
       } = await loadFixture(setupNFTCollectionContract);
-      await contract.setupWave(maxSupply, maxSupply, 0);
+      await contract.setupWave(waveMaxTokensOverall, waveMaxTokensPerWallet, 0);
+      await contract.batchMint(0, [[randomWallet2, maxSupply - 1]]);
       await sandContract.mint(
         contract,
         randomWallet,
-        maxSupply,
+        1,
         222,
         await mintSign(randomWallet, 222)
       );
-      await contract.setupWave(maxSupply, maxSupply, 0);
+      await contract.setupWave(waveMaxTokensOverall, waveMaxTokensPerWallet, 0);
       await expect(
         sandContract.mint(
           contract,
           randomWallet,
-          maxSupply,
+          1,
           223,
           await mintSign(randomWallet, 223)
         )
       )
         .to.revertedWithCustomError(contract, 'CannotMint')
-        .withArgs(randomWallet, maxSupply);
+        .withArgs(randomWallet, 1);
     });
 
     it('should not be able to mint without enough balance', async function () {
@@ -142,14 +148,20 @@ describe('NFTCollection mint', function () {
         sandContract,
         randomWallet,
         maxSupply,
+        waveMaxTokensOverall,
+        waveMaxTokensPerWallet,
       } = await loadFixture(setupNFTCollectionContract);
       const price = 10;
-      await contract.setupWave(maxSupply, maxSupply, price);
+      await contract.setupWave(
+        waveMaxTokensOverall,
+        waveMaxTokensPerWallet,
+        price
+      );
       await expect(
         sandContract.mint(
           contract,
           randomWallet,
-          maxSupply,
+          waveMaxTokensPerWallet,
           222,
           await mintSign(randomWallet, 222)
         )
@@ -297,13 +309,22 @@ describe('NFTCollection mint', function () {
         sandContract,
         randomWallet,
         treasury,
-        maxSupply,
+        waveMaxTokensOverall,
+        waveMaxTokensPerWallet,
       } = await loadFixture(setupNFTCollectionContract);
       const unitPrice = 10;
       await sandContract.donateTo(randomWallet, unitPrice * 5);
       // Setup two waves
-      await contract.setupWave(maxSupply, maxSupply, unitPrice);
-      await contract.setupWave(maxSupply, maxSupply, unitPrice);
+      await contract.setupWave(
+        waveMaxTokensOverall,
+        waveMaxTokensPerWallet,
+        unitPrice
+      );
+      await contract.setupWave(
+        waveMaxTokensOverall,
+        waveMaxTokensPerWallet,
+        unitPrice
+      );
       expect(await sandContract.balanceOf(treasury)).to.be.eq(0);
       expect(await sandContract.balanceOf(randomWallet)).to.be.eq(
         unitPrice * 5
@@ -362,11 +383,16 @@ describe('NFTCollection mint', function () {
         waveMintSign,
         sandContract,
         randomWallet,
-        maxSupply,
+        waveMaxTokensOverall,
+        waveMaxTokensPerWallet,
       } = await loadFixture(setupNFTCollectionContract);
       const unitPrice = 10;
       await sandContract.donateTo(randomWallet, unitPrice * 5);
-      await contract.setupWave(maxSupply, maxSupply, unitPrice);
+      await contract.setupWave(
+        waveMaxTokensOverall,
+        waveMaxTokensPerWallet,
+        unitPrice
+      );
 
       expect(await sandContract.balanceOf(randomWallet)).to.be.eq(
         unitPrice * 5
@@ -387,20 +413,10 @@ describe('NFTCollection mint', function () {
         contract.filters.WaveMint()
       );
 
-      const walletTotalMinted = await contract.waveOwnerToClaimedCounts(
-        0,
-        randomWallet
-      );
-      const waveTotalMinted = await contract.waveTotalMinted(0);
-
       expect(waveMintEvents).to.have.lengthOf(1);
       expect(waveMintEvents[0].args.tokenId).to.be.eq(1);
       expect(waveMintEvents[0].args.wallet).to.be.eq(randomWallet);
       expect(waveMintEvents[0].args.waveIndex).to.be.eq(0);
-      expect(waveMintEvents[0].args.walletMintCount).to.be.eq(
-        walletTotalMinted
-      );
-      expect(waveMintEvents[0].args.waveTotalMinted).to.be.eq(waveTotalMinted);
     });
 
     it('should emit WaveMint event when mint is called', async function () {
@@ -409,11 +425,16 @@ describe('NFTCollection mint', function () {
         mintSign,
         sandContract,
         randomWallet,
-        maxSupply,
+        waveMaxTokensOverall,
+        waveMaxTokensPerWallet,
       } = await loadFixture(setupNFTCollectionContract);
       const unitPrice = 10;
       await sandContract.donateTo(randomWallet, unitPrice * 5);
-      await contract.setupWave(maxSupply, maxSupply, unitPrice);
+      await contract.setupWave(
+        waveMaxTokensOverall,
+        waveMaxTokensPerWallet,
+        unitPrice
+      );
 
       const encodedData = contract.interface.encodeFunctionData('mint', [
         await randomWallet.getAddress(),
@@ -433,8 +454,6 @@ describe('NFTCollection mint', function () {
       expect(mintEvents[0].args.tokenId).to.be.eq(1);
       expect(mintEvents[0].args.wallet).to.be.eq(randomWallet);
       expect(mintEvents[0].args.waveIndex).to.be.eq(0);
-      expect(mintEvents[0].args.walletMintCount).to.be.eq(1);
-      expect(mintEvents[0].args.waveTotalMinted).to.be.eq(1);
     });
 
     describe('wrong args', function () {
@@ -446,6 +465,70 @@ describe('NFTCollection mint', function () {
         ).to.revertedWithCustomError(contract, 'ContractNotConfigured');
       });
 
+      it('should not allow minting more than maxTokensPerWallet', async function () {
+        const {
+          collectionContractAsOwner,
+          collectionContractAsRandomWallet: contract,
+          sandContract,
+          randomWallet,
+          waveMaxTokensOverall,
+          maxTokensPerWallet,
+          waveMintSign,
+        } = await loadFixture(setupNFTCollectionContract);
+
+        const unitPrice = 1;
+        await sandContract.donateTo(randomWallet, unitPrice * 40);
+
+        await collectionContractAsOwner.setupWave(
+          waveMaxTokensOverall,
+          maxTokensPerWallet,
+          unitPrice
+        );
+        await collectionContractAsOwner.setupWave(
+          waveMaxTokensOverall,
+          maxTokensPerWallet,
+          unitPrice
+        );
+
+        const encodedData = contract.interface.encodeFunctionData('waveMint', [
+          await randomWallet.getAddress(),
+          maxTokensPerWallet,
+          0,
+          222,
+          await waveMintSign(randomWallet, maxTokensPerWallet, 0, 222),
+        ]);
+
+        await sandContract
+          .connect(randomWallet)
+          .approveAndCall(
+            contract,
+            unitPrice * maxTokensPerWallet,
+            encodedData
+          );
+
+        const encodedData2 = contract.interface.encodeFunctionData('waveMint', [
+          await randomWallet.getAddress(),
+          maxTokensPerWallet,
+          1,
+          223,
+          await waveMintSign(randomWallet, maxTokensPerWallet, 1, 223),
+        ]);
+
+        await expect(
+          sandContract
+            .connect(randomWallet)
+            .approveAndCall(
+              contract,
+              unitPrice * maxTokensPerWallet,
+              encodedData2
+            )
+        )
+          .to.revertedWithCustomError(
+            contract,
+            'GlobalMaxTokensPerWalletExceeded'
+          )
+          .withArgs(maxTokensPerWallet, maxTokensPerWallet, maxTokensPerWallet);
+      });
       it('should not be able to waveMint when the caller is not allowed to execute mint', async function () {
         const {
           collectionContractAsOwner,

--- a/packages/avatar/test/avatar/nft-collection/NFTCollection.wave.setup.test.ts
+++ b/packages/avatar/test/avatar/nft-collection/NFTCollection.wave.setup.test.ts
@@ -1,7 +1,7 @@
 import {expect} from 'chai';
 
-import {setupNFTCollectionContract} from './NFTCollection.fixtures';
 import {loadFixture} from '@nomicfoundation/hardhat-network-helpers';
+import {setupNFTCollectionContract} from './NFTCollection.fixtures';
 
 describe('NFTCollection wave setup', function () {
   describe('setupWave', function () {
@@ -121,8 +121,11 @@ describe('NFTCollection wave setup', function () {
         0,
         0
       );
-    expect(await contract.waveTotalMinted(0)).to.be.eq(0);
-    expect(await contract.waveCount()).to.be.eq(1);
+    expect(await contract.waveTotalMinted(0)).to.be.eq(
+      0,
+      'Wave total minted not 0'
+    );
+    expect(await contract.waveCount()).to.be.eq(1, 'Wave count not 1');
     await contract.batchMint(0, [
       [randomWallet, 5],
       [randomWallet, 1],
@@ -134,15 +137,19 @@ describe('NFTCollection wave setup', function () {
       222,
       await mintSign(randomWallet, 222)
     );
-    expect(await contract.waveTotalMinted(0)).to.be.eq(5 + 1 + 2);
-    expect(await contract.waveTotalMinted(2n ** 256n - 1n)).to.be.eq(5 + 1 + 2);
-    expect(await contract.waveTotalMinted(1)).to.be.eq(5 + 1 + 2);
+    expect(await contract.waveTotalMinted(0)).to.be.eq(2);
+    expect(await contract.waveTotalMinted(2n ** 256n - 1n)).to.be.eq(2);
+    expect(await contract.waveTotalMinted(1)).to.be.eq(2);
+    expect(await contract.waveTotalMinted(5)).to.be.eq(2);
+
     expect(await contract.waveCount()).to.be.eq(1);
     await expect(contract.setupWave(10, 1, 2))
       .to.emit(contract, 'WaveSetup')
       .withArgs(nftCollectionAdmin, 10, 1, 2, 1);
-    expect(await contract.waveTotalMinted(0)).to.be.eq(5 + 1 + 2);
+    expect(await contract.waveTotalMinted(0)).to.be.eq(2);
+    expect(await contract.waveTotalMinted(5)).to.be.eq(0);
     expect(await contract.waveTotalMinted(1)).to.be.eq(0);
+
     expect(await contract.waveTotalMinted(2n ** 256n - 1n)).to.be.eq(0);
     expect(await contract.waveTotalMinted(2)).to.be.eq(0);
     expect(await contract.waveCount()).to.be.eq(2);

--- a/packages/deploy/deploy/28_nft_collection/100_deploy_nft_collection_mock.ts
+++ b/packages/deploy/deploy/28_nft_collection/100_deploy_nft_collection_mock.ts
@@ -28,6 +28,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const collectionName = 'NFTCollectionTest';
   const collectionSymbol = 'TEST';
   const MAX_SUPPLY = 500;
+  const MAX_TOKENS_PER_WALLET = 2;
 
   const TRUSTED_FORWARDER = await deployments.get('TRUSTED_FORWARDER_V2');
   const sandContract = await deployments.get('PolygonSand');
@@ -46,6 +47,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       TRUSTED_FORWARDER.address,
       sandContract.address,
       MAX_SUPPLY,
+      MAX_TOKENS_PER_WALLET,
     ]
   );
   await deployments.catchUnknownSigner(async () => {

--- a/packages/deploy/deploy/28_nft_collection/100_deploy_nft_collection_mock.ts
+++ b/packages/deploy/deploy/28_nft_collection/100_deploy_nft_collection_mock.ts
@@ -38,16 +38,18 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const encodedConstructorArgs = implementation.interface.encodeFunctionData(
     'initialize',
     [
-      nftCollectionAdmin,
-      metadataUrl,
-      collectionName,
-      collectionSymbol,
-      treasury,
-      raffleSignWallet,
-      TRUSTED_FORWARDER.address,
-      sandContract.address,
-      MAX_SUPPLY,
-      MAX_TOKENS_PER_WALLET,
+      [
+        nftCollectionAdmin,
+        metadataUrl,
+        collectionName,
+        collectionSymbol,
+        treasury,
+        raffleSignWallet,
+        TRUSTED_FORWARDER.address,
+        sandContract.address,
+        MAX_SUPPLY,
+        MAX_TOKENS_PER_WALLET,
+      ],
     ]
   );
   await deployments.catchUnknownSigner(async () => {

--- a/packages/deploy/deploy/28_nft_collection/101_save_nft_collection_mock_for_verification.ts
+++ b/packages/deploy/deploy/28_nft_collection/101_save_nft_collection_mock_for_verification.ts
@@ -16,7 +16,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const collectionName = 'NFTCollectionTest';
   const collectionSymbol = 'TEST';
   const MAX_SUPPLY = 500;
-
+  const MAX_TOKENS_PER_WALLET = 2;
   const TRUSTED_FORWARDER = await deployments.get('TRUSTED_FORWARDER_V2');
   const sandContract = await deployments.get('PolygonSand');
   const implementation = await ethers.getContract(
@@ -47,6 +47,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
         TRUSTED_FORWARDER.address,
         sandContract.address,
         MAX_SUPPLY,
+        MAX_TOKENS_PER_WALLET,
       ]),
     ]
   );

--- a/packages/deploy/deploy/28_nft_collection/101_save_nft_collection_mock_for_verification.ts
+++ b/packages/deploy/deploy/28_nft_collection/101_save_nft_collection_mock_for_verification.ts
@@ -38,16 +38,18 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     [
       beaconAddress,
       implementation.interface.encodeFunctionData('initialize', [
-        nftCollectionAdmin,
-        metadataUrl,
-        collectionName,
-        collectionSymbol,
-        treasury,
-        raffleSignWallet,
-        TRUSTED_FORWARDER.address,
-        sandContract.address,
-        MAX_SUPPLY,
-        MAX_TOKENS_PER_WALLET,
+        [
+          nftCollectionAdmin,
+          metadataUrl,
+          collectionName,
+          collectionSymbol,
+          treasury,
+          raffleSignWallet,
+          TRUSTED_FORWARDER.address,
+          sandContract.address,
+          MAX_SUPPLY,
+          MAX_TOKENS_PER_WALLET,
+        ],
       ]),
     ]
   );

--- a/packages/deploy/hardhat.config.ts
+++ b/packages/deploy/hardhat.config.ts
@@ -449,36 +449,47 @@ const networks = {
   },
 };
 
-const compilers = [
-  '0.8.26',
-  '0.8.23',
-  '0.8.21',
-  '0.8.19',
-  '0.8.18',
-  '0.8.2',
-  '0.7.5',
-  '0.7.6',
-  '0.6.5',
-  '0.5.9',
-].map((version) => ({
-  version,
-  settings: {
-    optimizer: {
-      enabled: true,
-      runs: 2000,
-    },
-  },
-}));
+const defaultOptimizer = {
+  enabled: true,
+  runs: 2000,
+};
 
-compilers.push({
-  version: '0.8.15',
-  settings: {
-    optimizer: {
-      enabled: true,
-      runs: 200, // needed for AvatarCollection contract that exceeds maximum contract size
+const lowRunsOptimizer = {
+  enabled: true,
+  runs: 200, // For large contracts that exceed size limits
+};
+
+const compilers = [
+  // Standard optimized compilers
+  ...[
+    '0.8.23',
+    '0.8.21',
+    '0.8.19',
+    '0.8.18',
+    '0.8.2',
+    '0.7.5',
+    '0.7.6',
+    '0.6.5',
+    '0.5.9',
+  ].map((version) => ({
+    version,
+    settings: {
+      optimizer: defaultOptimizer,
     },
-  },
-});
+  })),
+
+  // Special cases with lower optimization runs
+  ...[
+    {version: '0.8.26', comment: 'NFTCollection contract'},
+    {version: '0.8.15', comment: 'AvatarCollection contract'},
+  ].map(({version, comment}) => ({
+    version,
+    settings: {
+      optimizer: lowRunsOptimizer,
+      metadata: {comments: {optimizer: comment}},
+    },
+  })),
+];
 
 const config = skipDeploymentsOnLiveNetworks(
   addForkingSupport({

--- a/packages/deploy/hardhat.config.ts
+++ b/packages/deploy/hardhat.config.ts
@@ -479,14 +479,10 @@ const compilers = [
   })),
 
   // Special cases with lower optimization runs
-  ...[
-    {version: '0.8.26', comment: 'NFTCollection contract'},
-    {version: '0.8.15', comment: 'AvatarCollection contract'},
-  ].map(({version, comment}) => ({
+  ...[{version: '0.8.26'}, {version: '0.8.15'}].map(({version}) => ({
     version,
     settings: {
       optimizer: lowRunsOptimizer,
-      metadata: {comments: {optimizer: comment}},
     },
   })),
 ];


### PR DESCRIPTION
## Description

We have identified a couple issues that we had to address:

- We should have a general limit of tokens per wallet that is independent of the wave limit
- We want the owner to be able to mint over the wave and general limit for marketing events etc.
- We don't want TSB special mints to be included in the `waveTotalMinted` as that limit should be for regular user mints

This PR contains the logic that is supposed to solve the above issues by:

- Introducing `maxTokensPerWallet` measured in `mintedCount` per wallet
- The minted count is increased when we use `mint` and `waveMint` but not `batchMint` which is the owner function.
- We added extra errors and validation for example prevent admin from setting `waveMaxTokensPerWallet` higher than `maxTokensPerWallet` as that would make no sense.
- It is acceptable that even if `maxTokensPerWallet` is `1` to have two waves with `waveMaxTokensPerWallet` set to `1` also as we may let users chose the mint wave.

Other changes:

- Moved initialization params to a struct to avoid stack too deep error
- Removed unnecessary data from `WaveMint` event
