### PR TITLE
[PurchaseWrapperAudit] M-01

### DIFF
--- a/packages/avatar/contracts/nft-collection/INFTCollection.sol
+++ b/packages/avatar/contracts/nft-collection/INFTCollection.sol
@@ -333,4 +333,11 @@ interface INFTCollection {
      * @param isAgentControlled true if the wallet is agent-controlled
      */
     event AgentControlledSet(address indexed operator, address indexed wallet, bool isAgentControlled);
+
+    /**
+     * @notice Returns the token price for a specific wave.
+     * @param waveIndex Wave configuration index.
+     * @return Price per token in the wave's payment token.
+     */
+    function waveSingleTokenPrice(uint256 waveIndex) external view returns (uint256);
 }

--- a/packages/avatar/contracts/nft-collection/INFTCollection.sol
+++ b/packages/avatar/contracts/nft-collection/INFTCollection.sol
@@ -340,4 +340,20 @@ interface INFTCollection {
      * @return Price per token in the wave's payment token.
      */
     function waveSingleTokenPrice(uint256 waveIndex) external view returns (uint256);
+
+    /**
+     * @notice Mints a token for a specific wave.
+     * @param to The address to mint the token to.
+     * @param amount The amount of tokens to mint.
+     * @param waveIndex The wave index.
+     * @param signatureId The signature ID.
+     * @param signature The signature.
+     */
+    function waveMint(
+        address to,
+        uint256 amount,
+        uint256 waveIndex,
+        uint256 signatureId,
+        bytes calldata signature
+    ) external;
 }

--- a/packages/avatar/contracts/nft-collection/INFTCollection.sol
+++ b/packages/avatar/contracts/nft-collection/INFTCollection.sol
@@ -335,13 +335,6 @@ interface INFTCollection {
     event AgentControlledSet(address indexed operator, address indexed wallet, bool isAgentControlled);
 
     /**
-     * @notice Returns the token price for a specific wave.
-     * @param waveIndex Wave configuration index.
-     * @return Price per token in the wave's payment token.
-     */
-    function waveSingleTokenPrice(uint256 waveIndex) external view returns (uint256);
-
-    /**
      * @notice Mints a token for a specific wave.
      * @param to The address to mint the token to.
      * @param amount The amount of tokens to mint.
@@ -356,4 +349,11 @@ interface INFTCollection {
         uint256 signatureId,
         bytes calldata signature
     ) external returns (uint256[] memory);
+
+    /**
+     * @notice Returns the token price for a specific wave.
+     * @param waveIndex Wave configuration index.
+     * @return Price per token in the wave's payment token.
+     */
+    function waveSingleTokenPrice(uint256 waveIndex) external view returns (uint256);
 }

--- a/packages/avatar/contracts/nft-collection/INFTCollection.sol
+++ b/packages/avatar/contracts/nft-collection/INFTCollection.sol
@@ -355,5 +355,5 @@ interface INFTCollection {
         uint256 waveIndex,
         uint256 signatureId,
         bytes calldata signature
-    ) external;
+    ) external returns (uint256[] memory);
 }

--- a/packages/avatar/contracts/nft-collection/ISandboxSand.sol
+++ b/packages/avatar/contracts/nft-collection/ISandboxSand.sol
@@ -5,5 +5,9 @@ pragma solidity ^0.8.25;
  * @dev Minimal interface for the SAND token contract.
  */
 interface ISandboxSand {
-    function approveAndCall(address spender, uint256 amount, bytes calldata data) external;
+    function approveAndCall(
+        address target,
+        uint256 amount,
+        bytes calldata data
+    ) external payable returns (bytes memory);
 }

--- a/packages/avatar/contracts/nft-collection/ISandboxSand.sol
+++ b/packages/avatar/contracts/nft-collection/ISandboxSand.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+/**
+ * @dev Minimal interface for the SAND token contract.
+ */
+interface ISandboxSand {
+    function approveAndCall(address spender, uint256 amount, bytes calldata data) external;
+}

--- a/packages/avatar/contracts/nft-collection/NFTCollection.sol
+++ b/packages/avatar/contracts/nft-collection/NFTCollection.sol
@@ -95,7 +95,7 @@ contract NFTCollection is
         /**
          * @notice Mapping of wallets that are controlled by the purchase agent.
          */
-        mapping(address => bool) isAgentControlled;
+        mapping(address wallet => bool isAgentControlled) isAgentControlled;
     }
 
     // keccak256(abi.encode(uint256(keccak256("thesandbox.storage.avatar.nft-collection.NFTCollection")) - 1)) & ~bytes32(uint256(0xff));

