### PR TITLE
add deploy steps to set the royalty for the land and polygon land contracts

### DIFF
--- a/packages/deploy/deploy/700_land/land/742_setup_land_v4_royalty.ts
+++ b/packages/deploy/deploy/700_land/land/742_setup_land_v4_royalty.ts
@@ -1,8 +1,11 @@
 import {DeployFunction} from 'hardhat-deploy/types';
 import {HardhatRuntimeEnvironment} from 'hardhat/types';
 import {DEPLOY_TAGS} from '../../../hardhat.config';
+import {
+  ROYALTY_MANAGER_LAND_ROYALTY_BPS,
+  ROYALTY_MANAGER_TOTAL_BASIS_POINTS,
+} from '../../../royaltiesConfig';
 
-const ROYALTY_PERCENTAGE = 500;
 const func: DeployFunction = async function (
   hre: HardhatRuntimeEnvironment
 ): Promise<void> {
@@ -11,15 +14,20 @@ const func: DeployFunction = async function (
   const {royaltyManagerAdmin, commonRoyaltyReceiver} = await getNamedAccounts();
   const Land = await deployments.get('Land');
   // Here we assume a fixed royalty percentage that does not depend on the tokenId
-  const info = await read('Land', 'royaltyInfo', 1, 10000);
+  const info = await read(
+    'Land',
+    'royaltyInfo',
+    1,
+    ROYALTY_MANAGER_TOTAL_BASIS_POINTS
+  );
   if (info.receiver != commonRoyaltyReceiver) {
     console.warn(
       `The hardhat.config commonRoyaltyReceiver (${commonRoyaltyReceiver}) is different from the one configured in the royaltyManager (${info.receiver})`
     );
   }
-  if (!info.royaltyAmount.eq(ROYALTY_PERCENTAGE)) {
+  if (!info.royaltyAmount.eq(ROYALTY_MANAGER_LAND_ROYALTY_BPS)) {
     console.log(
-      `Changing land royalty from ${info.royaltyAmount} to ${ROYALTY_PERCENTAGE}`
+      `Changing land royalty from ${info.royaltyAmount} to ${ROYALTY_MANAGER_LAND_ROYALTY_BPS}`
     );
     await catchUnknownSigner(
       execute(
@@ -27,7 +35,7 @@ const func: DeployFunction = async function (
         {from: royaltyManagerAdmin, log: true},
         'setContractRoyalty',
         Land.address,
-        ROYALTY_PERCENTAGE
+        ROYALTY_MANAGER_LAND_ROYALTY_BPS
       )
     );
   }

--- a/packages/deploy/deploy/700_land/land/742_setup_land_v4_royalty.ts
+++ b/packages/deploy/deploy/700_land/land/742_setup_land_v4_royalty.ts
@@ -1,0 +1,44 @@
+import {DeployFunction} from 'hardhat-deploy/types';
+import {HardhatRuntimeEnvironment} from 'hardhat/types';
+import {DEPLOY_TAGS} from '../../../hardhat.config';
+
+const ROYALTY_PERCENTAGE = 500;
+const func: DeployFunction = async function (
+  hre: HardhatRuntimeEnvironment
+): Promise<void> {
+  const {deployments, getNamedAccounts} = hre;
+  const {execute, read, catchUnknownSigner} = deployments;
+  const {royaltyManagerAdmin, commonRoyaltyReceiver} = await getNamedAccounts();
+  const Land = await deployments.get('Land');
+  const info = await read('Land', 'royaltyInfo', 1, 10000);
+  if (info.receiver != commonRoyaltyReceiver) {
+    console.warn(
+      `The hardhat.config commonRoyaltyReceiver (${commonRoyaltyReceiver}) is different from the one configured in the royaltyManager (${info.receiver})`
+    );
+  }
+  if (!info.royaltyAmount.eq(ROYALTY_PERCENTAGE)) {
+    console.log(
+      `Changing land royalty from ${info.royaltyAmount} to ${ROYALTY_PERCENTAGE}`
+    );
+    await catchUnknownSigner(
+      execute(
+        'RoyaltyManager',
+        {from: royaltyManagerAdmin, log: true},
+        'setContractRoyalty',
+        Land.address,
+        ROYALTY_PERCENTAGE
+      )
+    );
+  }
+};
+export default func;
+func.tags = [
+  'Land',
+  'LandV4_setup',
+  'LandRoyaltyManager',
+  'LandRoyaltyManager_setup_royalty',
+  DEPLOY_TAGS.L1,
+  DEPLOY_TAGS.L1_PROD,
+  DEPLOY_TAGS.L1_TEST,
+];
+func.dependencies = ['LandRoyaltyManager_setup'];

--- a/packages/deploy/deploy/700_land/land/742_setup_land_v4_royalty.ts
+++ b/packages/deploy/deploy/700_land/land/742_setup_land_v4_royalty.ts
@@ -10,6 +10,7 @@ const func: DeployFunction = async function (
   const {execute, read, catchUnknownSigner} = deployments;
   const {royaltyManagerAdmin, commonRoyaltyReceiver} = await getNamedAccounts();
   const Land = await deployments.get('Land');
+  // Here we assume a fixed royalty percentage that does not depend on the tokenId
   const info = await read('Land', 'royaltyInfo', 1, 10000);
   if (info.receiver != commonRoyaltyReceiver) {
     console.warn(

--- a/packages/deploy/deploy/700_land/polygonLand/732_setup_polygonland_v3_royalty.ts
+++ b/packages/deploy/deploy/700_land/polygonLand/732_setup_polygonland_v3_royalty.ts
@@ -1,8 +1,11 @@
 import {DeployFunction} from 'hardhat-deploy/types';
 import {HardhatRuntimeEnvironment} from 'hardhat/types';
 import {DEPLOY_TAGS} from '../../../hardhat.config';
+import {
+  ROYALTY_MANAGER_POLYGON_LAND_ROYALTY_BPS,
+  ROYALTY_MANAGER_TOTAL_BASIS_POINTS,
+} from '../../../royaltiesConfig';
 
-const ROYALTY_PERCENTAGE = 500;
 const func: DeployFunction = async function (
   hre: HardhatRuntimeEnvironment
 ): Promise<void> {
@@ -11,15 +14,20 @@ const func: DeployFunction = async function (
   const {royaltyManagerAdmin, commonRoyaltyReceiver} = await getNamedAccounts();
   const PolygonLand = await deployments.get('PolygonLand');
   // Here we assume a fixed royalty percentage that does not depend on the tokenId
-  const info = await read('PolygonLand', 'royaltyInfo', 1, 10000);
+  const info = await read(
+    'PolygonLand',
+    'royaltyInfo',
+    1,
+    ROYALTY_MANAGER_TOTAL_BASIS_POINTS
+  );
   if (info.receiver != commonRoyaltyReceiver) {
     console.warn(
       `The hardhat.config commonRoyaltyReceiver (${commonRoyaltyReceiver}) is different from the one configured in the royaltyManager (${info.receiver})`
     );
   }
-  if (!info.royaltyAmount.eq(ROYALTY_PERCENTAGE)) {
+  if (!info.royaltyAmount.eq(ROYALTY_MANAGER_POLYGON_LAND_ROYALTY_BPS)) {
     console.log(
-      `Changing land royalty from ${info.royaltyAmount} to ${ROYALTY_PERCENTAGE}`
+      `Changing land royalty from ${info.royaltyAmount} to ${ROYALTY_MANAGER_POLYGON_LAND_ROYALTY_BPS}`
     );
     await catchUnknownSigner(
       execute(
@@ -27,7 +35,7 @@ const func: DeployFunction = async function (
         {from: royaltyManagerAdmin, log: true},
         'setContractRoyalty',
         PolygonLand.address,
-        ROYALTY_PERCENTAGE
+        ROYALTY_MANAGER_POLYGON_LAND_ROYALTY_BPS
       )
     );
   }

--- a/packages/deploy/deploy/700_land/polygonLand/732_setup_polygonland_v3_royalty.ts
+++ b/packages/deploy/deploy/700_land/polygonLand/732_setup_polygonland_v3_royalty.ts
@@ -10,6 +10,7 @@ const func: DeployFunction = async function (
   const {execute, read, catchUnknownSigner} = deployments;
   const {royaltyManagerAdmin, commonRoyaltyReceiver} = await getNamedAccounts();
   const PolygonLand = await deployments.get('PolygonLand');
+  // Here we assume a fixed royalty percentage that does not depend on the tokenId
   const info = await read('PolygonLand', 'royaltyInfo', 1, 10000);
   if (info.receiver != commonRoyaltyReceiver) {
     console.warn(

--- a/packages/deploy/deploy/700_land/polygonLand/732_setup_polygonland_v3_royalty.ts
+++ b/packages/deploy/deploy/700_land/polygonLand/732_setup_polygonland_v3_royalty.ts
@@ -1,0 +1,45 @@
+import {DeployFunction} from 'hardhat-deploy/types';
+import {HardhatRuntimeEnvironment} from 'hardhat/types';
+import {DEPLOY_TAGS} from '../../../hardhat.config';
+
+const ROYALTY_PERCENTAGE = 500;
+const func: DeployFunction = async function (
+  hre: HardhatRuntimeEnvironment
+): Promise<void> {
+  const {deployments, getNamedAccounts} = hre;
+  const {execute, read, catchUnknownSigner} = deployments;
+  const {royaltyManagerAdmin, commonRoyaltyReceiver} = await getNamedAccounts();
+  const PolygonLand = await deployments.get('PolygonLand');
+  const info = await read('PolygonLand', 'royaltyInfo', 1, 10000);
+  if (info.receiver != commonRoyaltyReceiver) {
+    console.warn(
+      `The hardhat.config commonRoyaltyReceiver (${commonRoyaltyReceiver}) is different from the one configured in the royaltyManager (${info.receiver})`
+    );
+  }
+  if (!info.royaltyAmount.eq(ROYALTY_PERCENTAGE)) {
+    console.log(
+      `Changing land royalty from ${info.royaltyAmount} to ${ROYALTY_PERCENTAGE}`
+    );
+    await catchUnknownSigner(
+      execute(
+        'RoyaltyManager',
+        {from: royaltyManagerAdmin, log: true},
+        'setContractRoyalty',
+        PolygonLand.address,
+        ROYALTY_PERCENTAGE
+      )
+    );
+  }
+};
+
+export default func;
+func.tags = [
+  'PolygonLand',
+  'PolygonLandV3_setup',
+  'PolygonRoyaltyManager',
+  'PolygonRoyaltyManager_setup_royalty',
+  DEPLOY_TAGS.L1,
+  DEPLOY_TAGS.L1_PROD,
+  DEPLOY_TAGS.L1_TEST,
+];
+func.dependencies = ['PolygonRoyaltyManager_setup'];

--- a/packages/deploy/royaltiesConfig.ts
+++ b/packages/deploy/royaltiesConfig.ts
@@ -1,0 +1,4 @@
+// Add all the royalty related constants here
+export const ROYALTY_MANAGER_TOTAL_BASIS_POINTS = 10000;
+export const ROYALTY_MANAGER_POLYGON_LAND_ROYALTY_BPS = 500;
+export const ROYALTY_MANAGER_LAND_ROYALTY_BPS = 500;


### PR DESCRIPTION
## Description
Helper scripts to set the royalty in the RoyaltyManager contract to 5% for the Land and PolygonLand contracts.