### PR TITLE
[nft-collection N-10] Missing Named Parameters in Mappings

### DIFF
--- a/packages/avatar/contracts/nft-collection/INFTCollection.sol
+++ b/packages/avatar/contracts/nft-collection/INFTCollection.sol
@@ -75,7 +75,7 @@ interface INFTCollection {
         uint256 waveMaxTokensPerWallet;
         uint256 waveSingleTokenPrice;
         uint256 waveTotalMinted;
-        mapping(address => uint256) waveOwnerToClaimedCounts;
+        mapping(address owner => uint256 count) waveOwnerToClaimedCounts;
     }
 
     /**

--- a/packages/avatar/contracts/nft-collection/NFTCollection.sol
+++ b/packages/avatar/contracts/nft-collection/NFTCollection.sol
@@ -75,11 +75,11 @@ contract NFTCollection is
         /**
          * @notice Mapping of token personalization traits.
          */
-        mapping(uint256 => uint256) personalizationTraits;
+        mapping(uint256 tokenId => uint256 mask) personalizationTraits;
         /**
          * @notice Mapping of tokens minted per address.
          */
-        mapping(address => uint256) mintedCount;
+        mapping(address wallet => uint256 count) mintedCount;
         /**
          * @notice Current total supply of minted tokens.
          */

--- a/packages/avatar/contracts/nft-collection/NFTCollectionSignature.sol
+++ b/packages/avatar/contracts/nft-collection/NFTCollectionSignature.sol
@@ -39,7 +39,7 @@ abstract contract NFTCollectionSignature {
          *      values are 0 (default, unused) and 1 (used)
          *      Used to avoid a signature reuse
          */
-        mapping(uint256 => SignatureType) signatureIds;
+        mapping(uint256 signatureId => SignatureType signatureType) signatureIds;
     }
 
     /**


### PR DESCRIPTION
# Description

https://internal-jira.atlassian.net/browse/GE-100

## Audit

Since [Solidity 0.8.18](https://github.com/ethereum/solidity/releases/tag/v0.8.18), developers can utilize named parameters in mappings. This means mappings can take the form of mapping(KeyType KeyName? => ValueType ValueName?). This updated syntax provides a more transparent representation of a mapping's purpose.

Throughout the codebase, multiple instances of mappings without named parameters were identified:

The [burner state variable](https://github.com/thesandboxgame/sandbox-smart-contracts/blob/3b1fa4b58d635fb2fe891e07747b59987ee32ad0/packages/avatar/contracts/nft-collection/ERC721BurnMemoryUpgradeable.sol#L19) in the ERC721BurnMemoryUpgradeable contract
The [burnedTokens state variable](https://github.com/thesandboxgame/sandbox-smart-contracts/blob/3b1fa4b58d635fb2fe891e07747b59987ee32ad0/packages/avatar/contracts/nft-collection/ERC721BurnMemoryUpgradeable.sol#L24) in the ERC721BurnMemoryUpgradeable contract
The [personalizationTraits state variable](https://github.com/thesandboxgame/sandbox-smart-contracts/blob/3b1fa4b58d635fb2fe891e07747b59987ee32ad0/packages/avatar/contracts/nft-collection/NFTCollection.sol#L82) in the NFTCollection contract
The [mintedCount state variable](https://github.com/thesandboxgame/sandbox-smart-contracts/blob/3b1fa4b58d635fb2fe891e07747b59987ee32ad0/packages/avatar/contracts/nft-collection/NFTCollection.sol#L86) in the NFTCollection contract
The [signatureIds state variable](https://github.com/thesandboxgame/sandbox-smart-contracts/blob/3b1fa4b58d635fb2fe891e07747b59987ee32ad0/packages/avatar/contracts/nft-collection/NFTCollectionSignature.sol#L41) in the NFTCollectionSignature contract
Consider adding named parameters to mappings in order to improve the readability and maintainability of the codebase.

## Fix
fixed