### PR TITLE
[nft-collection M-01] Incomplete Checks in setupWave Function

### DIFF
--- a/packages/avatar/contracts/nft-collection/NFTCollection.sol
+++ b/packages/avatar/contracts/nft-collection/NFTCollection.sol
@@ -168,7 +168,7 @@ INFTCollection
     ) external onlyOwner {
         NFTCollectionStorage storage $ = _getNFTCollectionStorage();
         if (
-            _waveMaxTokensOverall > $.maxSupply ||
+            $.totalSupply + _waveMaxTokensOverall > $.maxSupply ||
             _waveMaxTokensOverall == 0 ||
             _waveMaxTokensPerWallet == 0 ||
             _waveMaxTokensPerWallet > _waveMaxTokensOverall

--- a/packages/avatar/test/avatar/nft-collection/NFTCollection.mint.test.ts
+++ b/packages/avatar/test/avatar/nft-collection/NFTCollection.mint.test.ts
@@ -119,7 +119,6 @@ describe('NFTCollection mint', function () {
         waveMaxTokensPerWallet,
       } = await loadFixture(setupNFTCollectionContract);
       await contract.setupWave(waveMaxTokensOverall, waveMaxTokensPerWallet, 0);
-      await contract.batchMint(0, [[randomWallet2, maxSupply - 1]]);
       await sandContract.mint(
         contract,
         randomWallet,
@@ -128,6 +127,7 @@ describe('NFTCollection mint', function () {
         await mintSign(randomWallet, 222)
       );
       await contract.setupWave(waveMaxTokensOverall, waveMaxTokensPerWallet, 0);
+      await contract.batchMint(0, [[randomWallet2, maxSupply - 1]]);
       await expect(
         sandContract.mint(
           contract,

--- a/packages/avatar/test/avatar/nft-collection/NFTCollection.wave.setup.test.ts
+++ b/packages/avatar/test/avatar/nft-collection/NFTCollection.wave.setup.test.ts
@@ -32,6 +32,19 @@ describe('NFTCollection wave setup', function () {
         .withArgs(maxSupply + 1, 1);
     });
 
+    it('should fail to setup a wave when waveMaxTokensOverall excess maxSupply-totalSupply', async function () {
+      const {
+        collectionContractAsOwner: contract,
+        randomWallet2,
+        maxSupply,
+      } = await loadFixture(setupNFTCollectionContract);
+      await contract.setupWave(1, 1, 2);
+      await contract.batchMint(0, [[randomWallet2, 1]]);
+      await expect(contract.setupWave(maxSupply, 1, 2))
+        .to.revertedWithCustomError(contract, 'InvalidWaveData')
+        .withArgs(maxSupply, 1);
+    });
+
     it('should fail to setup a wave when waveMaxTokensPerWallet excess maxTokensPerWallet', async function () {
       const {
         collectionContractAsOwner: contract,


### PR DESCRIPTION
# Description
https://internal-jira.atlassian.net/browse/GE-100

## Audit
The [setupWave](https://github.com/thesandboxgame/sandbox-smart-contracts/blob/3b1fa4b58d635fb2fe891e07747b59987ee32ad0/packages/avatar/contracts/nft-collection/NFTCollection.sol#L171) function verifies parameters to ensure the following:

That _waveMaxTokensOverall is not larger than $.maxSupply. The maximum number of tokens that can be minted in this wave should not exceed the global maximum amount of tokens that can be minted.
That _waveMaxTokensPerWallet is not larger than _waveMaxTokensOverall. The maximum number of tokens that can be minted per wallet should not exceed the total number of tokens allowed to be minted in this wave.
However, the first check does not take into account the tokens already minted in previous waves, which are represented by $.totalSupply. In addition, the second condition does not verify whether _waveMaxTokensOverall is divisible by _waveMaxTokensPerWallet, which could lead to an uneven distribution of tokens among wallets in the same wave.

Consider fixing the above issues present in the setupWave function.

## Fix
We check that `_waveMaxTokensOverall <  maxSupply - totalSupply`.
For the second condition we don't want an even distribution of tokens among wallets.