--- a/packages/avatar/contracts/nft-collection/NFTCollection.sol
+++ b/packages/avatar/contracts/nft-collection/NFTCollection.sol
@@ -630,64 +630,6 @@ contract NFTCollection is
     }
 
     /**
-     * @notice Sets approval for an operator to manage caller's tokens.
-     * @param operator Address to grant approval to.
-     * @param approved True to approve, false to revoke.
-     * @dev Overrides ERC721 implementation to add operator filtering.
-     */
-    function setApprovalForAll(
-        address operator,
-        bool approved
-    ) public override whenNotPaused onlyAllowedOperatorApproval(operator) {
-        super.setApprovalForAll(operator, approved);
-    }
-
-    /**
-     * @notice Approves an operator to transfer a specific token.
-     * @param operator Address to grant approval to.
-     * @param tokenId ID of token to approve.
-     * @dev Overrides ERC721 implementation to add operator filtering.
-     */
-    function approve(
-        address operator,
-        uint256 tokenId
-    ) public override whenNotPaused onlyAllowedOperatorApproval(operator) {
-        super.approve(operator, tokenId);
-    }
-
-    /**
-     * @notice Transfers a token between addresses.
-     * @param from Source address.
-     * @param to Destination address.
-     * @param tokenId ID of token to transfer.
-     * @dev Overrides ERC721 implementation to add operator filtering.
-     */
-    function transferFrom(
-        address from,
-        address to,
-        uint256 tokenId
-    ) public override whenNotPaused onlyAllowedOperator(from) {
-        super.transferFrom(from, to, tokenId);
-    }
-
-    /**
-     * @notice Safely transfers a token between addresses.
-     * @param from Source address.
-     * @param to Destination address.
-     * @param tokenId ID of token to transfer.
-     * @param data Additional data for receiver callback.
-     * @dev Overrides ERC721 implementation to add operator filtering.
-     */
-    function safeTransferFrom(
-        address from,
-        address to,
-        uint256 tokenId,
-        bytes memory data
-    ) public override whenNotPaused onlyAllowedOperator(from) {
-        super.safeTransferFrom(from, to, tokenId, data);
-    }
-
-    /**
      * @notice Retrieves personalization traits for a token.
      * @param tokenId Token ID to query.
      * @return Bit mask of token's personalization traits.
@@ -883,6 +825,64 @@ contract NFTCollection is
     }
 
     /**
+     * @notice Sets approval for an operator to manage caller's tokens.
+     * @param operator Address to grant approval to.
+     * @param approved True to approve, false to revoke.
+     * @dev Overrides ERC721 implementation to add operator filtering.
+     */
+    function setApprovalForAll(
+        address operator,
+        bool approved
+    ) public override whenNotPaused onlyAllowedOperatorApproval(operator) {
+        super.setApprovalForAll(operator, approved);
+    }
+
+    /**
+     * @notice Approves an operator to transfer a specific token.
+     * @param operator Address to grant approval to.
+     * @param tokenId ID of token to approve.
+     * @dev Overrides ERC721 implementation to add operator filtering.
+     */
+    function approve(
+        address operator,
+        uint256 tokenId
+    ) public override whenNotPaused onlyAllowedOperatorApproval(operator) {
+        super.approve(operator, tokenId);
+    }
+
+    /**
+     * @notice Transfers a token between addresses.
+     * @param from Source address.
+     * @param to Destination address.
+     * @param tokenId ID of token to transfer.
+     * @dev Overrides ERC721 implementation to add operator filtering.
+     */
+    function transferFrom(
+        address from,
+        address to,
+        uint256 tokenId
+    ) public override whenNotPaused onlyAllowedOperator(from) {
+        super.transferFrom(from, to, tokenId);
+    }
+
+    /**
+     * @notice Safely transfers a token between addresses.
+     * @param from Source address.
+     * @param to Destination address.
+     * @param tokenId ID of token to transfer.
+     * @param data Additional data for receiver callback.
+     * @dev Overrides ERC721 implementation to add operator filtering.
+     */
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint256 tokenId,
+        bytes memory data
+    ) public override whenNotPaused onlyAllowedOperator(from) {
+        super.safeTransferFrom(from, to, tokenId, data);
+    }
+
+    /**
      * @notice Checks interface support using ERC165.
      * @param interfaceId Interface identifier to check.
      * @return True if interface is supported.
@@ -892,24 +892,6 @@ contract NFTCollection is
         bytes4 interfaceId
     ) public view virtual override(ERC2981Upgradeable, ERC721Upgradeable) returns (bool) {
         return interfaceId == bytes4(0x49064906) || super.supportsInterface(interfaceId);
-    }
-
-    /**
-     * @dev See {ERC721-_isAuthorized}.
-     *
-     * Overridden to allow the `purchaseAgent` to transfer tokens from `isAgentControlled` wallets.
-     */
-    function _isAuthorized(
-        address owner,
-        address spender,
-        uint256 tokenId
-    ) internal view virtual override(ERC721Upgradeable) returns (bool) {
-        NFTCollectionStorage storage $ = _getNFTCollectionStorage();
-        // The purchaseAgent can spend tokens from agent-controlled wallets.
-        if ($.purchaseAgent != address(0) && spender == $.purchaseAgent && $.isAgentControlled[owner]) {
-            return true;
-        }
-        return super._isAuthorized(owner, spender, tokenId);
     }
 
     /**
@@ -949,6 +931,127 @@ contract NFTCollection is
             emit WaveMint(tokenIds[i], wallet, waveIndex);
         }
         return tokenIds;
+    }
+
+    /**
+     * @notice Updates the treasury address.
+     * @param _treasury New treasury address.
+     * @dev Validates address is non-zero and emits update event.
+     */
+    function _setTreasury(address _treasury) internal {
+        NFTCollectionStorage storage $ = _getNFTCollectionStorage();
+        if (_treasury == address(0)) {
+            revert InvalidTreasury(_treasury);
+        }
+        emit TreasurySet(_msgSender(), $.mintTreasury, _treasury);
+        $.mintTreasury = _treasury;
+    }
+
+    /**
+     * @notice Updates the allowed minting token.
+     * @param _minterToken New ERC20 token for minting payments.
+     * @dev Validates contract address and emits update event.
+     */
+    function _setAllowedExecuteMint(IERC20Metadata _minterToken) internal {
+        NFTCollectionStorage storage $ = _getNFTCollectionStorage();
+        if (!_isContract(address(_minterToken))) {
+            revert InvalidAllowedToExecuteMint(_minterToken);
+        }
+        emit AllowedExecuteMintSet(_msgSender(), $.allowedToExecuteMint, _minterToken);
+        $.allowedToExecuteMint = _minterToken;
+    }
+
+    /**
+     * @notice Updates the maximum supply cap.
+     * @param _maxSupply New maximum token supply.
+     * @dev Validates against current supply and emits update event.
+     */
+    function _setMaxSupply(uint256 _maxSupply) internal {
+        NFTCollectionStorage storage $ = _getNFTCollectionStorage();
+        if (_maxSupply == 0) {
+            revert LowMaxSupply(0, $.totalSupply);
+        }
+        if (_maxSupply < $.totalSupply) {
+            revert LowMaxSupply(_maxSupply, $.totalSupply);
+        }
+        emit MaxSupplySet(_msgSender(), $.maxSupply, _maxSupply);
+        $.maxSupply = _maxSupply;
+    }
+
+    /**
+     * @notice Updates the maximum tokens per wallet.
+     * @param _maxTokensPerWallet New maximum tokens per wallet.
+     * @dev Validates against maxSupply and emits update event.
+     */
+    function _setMaxTokensPerWallet(uint256 _maxTokensPerWallet) internal {
+        NFTCollectionStorage storage $ = _getNFTCollectionStorage();
+        if (_maxTokensPerWallet == 0 || _maxTokensPerWallet > $.maxSupply) {
+            revert InvalidMaxTokensPerWallet(_maxTokensPerWallet, $.maxSupply);
+        }
+        emit MaxTokensPerWalletSet(_msgSender(), $.maxTokensPerWallet, _maxTokensPerWallet);
+        $.maxTokensPerWallet = _maxTokensPerWallet;
+    }
+
+    /**
+     * @notice Burns a token with validation checks.
+     * @param tokenId Token ID to burn.
+     * @dev Verifies burn is enabled and caller is authorized.
+     */
+    function _burnWithCheck(uint256 tokenId) internal virtual {
+        NFTCollectionStorage storage $ = _getNFTCollectionStorage();
+        if (!$.isBurnEnabled) {
+            revert ExpectedBurn();
+        }
+        address sender = _msgSender();
+        // Setting an "auth" arguments enables the `_isAuthorized` check which verifies that the token exists
+        // (from != 0). Therefore, it is not needed to verify that the return value is not 0 here.
+        address previousOwner = _update(address(0), tokenId, sender);
+        emit TokenBurned(sender, tokenId, previousOwner);
+    }
+
+    /**
+     * @notice Updates token personalization traits.
+     * @param tokenId Token ID to update.
+     * @param personalizationMask New trait configuration.
+     * @dev No input validation - calling functions must perform checks.
+     */
+    function _updateTokenTraits(uint256 tokenId, uint256 personalizationMask) internal {
+        NFTCollectionStorage storage $ = _getNFTCollectionStorage();
+        $.personalizationTraits[tokenId] = personalizationMask;
+        emit Personalized(_msgSender(), tokenId, personalizationMask);
+        emit MetadataUpdate(tokenId);
+    }
+
+    /**
+     * @notice Updates the base token URI.
+     * @param baseURI New base URI for token metadata.
+     * @dev Validates URI length and emits update event.
+     */
+    function _setBaseURI(string calldata baseURI) internal {
+        NFTCollectionStorage storage $ = _getNFTCollectionStorage();
+        if (bytes(baseURI).length == 0) {
+            revert InvalidBaseTokenURI(baseURI);
+        }
+        emit BaseURISet(_msgSender(), $.baseTokenURI, baseURI);
+        $.baseTokenURI = baseURI;
+    }
+
+    /**
+     * @dev See {ERC721-_isAuthorized}.
+     *
+     * Overridden to allow the `purchaseAgent` to transfer tokens from `isAgentControlled` wallets.
+     */
+    function _isAuthorized(
+        address owner,
+        address spender,
+        uint256 tokenId
+    ) internal view virtual override(ERC721Upgradeable) returns (bool) {
+        NFTCollectionStorage storage $ = _getNFTCollectionStorage();
+        // The purchaseAgent can spend tokens from agent-controlled wallets.
+        if ($.purchaseAgent != address(0) && spender == $.purchaseAgent && $.isAgentControlled[owner]) {
+            return true;
+        }
+        return super._isAuthorized(owner, spender, tokenId);
     }
 
     /**
@@ -1051,19 +1154,6 @@ contract NFTCollection is
     }
 
     /**
-     * @notice Updates token personalization traits.
-     * @param tokenId Token ID to update.
-     * @param personalizationMask New trait configuration.
-     * @dev No input validation - calling functions must perform checks.
-     */
-    function _updateTokenTraits(uint256 tokenId, uint256 personalizationMask) internal {
-        NFTCollectionStorage storage $ = _getNFTCollectionStorage();
-        $.personalizationTraits[tokenId] = personalizationMask;
-        emit Personalized(_msgSender(), tokenId, personalizationMask);
-        emit MetadataUpdate(tokenId);
-    }
-
-    /**
      * @notice Checks if an address is a contract.
      * @param account Address to check.
      * @return True if the address contains code.
@@ -1074,96 +1164,6 @@ contract NFTCollection is
         // for contracts in construction, since the code is only stored at the end
         // of the constructor execution.
         return account.code.length > 0;
-    }
-
-    /**
-     * @notice Updates the base token URI.
-     * @param baseURI New base URI for token metadata.
-     * @dev Validates URI length and emits update event.
-     */
-    function _setBaseURI(string calldata baseURI) internal {
-        NFTCollectionStorage storage $ = _getNFTCollectionStorage();
-        if (bytes(baseURI).length == 0) {
-            revert InvalidBaseTokenURI(baseURI);
-        }
-        emit BaseURISet(_msgSender(), $.baseTokenURI, baseURI);
-        $.baseTokenURI = baseURI;
-    }
-
-    /**
-     * @notice Updates the treasury address.
-     * @param _treasury New treasury address.
-     * @dev Validates address is non-zero and emits update event.
-     */
-    function _setTreasury(address _treasury) internal {
-        NFTCollectionStorage storage $ = _getNFTCollectionStorage();
-        if (_treasury == address(0)) {
-            revert InvalidTreasury(_treasury);
-        }
-        emit TreasurySet(_msgSender(), $.mintTreasury, _treasury);
-        $.mintTreasury = _treasury;
-    }
-
-    /**
-     * @notice Updates the allowed minting token.
-     * @param _minterToken New ERC20 token for minting payments.
-     * @dev Validates contract address and emits update event.
-     */
-    function _setAllowedExecuteMint(IERC20Metadata _minterToken) internal {
-        NFTCollectionStorage storage $ = _getNFTCollectionStorage();
-        if (!_isContract(address(_minterToken))) {
-            revert InvalidAllowedToExecuteMint(_minterToken);
-        }
-        emit AllowedExecuteMintSet(_msgSender(), $.allowedToExecuteMint, _minterToken);
-        $.allowedToExecuteMint = _minterToken;
-    }
-
-    /**
-     * @notice Updates the maximum supply cap.
-     * @param _maxSupply New maximum token supply.
-     * @dev Validates against current supply and emits update event.
-     */
-    function _setMaxSupply(uint256 _maxSupply) internal {
-        NFTCollectionStorage storage $ = _getNFTCollectionStorage();
-        if (_maxSupply == 0) {
-            revert LowMaxSupply(0, $.totalSupply);
-        }
-        if (_maxSupply < $.totalSupply) {
-            revert LowMaxSupply(_maxSupply, $.totalSupply);
-        }
-        emit MaxSupplySet(_msgSender(), $.maxSupply, _maxSupply);
-        $.maxSupply = _maxSupply;
-    }
-
-    /**
-     * @notice Updates the maximum tokens per wallet.
-     * @param _maxTokensPerWallet New maximum tokens per wallet.
-     * @dev Validates against maxSupply and emits update event.
-     */
-    function _setMaxTokensPerWallet(uint256 _maxTokensPerWallet) internal {
-        NFTCollectionStorage storage $ = _getNFTCollectionStorage();
-        if (_maxTokensPerWallet == 0 || _maxTokensPerWallet > $.maxSupply) {
-            revert InvalidMaxTokensPerWallet(_maxTokensPerWallet, $.maxSupply);
-        }
-        emit MaxTokensPerWalletSet(_msgSender(), $.maxTokensPerWallet, _maxTokensPerWallet);
-        $.maxTokensPerWallet = _maxTokensPerWallet;
-    }
-
-    /**
-     * @notice Burns a token with validation checks.
-     * @param tokenId Token ID to burn.
-     * @dev Verifies burn is enabled and caller is authorized.
-     */
-    function _burnWithCheck(uint256 tokenId) internal virtual {
-        NFTCollectionStorage storage $ = _getNFTCollectionStorage();
-        if (!$.isBurnEnabled) {
-            revert ExpectedBurn();
-        }
-        address sender = _msgSender();
-        // Setting an "auth" arguments enables the `_isAuthorized` check which verifies that the token exists
-        // (from != 0). Therefore, it is not needed to verify that the return value is not 0 here.
-        address previousOwner = _update(address(0), tokenId, sender);
-        emit TokenBurned(sender, tokenId, previousOwner);
     }
 
     /**

--- a/packages/avatar/contracts/nft-collection/NFTCollection.sol
+++ b/packages/avatar/contracts/nft-collection/NFTCollection.sol
@@ -518,7 +518,7 @@ contract NFTCollection is
         if (wallets.length != agentControlledFlags.length) {
             revert InvalidBatchData();
         }
-        for (uint256 i; i < wallets.length; i++) {
+        for (uint256 i; i < wallets.length; ++i) {
             $.isAgentControlled[wallets[i]] = agentControlledFlags[i];
             emit AgentControlledSet(_msgSender(), wallets[i], agentControlledFlags[i]);
         }

--- a/packages/avatar/contracts/nft-collection/PurchaseWrapper.sol
+++ b/packages/avatar/contracts/nft-collection/PurchaseWrapper.sol
@@ -55,7 +55,12 @@ contract PurchaseWrapper is AccessControl, IERC721Receiver, ReentrancyGuard {
      * @param localTokenId The temporary local token ID for this purchase.
      * @param nftTokenId The actual ID of the minted NFT.
      */
-    event PurchaseConfirmed(address originalSender, address nftCollection, uint256 localTokenId, uint256 nftTokenId);
+    event PurchaseConfirmed(
+        address indexed originalSender,
+        address indexed nftCollection,
+        uint256 localTokenId,
+        uint256 indexed nftTokenId
+    );
 
     /**
      * @notice Emitted when an NFT is transferred using the wrapper's transfer functions.
@@ -64,7 +69,12 @@ contract PurchaseWrapper is AccessControl, IERC721Receiver, ReentrancyGuard {
      * @param to The address to which the NFT is transferred.
      * @param nftTokenId The actual ID of the transferred NFT.
      */
-    event NftTransferredViaWrapper(uint256 localTokenId, address from, address to, uint256 nftTokenId);
+    event NftTransferredViaWrapper(
+        uint256 localTokenId,
+        address indexed from,
+        address indexed to,
+        uint256 indexed nftTokenId
+    );
 
     // Custom Errors
     error PurchaseWrapperSandTokenAddressCannotBeZero();

--- a/packages/avatar/contracts/nft-collection/PurchaseWrapper.sol
+++ b/packages/avatar/contracts/nft-collection/PurchaseWrapper.sol
@@ -81,7 +81,6 @@ contract PurchaseWrapper is AccessControl, IERC721Receiver, ReentrancyGuard {
     error PurchaseWrapperNftCollectionAddressCannotBeZero();
     error PurchaseWrapperLocalTokenIdAlreadyInUse(uint256 localTokenId);
     error PurchaseWrapperNftPurchaseFailedViaApproveAndCall();
-    error PurchaseWrapperReceivedNftFromUnexpectedCollection(address expected, address actual);
     error PurchaseWrapperInvalidRecipientAddress();
     error PurchaseWrapperNoSandTokensToRecover();
     error PurchaseWrapperTransferToZeroAddress();
@@ -90,9 +89,7 @@ contract PurchaseWrapper is AccessControl, IERC721Receiver, ReentrancyGuard {
     error PurchaseWrapperNftCollectionNotRecorded(uint256 localTokenId);
     error PurchaseWrapperFromAddressIsNotOriginalRecipient(address expected, address actual);
     error PurchaseWrapperCallerNotAuthorized(address caller);
-    error PurchaseWrapperSenderIsNotSandToken();
     error PurchaseWrapperRandomTempTokenIdCannotBeZero();
-    error PurchaseWrapperNotInConfirmPurchase();
 
     /**
      * @notice Constructor to set the SAND token contract address.

--- a/packages/avatar/contracts/nft-collection/PurchaseWrapper.sol
+++ b/packages/avatar/contracts/nft-collection/PurchaseWrapper.sol
@@ -56,7 +56,7 @@ contract PurchaseWrapper is AccessControl, IERC721Receiver, ReentrancyGuard {
     /**
      * @notice Emitted when an NFT collection is authorized.
      */
-    event NftCollectionAuthorized(address indexed nftCollection);
+    event NftCollectionAuthorized(address indexed nftCollection, bool isAuthorized);
 
     /**
      * @notice Emitted when an NFT purchase is confirmed and the minting process is initiated.
@@ -204,14 +204,18 @@ contract PurchaseWrapper is AccessControl, IERC721Receiver, ReentrancyGuard {
     }
 
     /**
-     * @notice Authorizes an NFT collection to be used with this contract.
+     * @notice Sets the authorization status for an NFT collection to be used with this contract.
      * @dev Only callable by the contract owner.
      * @param nftCollection The address of the NFT collection to authorize.
+     * @param isAuthorized Whether the NFT collection is authorized.
      */
-    function authorizeNftCollection(address nftCollection) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    function setNftCollectionAuthorization(
+        address nftCollection,
+        bool isAuthorized
+    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
         if (nftCollection == address(0)) revert PurchaseWrapperNftCollectionAddressCannotBeZero();
-        _authorizedNftCollections[nftCollection] = true;
-        emit NftCollectionAuthorized(nftCollection);
+        _authorizedNftCollections[nftCollection] = isAuthorized;
+        emit NftCollectionAuthorized(nftCollection, isAuthorized);
     }
 
     /**

--- a/packages/avatar/contracts/nft-collection/PurchaseWrapper.sol
+++ b/packages/avatar/contracts/nft-collection/PurchaseWrapper.sol
@@ -177,6 +177,7 @@ contract PurchaseWrapper is AccessControl, IERC721Receiver, ReentrancyGuard {
             )
         );
 
+        // solhint-disable-next-line avoid-low-level-calls
         (bool success, bytes memory result) = address(sandToken).call(
             abi.encodeCall(ISandboxSand.approveAndCall, (nftCollection, sandAmount, data))
         );

--- a/packages/avatar/contracts/nft-collection/PurchaseWrapper.sol
+++ b/packages/avatar/contracts/nft-collection/PurchaseWrapper.sol
@@ -141,7 +141,6 @@ contract PurchaseWrapper is AccessControl, IERC721Receiver, ReentrancyGuard {
         SafeERC20.safeTransferFrom(sandTokenCached, sender, address(this), sandAmount);
 
         uint256 nftTokenId = _initiateMintViaApproveAndCall(
-            sandTokenCached,
             nftCollection,
             sandAmount,
             waveIndex,
@@ -217,7 +216,6 @@ contract PurchaseWrapper is AccessControl, IERC721Receiver, ReentrancyGuard {
     }
 
     function _initiateMintViaApproveAndCall(
-        IERC20 sandToken,
         address nftCollection,
         uint256 sandAmount,
         uint256 waveIndex,

--- a/packages/avatar/contracts/nft-collection/PurchaseWrapper.sol
+++ b/packages/avatar/contracts/nft-collection/PurchaseWrapper.sol
@@ -8,13 +8,7 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
 import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import {INFTCollection} from "./INFTCollection.sol";
-
-/**
- * @dev Minimal interface for the SAND token contract.
- */
-interface ISandboxSand {
-    function approveAndCall(address spender, uint256 amount, bytes calldata data) external;
-}
+import {ISandboxSand} from "./ISandboxSand.sol";
 
 /**
  * @title PurchaseWrapper

--- a/packages/avatar/contracts/nft-collection/PurchaseWrapper.sol
+++ b/packages/avatar/contracts/nft-collection/PurchaseWrapper.sol
@@ -29,6 +29,9 @@ contract PurchaseWrapper is AccessControl, IERC721Receiver, ReentrancyGuard {
         uint256 nftTokenId;
     }
 
+    /**
+     * @notice The role that is authorized to call this contract's functions.
+     */
     bytes32 public constant AUTHORIZED_CALLER_ROLE = keccak256("AUTHORIZED_CALLER_ROLE");
 
     /**

--- a/packages/avatar/contracts/nft-collection/PurchaseWrapper.sol
+++ b/packages/avatar/contracts/nft-collection/PurchaseWrapper.sol
@@ -76,7 +76,6 @@ contract PurchaseWrapper is AccessControl, IERC721Receiver, ReentrancyGuard {
 
     // Custom Errors
     error PurchaseWrapper__SandTokenAddressCannotBeZero();
-    error PurchaseWrapper__SenderAddressCannotBeZero();
     error PurchaseWrapper__NftCollectionAddressCannotBeZero();
     error PurchaseWrapper__LocalTokenIdAlreadyInUse(uint256 localTokenId);
     error PurchaseWrapper__NftPurchaseFailedViaApproveAndCall();
@@ -152,13 +151,11 @@ contract PurchaseWrapper is AccessControl, IERC721Receiver, ReentrancyGuard {
         address nftCollection,
         uint256 randomTempTokenId
     ) private view {
-        address caller = msg.sender == address(sandToken) ? sender : msg.sender;
-        if (!hasRole(AUTHORIZED_CALLER_ROLE, caller)) {
-            revert PurchaseWrapper__CallerNotAuthorized(caller);
+        if (msg.sender != address(sandToken) || !hasRole(AUTHORIZED_CALLER_ROLE, sender)) {
+            revert PurchaseWrapper__CallerNotAuthorized(sender);
         }
 
         if (randomTempTokenId == 0) revert PurchaseWrapper__RandomTempTokenIdCannotBeZero();
-        if (sender == address(0)) revert PurchaseWrapper__SenderAddressCannotBeZero();
         if (nftCollection == address(0)) revert PurchaseWrapper__NftCollectionAddressCannotBeZero();
         if (_purchaseInfo[randomTempTokenId].nftTokenId != 0) {
             revert PurchaseWrapper__LocalTokenIdAlreadyInUse(randomTempTokenId);

--- a/packages/avatar/contracts/nft-collection/PurchaseWrapper.sol
+++ b/packages/avatar/contracts/nft-collection/PurchaseWrapper.sol
@@ -46,7 +46,7 @@ contract PurchaseWrapper is AccessControl, IERC721Receiver, ReentrancyGuard {
      *      to uniquely identify a purchase transaction and later to reference the minted NFT
      *      in the wrapper's transfer functions.
      */
-    mapping(uint256 localTokenId => PurchaseInfo) private _purchaseInfo;
+    mapping(uint256 localTokenId => PurchaseInfo purchaseInfo) private _purchaseInfo;
 
     /**
      * @notice Emitted when an NFT purchase is confirmed and the minting process is initiated.

--- a/packages/avatar/contracts/nft-collection/PurchaseWrapper.sol
+++ b/packages/avatar/contracts/nft-collection/PurchaseWrapper.sol
@@ -7,6 +7,7 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {INFTCollection} from "./INFTCollection.sol";
 
 /**
  * @title PurchaseWrapper
@@ -113,7 +114,6 @@ contract PurchaseWrapper is AccessControl, IERC721Receiver, ReentrancyGuard {
      *      variables (`_txContext_...`) that are used by `onERC721Received`.
      * @param sender The original EOA initiating the purchase and who will receive the NFT.
      * @param nftCollection Address of the target NFT Collection contract for minting.
-     * @param sandAmount The amount of `sandToken` to be transferred for the purchase.
      * @param waveIndex The wave index for minting on the NFT Collection.
      * @param signatureId The signature ID for verification by the NFT Collection.
      * @param randomTempTokenId A unique temporary ID chosen by the caller to identify this purchase.
@@ -123,13 +123,14 @@ contract PurchaseWrapper is AccessControl, IERC721Receiver, ReentrancyGuard {
     function confirmPurchase(
         address sender,
         address nftCollection,
-        uint256 sandAmount,
         uint256 waveIndex,
         uint256 signatureId,
         uint256 randomTempTokenId,
         bytes calldata signature
     ) external nonReentrant {
         _validateAndAuthorizePurchase(sender, nftCollection, randomTempTokenId);
+
+        uint256 sandAmount = INFTCollection(nftCollection).waveSingleTokenPrice(waveIndex);
 
         _txContextLocalTokenId = randomTempTokenId;
         _isInConfirmPurchase = true;

--- a/packages/avatar/test/avatar/nft-collection/PurchaseWrapper.test.ts
+++ b/packages/avatar/test/avatar/nft-collection/PurchaseWrapper.test.ts
@@ -5,7 +5,7 @@ import {ethers} from 'hardhat';
 import {NFTCollection, PurchaseWrapper} from '../../../typechain-types';
 import {setupNFTCollectionContract} from './NFTCollection.fixtures';
 
-describe('PurchaseWrapper', function () {
+describe.only('PurchaseWrapper', function () {
   async function setupPurchaseWrapperFixture() {
     const nftCollectionFixture = await setupNFTCollectionContract();
     const PurchaseWrapperFactory = await ethers.getContractFactory(
@@ -138,7 +138,6 @@ describe('PurchaseWrapper', function () {
         .confirmPurchase(
           userAAddress, // sender is userA, who will receive the NFT
           collectionContractAddress,
-          sandPrice,
           waveIndex,
           signatureId,
           randomTempTokenId,
@@ -210,7 +209,6 @@ describe('PurchaseWrapper', function () {
         purchaseWrapper.connect(userA).confirmPurchase(
           ZeroAddress, // sender
           collectionContractAddress,
-          sandPrice,
           waveIndex,
           signatureId,
           randomTempTokenId,
@@ -253,7 +251,6 @@ describe('PurchaseWrapper', function () {
         purchaseWrapper.connect(userA).confirmPurchase(
           userAAddress,
           ZeroAddress, // nftCollection
-          sandPrice,
           waveIndex,
           signatureId,
           randomTempTokenId,
@@ -305,7 +302,6 @@ describe('PurchaseWrapper', function () {
       await purchaseWrapper.connect(userA).confirmPurchase(
         userAAddress,
         collectionContractAddress,
-        sandPrice,
         waveIndex,
         signatureId,
         randomTempTokenId, // Use the ID
@@ -323,7 +319,6 @@ describe('PurchaseWrapper', function () {
         purchaseWrapper.connect(userA).confirmPurchase(
           userAAddress,
           collectionContractAddress,
-          sandPrice,
           waveIndex,
           signatureId + 1,
           randomTempTokenId, // Reuse the ID
@@ -344,6 +339,9 @@ describe('PurchaseWrapper', function () {
         randomWallet: userA,
         purchaseWrapper,
         purchaseWrapperAddress,
+        waveMaxTokensOverall,
+        waveMaxTokensPerWallet,
+        collectionContractAsOwner: nftCollection,
       } = await loadFixture(setupPurchaseWrapperFixture);
 
       const userAAddress = await userA.getAddress();
@@ -358,6 +356,12 @@ describe('PurchaseWrapper', function () {
         .connect(userA)
         .approve(purchaseWrapperAddress, sandPrice);
 
+      await nftCollection.setupWave(
+        waveMaxTokensOverall,
+        waveMaxTokensPerWallet,
+        sandPrice
+      );
+
       const invalidSignature = '0xdeadbeef';
 
       const balanceBefore = await sandContract.balanceOf(userAAddress);
@@ -368,7 +372,6 @@ describe('PurchaseWrapper', function () {
           .confirmPurchase(
             userAAddress,
             collectionContractAddress,
-            sandPrice,
             waveIndex,
             signatureId,
             randomTempTokenId,
@@ -419,7 +422,6 @@ describe('PurchaseWrapper', function () {
           // deployer doesn't have AUTHORIZED_CALLER_ROLE
           userAAddress,
           collectionContractAddress,
-          sandPrice,
           waveIndex,
           signatureId,
           randomTempTokenId,
@@ -494,7 +496,6 @@ describe('PurchaseWrapper', function () {
         .confirmPurchase(
           userAAddress,
           collectionContractAddress,
-          sandPrice,
           waveIndex,
           signatureId,
           randomTempTokenId,

--- a/packages/avatar/test/avatar/nft-collection/PurchaseWrapper.test.ts
+++ b/packages/avatar/test/avatar/nft-collection/PurchaseWrapper.test.ts
@@ -5,7 +5,7 @@ import {ethers} from 'hardhat';
 import {NFTCollection, PurchaseWrapper} from '../../../typechain-types';
 import {setupNFTCollectionContract} from './NFTCollection.fixtures';
 
-describe.only('PurchaseWrapper', function () {
+describe('PurchaseWrapper', function () {
   async function setupPurchaseWrapperFixture() {
     const nftCollectionFixture = await setupNFTCollectionContract();
     const PurchaseWrapperFactory = await ethers.getContractFactory(

--- a/packages/avatar/test/avatar/nft-collection/PurchaseWrapper.test.ts
+++ b/packages/avatar/test/avatar/nft-collection/PurchaseWrapper.test.ts
@@ -23,6 +23,9 @@ describe('PurchaseWrapper', function () {
       nftCollectionFixture.deployer
     ).deploy(deployerAddress, sandContractAddress, authorizedCallerAddress); // Pass admin, sandToken, and authorizedCaller
 
+    // Authorize the collection for purchases
+    await purchaseWrapper.authorizeNftCollection(collectionContractAddress);
+
     return {
       ...nftCollectionFixture,
       purchaseWrapper,
@@ -304,56 +307,6 @@ describe('PurchaseWrapper', function () {
 
       expect(await sandContract.balanceOf(userAAddress)).to.be.eq(0);
       expect(await sandContract.balanceOf(purchaseWrapperAddress)).to.be.eq(0);
-    });
-
-    it('should revert if sender address is zero', async function () {
-      // cannot happen due to the FIRST_PARAM check in Sand
-    });
-
-    it('should revert if NFT Collection address is zero', async function () {
-      const {
-        waveMintSign,
-        sandContract,
-        purchaseWrapper,
-        purchaseWrapperAddress,
-        randomWallet: userA,
-      } = await loadFixture(setupPurchaseWrapperFixture);
-
-      const sandPrice = ethers.parseEther('100');
-      const waveIndex = 0;
-      const signatureId = 1;
-      const randomTempTokenId = 1;
-      const userAAddress = await userA.getAddress();
-
-      await sandContract.donateTo(userAAddress, sandPrice);
-
-      const signature = await waveMintSign(
-        purchaseWrapperAddress,
-        1,
-        waveIndex,
-        signatureId
-      );
-
-      const data = purchaseWrapper.interface.encodeFunctionData(
-        'confirmPurchase',
-        [
-          userAAddress,
-          ZeroAddress, // nftCollection
-          waveIndex,
-          signatureId,
-          randomTempTokenId,
-          signature,
-        ]
-      );
-
-      await expect(
-        sandContract
-          .connect(userA)
-          .approveAndCall(purchaseWrapperAddress, sandPrice, data)
-      ).to.be.revertedWithCustomError(
-        purchaseWrapper,
-        'PurchaseWrapperNftCollectionAddressCannotBeZero'
-      );
     });
 
     it('should revert if local token ID is already in use', async function () {

--- a/packages/avatar/test/avatar/nft-collection/PurchaseWrapper.test.ts
+++ b/packages/avatar/test/avatar/nft-collection/PurchaseWrapper.test.ts
@@ -24,7 +24,10 @@ describe('PurchaseWrapper', function () {
     ).deploy(deployerAddress, sandContractAddress, authorizedCallerAddress); // Pass admin, sandToken, and authorizedCaller
 
     // Authorize the collection for purchases
-    await purchaseWrapper.authorizeNftCollection(collectionContractAddress);
+    await purchaseWrapper.setNftCollectionAuthorization(
+      collectionContractAddress,
+      true
+    );
 
     return {
       ...nftCollectionFixture,
@@ -723,6 +726,146 @@ describe('PurchaseWrapper', function () {
         purchaseWrapperAsDeployer,
         'PurchaseWrapperNoSandTokensToRecover'
       );
+    });
+  });
+
+  describe('setNftCollectionAuthorization', function () {
+    it('should allow admin to authorize a collection', async function () {
+      const {
+        purchaseWrapperAsDeployer,
+        collectionContractAddress,
+        purchaseWrapper,
+      } = await loadFixture(setupPurchaseWrapperFixture);
+
+      // It's authorized in the fixture, so we de-authorize it first.
+      await purchaseWrapperAsDeployer.setNftCollectionAuthorization(
+        collectionContractAddress,
+        false
+      );
+
+      // Let's re-authorize and check for the event.
+      await expect(
+        purchaseWrapperAsDeployer.setNftCollectionAuthorization(
+          collectionContractAddress,
+          true
+        )
+      )
+        .to.emit(purchaseWrapper, 'NftCollectionAuthorized')
+        .withArgs(collectionContractAddress, true);
+    });
+
+    it('should allow admin to de-authorize a collection', async function () {
+      const {
+        purchaseWrapperAsDeployer,
+        collectionContractAddress,
+        purchaseWrapper,
+      } = await loadFixture(setupPurchaseWrapperFixture);
+
+      // It is authorized in the fixture.
+      await expect(
+        purchaseWrapperAsDeployer.setNftCollectionAuthorization(
+          collectionContractAddress,
+          false
+        )
+      )
+        .to.emit(purchaseWrapper, 'NftCollectionAuthorized')
+        .withArgs(collectionContractAddress, false);
+    });
+
+    it('should revert if a non-admin tries to authorize a collection', async function () {
+      const {purchaseWrapperAsUserA, collectionContractAddress} =
+        await loadFixture(setupPurchaseWrapperFixture);
+
+      await expect(
+        purchaseWrapperAsUserA.setNftCollectionAuthorization(
+          collectionContractAddress,
+          true
+        )
+      ).to.be.revertedWithCustomError(
+        purchaseWrapperAsUserA,
+        'AccessControlUnauthorizedAccount'
+      );
+    });
+
+    it('should revert if the collection address is the zero address', async function () {
+      const {purchaseWrapperAsDeployer} = await loadFixture(
+        setupPurchaseWrapperFixture
+      );
+
+      await expect(
+        purchaseWrapperAsDeployer.setNftCollectionAuthorization(
+          ZeroAddress,
+          true
+        )
+      ).to.be.revertedWithCustomError(
+        purchaseWrapperAsDeployer,
+        'PurchaseWrapperNftCollectionAddressCannotBeZero'
+      );
+    });
+
+    it('should prevent purchase from a de-authorized collection', async function () {
+      const {
+        collectionContractAsOwner: nftCollection,
+        collectionContractAddress,
+        waveMintSign,
+        sandContract,
+        randomWallet: userA,
+        purchaseWrapper,
+        purchaseWrapperAddress,
+        waveMaxTokensOverall,
+        waveMaxTokensPerWallet,
+        purchaseWrapperAsDeployer,
+      } = await loadFixture(setupPurchaseWrapperFixture);
+
+      const userAAddress = await userA.getAddress();
+
+      const sandPrice = ethers.parseEther('100');
+      const waveIndex = 0;
+      const signatureId = 222;
+      const randomTempTokenId = 12345;
+
+      // De-authorize the collection
+      await purchaseWrapperAsDeployer.setNftCollectionAuthorization(
+        collectionContractAddress,
+        false
+      );
+
+      await nftCollection.setupWave(
+        waveMaxTokensOverall,
+        waveMaxTokensPerWallet,
+        sandPrice
+      );
+      await sandContract.donateTo(userAAddress, sandPrice);
+
+      const signature = await waveMintSign(
+        purchaseWrapperAddress, // Mint to purchase wrapper
+        1,
+        waveIndex,
+        signatureId
+      );
+
+      const data = purchaseWrapper.interface.encodeFunctionData(
+        'confirmPurchase',
+        [
+          userAAddress, // sender is userA, who will receive the NFT
+          collectionContractAddress,
+          waveIndex,
+          signatureId,
+          randomTempTokenId,
+          signature,
+        ]
+      );
+
+      await expect(
+        sandContract
+          .connect(userA)
+          .approveAndCall(purchaseWrapperAddress, sandPrice, data)
+      )
+        .to.be.revertedWithCustomError(
+          purchaseWrapper,
+          'PurchaseWrapperNftCollectionNotAuthorized'
+        )
+        .withArgs(collectionContractAddress);
     });
   });
 });

--- a/packages/avatar/test/avatar/nft-collection/PurchaseWrapper.test.ts
+++ b/packages/avatar/test/avatar/nft-collection/PurchaseWrapper.test.ts
@@ -88,7 +88,7 @@ describe('PurchaseWrapper', function () {
         )
       ).to.be.revertedWithCustomError(
         PurchaseWrapperFactory,
-        'PurchaseWrapper__SandTokenAddressCannotBeZero'
+        'PurchaseWrapperSandTokenAddressCannotBeZero'
       );
     });
   });
@@ -352,7 +352,7 @@ describe('PurchaseWrapper', function () {
           .approveAndCall(purchaseWrapperAddress, sandPrice, data)
       ).to.be.revertedWithCustomError(
         purchaseWrapper,
-        'PurchaseWrapper__NftCollectionAddressCannotBeZero'
+        'PurchaseWrapperNftCollectionAddressCannotBeZero'
       );
     });
 
@@ -431,7 +431,7 @@ describe('PurchaseWrapper', function () {
       )
         .to.be.revertedWithCustomError(
           purchaseWrapper,
-          'PurchaseWrapper__LocalTokenIdAlreadyInUse'
+          'PurchaseWrapperLocalTokenIdAlreadyInUse'
         )
         .withArgs(randomTempTokenId);
     });
@@ -488,7 +488,7 @@ describe('PurchaseWrapper', function () {
           .approveAndCall(purchaseWrapperAddress, sandPrice, data)
       ).to.be.revertedWithCustomError(
         purchaseWrapper,
-        'PurchaseWrapper__NftPurchaseFailedViaApproveAndCall'
+        'PurchaseWrapperNftPurchaseFailedViaApproveAndCall'
       );
 
       expect(await sandContract.balanceOf(userAAddress)).to.equal(
@@ -538,7 +538,7 @@ describe('PurchaseWrapper', function () {
         )
       ).to.be.revertedWithCustomError(
         purchaseWrapper,
-        'PurchaseWrapper__CallerNotAuthorized'
+        'PurchaseWrapperCallerNotAuthorized'
       );
     });
   });
@@ -654,7 +654,7 @@ describe('PurchaseWrapper', function () {
         )
       ).to.be.revertedWithCustomError(
         purchaseWrapperAsUserA,
-        'PurchaseWrapper__TransferToZeroAddress'
+        'PurchaseWrapperTransferToZeroAddress'
       );
     });
 
@@ -669,7 +669,7 @@ describe('PurchaseWrapper', function () {
       )
         .to.be.revertedWithCustomError(
           purchaseWrapperAsUserA,
-          'PurchaseWrapper__InvalidLocalTokenIdOrPurchaseNotCompleted'
+          'PurchaseWrapperInvalidLocalTokenIdOrPurchaseNotCompleted'
         )
         .withArgs(invalidLocalTokenId);
     });
@@ -685,7 +685,7 @@ describe('PurchaseWrapper', function () {
       )
         .to.be.revertedWithCustomError(
           purchaseWrapperAsUserA,
-          'PurchaseWrapper__FromAddressIsNotOriginalRecipient'
+          'PurchaseWrapperFromAddressIsNotOriginalRecipient'
         )
         .withArgs(userBAddress, userAAddress);
     });
@@ -752,7 +752,7 @@ describe('PurchaseWrapper', function () {
         purchaseWrapperAsDeployer.recoverSand(ZeroAddress)
       ).to.be.revertedWithCustomError(
         purchaseWrapperAsDeployer,
-        'PurchaseWrapper__InvalidRecipientAddress'
+        'PurchaseWrapperInvalidRecipientAddress'
       );
     });
 
@@ -768,7 +768,7 @@ describe('PurchaseWrapper', function () {
         purchaseWrapperAsDeployer.recoverSand(await randomWallet.getAddress())
       ).to.be.revertedWithCustomError(
         purchaseWrapperAsDeployer,
-        'PurchaseWrapper__NoSandTokensToRecover'
+        'PurchaseWrapperNoSandTokensToRecover'
       );
     });
   });


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/982667ca-826c-4752-9ca4-5867ea6d5259)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a "purchase agent" role, allowing designated agents to transfer NFTs on behalf of specified wallets.
  - Added the ability to batch assign or remove agent-controlled status for multiple wallets.
  - Deployed a new contract enabling NFT purchases using SAND tokens, with secure role-based access and purchase tracking.
  - Provided a new deployment script and deployment artifacts for the NFT purchase wrapper and upgradeable beacon.

- **Bug Fixes**
  - Ensured only authorized users can configure purchase agent roles and agent-controlled wallets.

- **Tests**
  - Added comprehensive tests for the purchase agent functionality and NFT purchase wrapper contract, covering configuration, transfer logic, purchase flows, and token recovery.

- **Chores**
  - Updated deployment and configuration files to support the new purchase wrapper contract.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->